### PR TITLE
ZENKO-3094 renaming zenko tag stage to release

### DIFF
--- a/eve/main.yml
+++ b/eve/main.yml
@@ -115,7 +115,7 @@ stages:
           haltOnFailure: True
           env: *deploy-env
 
-  tag:
+  release:
   # Force this stage manually
   # Add the property tag with the tag name as value
     worker: *worker


### PR DESCRIPTION
I felt like naming this stage `tag` doesn't feel right, and I rather renaming it to `release` if you don't mind