### PR TITLE
ZENKO-2673 Redirect user after successful authentication

### DIFF
--- a/src/react/actions/__tests__/auth.test.js
+++ b/src/react/actions/__tests__/auth.test.js
@@ -7,6 +7,7 @@ import {
     USER_MANAGER_ERROR_MSG,
     errorUserManagerState,
     initState,
+    signinRedirectCallbackState,
     testActionFunction,
     testDispatchFunction,
 } from './utils/testUtil';
@@ -81,6 +82,30 @@ describe('auth actions', () => {
             it: 'signinCallback: should return expected actions',
             fn: actions.signinCallback(),
             storeState: initState,
+            expectedActions: [
+                dispatchAction.LOCATION_PUSH_ACTION('/'),
+            ],
+        },
+        {
+            it: 'signinCallback: should return push action with expected path "/data"',
+            fn: actions.signinCallback(),
+            storeState: signinRedirectCallbackState('/data'),
+            expectedActions: [
+                dispatchAction.LOCATION_PUSH_ACTION('/data'),
+            ],
+        },
+        {
+            it: 'signinCallback: should return push action with expected path "/" if state path set to "/login"',
+            fn: actions.signinCallback(),
+            storeState: signinRedirectCallbackState('/login'),
+            expectedActions: [
+                dispatchAction.LOCATION_PUSH_ACTION('/'),
+            ],
+        },
+        {
+            it: 'signinCallback: should return push action with expected path "/" if state path set to "/login/callback"',
+            fn: actions.signinCallback(),
+            storeState: signinRedirectCallbackState('/login/callback'),
             expectedActions: [
                 dispatchAction.LOCATION_PUSH_ACTION('/'),
             ],

--- a/src/react/actions/__tests__/utils/testUtil.js
+++ b/src/react/actions/__tests__/utils/testUtil.js
@@ -1,6 +1,6 @@
 // @flow
 import { ApiErrorObject } from '../../../../js/mock/error';
-import { ErrorUserManager } from '../../../../js/mock/userManager';
+import { ErrorUserManager, MockUserManager } from '../../../../js/mock/userManager';
 import configureStore from 'redux-mock-store';
 import { initialFullState } from '../../../reducers/initialConstants';
 import thunk from 'redux-thunk';
@@ -45,6 +45,25 @@ export function errorUserManagerState(): AppState {
         auth: {
             ...state.auth,
             userManager: new ErrorUserManager(USER_MANAGER_ERROR),
+        },
+    };
+}
+
+export function signinRedirectCallbackState(path: string): AppState {
+    const state = initState;
+    const userManager = new MockUserManager();
+    userManager.signinRedirectCallback = () => {
+        return Promise.resolve({
+            state: {
+                path,
+            },
+        });
+    };
+    return {
+        ...state,
+        auth: {
+            ...state.auth,
+            userManager,
         },
     };
 }

--- a/src/react/actions/auth.js
+++ b/src/react/actions/auth.js
@@ -103,7 +103,10 @@ export function signinCallback(): ThunkStatePromisedAction {
         const userManager = getState().auth.userManager;
         return userManager.signinRedirectCallback()
             .then(user => {
-                const path = (user.state && user.state.path) || '/';
+                const path = user.state &&
+                user.state.path &&
+                user.state.path !== '/login' &&
+                user.state.path !== '/login/callback' ? user.state.path : '/';
                 dispatch(push(path));
             })
             .catch(error => {

--- a/src/react/auth/Login.jsx
+++ b/src/react/auth/Login.jsx
@@ -8,7 +8,7 @@ import { signin } from '../actions';
 
 function Login(props) {
     const { authenticated, dispatch, isSigningOut, location } = props;
-    const path = location && location.state && location.state.path && location.state.path !== '/login' ? props.location.state.path : '/';
+    const path = location && location.state && location.state.path || '/';
     useEffect(() => {
         if (!authenticated && !isSigningOut) {
             dispatch(signin(path));


### PR DESCRIPTION
Redirect user to home page ("/") if coming from "/login" or "/login/callback" pages.