### PR TITLE
feature: ZENKO-3076 Add coverage reporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,5 +7,6 @@ yarn-error.log
 
 
 node_modules
+coverage
 
 .idea

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Zenko UI
 
+[![codecov](https://codecov.io/gh/scality/zenko-ui/branch/development/1.0/graph/badge.svg?token=BRX58ZF4VJ)](https://codecov.io/gh/scality/zenko-ui)
+
 Zenko UI is our portal to manage offline Zenko instances.
 
 It provides a User Interface to

--- a/eve/main.yml
+++ b/eve/main.yml
@@ -19,6 +19,11 @@ models:
       KEYCLOAK_PASSWORD: "123"
       KEYCLOAK_USER_FIRSTNAME: "Bart"
       KEYCLOAK_USER_LASTNAME: "Simpson"
+  - env: &coverage
+      CODECOV_TOKEN: '%(secret:codecov_token)s'
+      VCS_COMMIT_ID: '%(prop:revision)s'
+      VCS_BRANCH_NAME: '%(prop:branch)s'
+      CI_BUILD_ID: '%(prop:bootstrap)s'
   - Git: &clone
       name: fetch source
       repourl: '%(prop:git_reference)s'
@@ -67,7 +72,7 @@ stages:
           haltOnFailure: True
       - ShellCommand:
           name: run test suite
-          command: yarn test
+          command: yarn test:coverage
           haltOnFailure: True
       - ShellCommand: *yarn-build
       - ShellCommand: *docker-build
@@ -88,6 +93,12 @@ stages:
           env:
             <<: *deploy-env
             <<: *keycloak-env
+      - ShellCommand:
+          name: upload test coverage
+          haltOnFailure: False
+          command: "curl -s https://codecov.io/bash | bash"
+          env:
+            <<: *coverage
   post-merge:
     worker: *worker
     steps:

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "jest",
+    "test:coverage": "jest --coverage --ci",
     "test:lint": "eslint --ext js --ext jsx src",
     "start:dev": "webpack-dev-server --config webpack.dev.js",
     "build": "webpack -p --progress --config webpack.prod.js",


### PR DESCRIPTION
Adds code coverage report to readme and codecov upload

https://codecov.io/gh/scality/zenko-ui/ to view the web UI for coverage.
https://app.codecov.io/gh/scality/zenko-ui/branch/feature%2FZENKO-3076_AddCodeCoverage for this branch/PR.

Note: the badge in the readme will show unknown until this is merged as there isn't a build on the default branch yet.