### PR TITLE
zenko-3050 release stage

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -39,6 +39,13 @@ models:
         docker build --pull -t ${SCALITY_OCI_REPO_DEV}:%(prop:commit_short_revision)s .;
       haltOnFailure: True
       env: *deploy-env
+  - ShellCommand: &docker-login
+      name: login to docker registry
+      command: >-
+        docker login
+        --username "%(secret:harbor_login)s"
+        --password "%(secret:harbor_password)s"
+        registry.scality.com
 
 stages:
   pre-merge:
@@ -87,6 +94,7 @@ stages:
       - Git: *clone
       - ShellCommand: *yarn-install
       - ShellCommand: *yarn-build
+      - ShellCommand: *docker-login
       - ShellCommand: *docker-build
       - ShellCommand:
           name: publish docker image to Scality OCI registry

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -22,7 +22,6 @@ models:
   - Git: &clone
       name: fetch source
       repourl: '%(prop:git_reference)s'
-      shallow: true
       retryFetch: true
       haltOnFailure: true
   - ShellCommand: &yarn-install

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -9,7 +9,8 @@ branches:
 
 models:
   - env: &deploy-env
-      SCALITY_OCI_REPO: registry.scality.com/scality/zenko-ui
+      SCALITY_OCI_REPO: registry.scality.com/zenko-ui/zenko-ui
+      SCALITY_OCI_REPO_DEV: registry.scality.com/zenko-ui-dev/zenko-ui
   - env: &keycloak-env
       KEYCLOAK_ROOT: "http://127.0.0.1:8080"
       KEYCLOAK_REALM: "myrealm"
@@ -36,7 +37,7 @@ models:
       name: build docker image
       command: >-
         set -exu;
-        docker build --pull -t ${SCALITY_OCI_REPO}:%(prop:commit_short_revision)s .;
+        docker build --pull -t ${SCALITY_OCI_REPO_DEV}:%(prop:commit_short_revision)s .;
       haltOnFailure: True
       env: *deploy-env
 
@@ -67,7 +68,7 @@ stages:
       - ShellCommand:
           name: run end-to-end tests
           command: >-
-            docker run -d -p 8383:8383 ${SCALITY_OCI_REPO}:%(prop:commit_short_revision)s;
+            docker run -d -p 8383:8383 ${SCALITY_OCI_REPO_DEV}:%(prop:commit_short_revision)s;
             set -exu;
             bash wait_for_local_port.bash 8080 40;
             bash wait_for_local_port.bash 8383 40;
@@ -92,7 +93,6 @@ stages:
           name: publish docker image to Scality OCI registry
           command: >-
             set -exu;
-            docker login --username "%(secret:harbor_login)s" --password "%(secret:harbor_password)s" ${SCALITY_OCI_REPO};
-            docker push ${SCALITY_OCI_REPO}:%(prop:commit_short_revision)s;
+            docker push ${SCALITY_OCI_REPO_DEV}:%(prop:commit_short_revision)s;
           haltOnFailure: True
           env: *deploy-env

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -103,3 +103,21 @@ stages:
             docker push ${SCALITY_OCI_REPO_DEV}:%(prop:commit_short_revision)s;
           haltOnFailure: True
           env: *deploy-env
+
+  tag:
+  # Force this stage manually
+  # Add the property tag with the tag name as value
+    worker: *worker
+    steps:
+      - Git: *clone
+      - ShellCommand: *docker-login
+      - EvePropertyFromCommand:
+          name: get tag short revision
+          property: tag_revision
+          command: git rev-parse --short %(prop:tag)s
+      - ShellCommand:
+          name: publish docker image to Scality Production OCI registry
+          command: |
+            docker pull ${SCALITY_OCI_REPO_DEV}:%(prop:tag_revision)s
+            docker tag ${SCALITY_OCI_REPO_DEV}:%(prop:tag_revision)s ${SCALITY_OCI_REPO}:%(prop:tag)s
+            docker push ${SCALITY_OCI_REPO}:%(prop:tag)s


### PR DESCRIPTION
Experimental, but the idea here is to create a stage `tag` that we will use to perform all the steps required to release zenko-ui.

Ideally this stage would be triggered automatically when tagging the project, but we don't have this feature (yet). It doesn't stop us from being prepared.

I've created two namespaces in registry.scality.com
registry.scality.com/zenko-ui -> for tagged images, production usage
registry.scality.com/zenko-ui-dev -> for dev images

both namespaces are public to the world, as zenko-ui is a public repository. therefore we don't need credentials to pull the images, but need to push them, which the CI does it for us.

the `tag` stage, which can be forced manually, will take a tag as a paremeter, check it's revision, pull the image from the dev namespace and publish it into the production one.

