### PR TITLE
ZENKO-3042 Fix list versions toggle

### DIFF
--- a/src/react/databrowser/objects/ObjectList.jsx
+++ b/src/react/databrowser/objects/ObjectList.jsx
@@ -2,8 +2,9 @@
 
 import * as L from '../../ui-elements/ListLayout2';
 import * as T from '../../ui-elements/Table';
+import type { BucketInfo, ListObjectsType, Object } from '../../../types/s3';
 import { LIST_OBJECTS_METADATA_TYPE, LIST_OBJECTS_S3_TYPE, LIST_OBJECT_VERSIONS_S3_TYPE } from '../../utils/s3';
-import type { ListObjectsType, Object } from '../../../types/s3';
+import { isVersioningDisabled, maybePluralize } from '../../utils';
 import { listObjects, openFolderCreateModal, openObjectDeleteModal, openObjectUploadModal } from '../../actions';
 import { useDispatch, useSelector } from 'react-redux';
 import type { AppState } from '../../../types/state';
@@ -13,7 +14,6 @@ import ObjectListTable from './ObjectListTable';
 import React from 'react';
 import { Toggle } from '@scality/core-ui';
 import { WarningMetadata } from '../../ui-elements/Warning';
-import { maybePluralize } from '../../utils';
 
 type Props = {
     objects: List<Object>,
@@ -21,11 +21,13 @@ type Props = {
     prefixWithSlash: string,
     toggled: List<Object>,
     listType: ListObjectsType,
+    bucketInfo: BucketInfo,
 };
 
-export default function ObjectList({ objects, bucketName, prefixWithSlash, toggled, listType }: Props){
+export default function ObjectList({ objects, bucketName, prefixWithSlash, toggled, listType, bucketInfo }: Props){
     const dispatch = useDispatch();
     const errorZenkoMsg = useSelector((state: AppState) => state.zenko.error.message);
+    const isBucketVersioningDisabled = isVersioningDisabled(bucketInfo.versioning);
     const isMetadataType = listType === LIST_OBJECTS_METADATA_TYPE;
     const isVersioningType = listType === LIST_OBJECT_VERSIONS_S3_TYPE;
 
@@ -45,7 +47,8 @@ export default function ObjectList({ objects, bucketName, prefixWithSlash, toggl
                 <T.ExtraButton id='object-list-create-folder-button' text='Folder' icon={<i className="fas fa-plus" />} variant='info' onClick={() => dispatch(openFolderCreateModal())} size="default" />
                 <T.ExtraButton id='object-list-delete-button' text='Delete' icon={<i className="fas fa-trash" />} disabled={isToggledEmpty} variant='danger' onClick={() => dispatch(openObjectDeleteModal())} size="default" />
                 <Toggle
-                    disabled={isMetadataType}
+                    id='list-versions-toggle'
+                    disabled={isMetadataType || isBucketVersioningDisabled}
                     toggle={isVersioningType}
                     label='List Versions'
                     onChange={() => {

--- a/src/react/databrowser/objects/ObjectList.jsx
+++ b/src/react/databrowser/objects/ObjectList.jsx
@@ -2,7 +2,7 @@
 
 import * as L from '../../ui-elements/ListLayout2';
 import * as T from '../../ui-elements/Table';
-import type { BucketInfo, ListObjectsType, Object } from '../../../types/s3';
+import type { BucketInfo, ListObjectsType, ObjectEntity } from '../../../types/s3';
 import { LIST_OBJECTS_METADATA_TYPE, LIST_OBJECTS_S3_TYPE, LIST_OBJECT_VERSIONS_S3_TYPE } from '../../utils/s3';
 import { isVersioningDisabled, maybePluralize } from '../../utils';
 import { listObjects, openFolderCreateModal, openObjectDeleteModal, openObjectUploadModal } from '../../actions';
@@ -16,10 +16,10 @@ import { Toggle } from '@scality/core-ui';
 import { WarningMetadata } from '../../ui-elements/Warning';
 
 type Props = {
-    objects: List<Object>,
+    objects: List<ObjectEntity>,
     bucketName: string,
     prefixWithSlash: string,
-    toggled: List<Object>,
+    toggled: List<ObjectEntity>,
     listType: ListObjectsType,
     bucketInfo: BucketInfo,
 };

--- a/src/react/databrowser/objects/ObjectListTable.jsx
+++ b/src/react/databrowser/objects/ObjectListTable.jsx
@@ -10,7 +10,7 @@ import { AutoSizer } from 'react-virtualized';
 import { FixedSizeList } from 'react-window';
 import InfiniteLoader from 'react-window-infinite-loader';
 import { List } from 'immutable';
-import type { Object } from '../../../types/s3';
+import type { ObjectEntity } from '../../../types/s3';
 import { formatBytes } from '../../utils';
 import { push } from 'connected-react-router';
 import styled from 'styled-components';
@@ -22,14 +22,14 @@ export const Icon = styled.i`
 
 type CellProps = {
     row: {
-        original: Object,
+        original: ObjectEntity,
     },
 };
 
 type Props = {
-    objects: List<Object>,
+    objects: List<ObjectEntity>,
     bucketName: string,
-    toggled: List<Object>,
+    toggled: List<ObjectEntity>,
     isVersioningType: boolean,
     prefixWithSlash: string,
 };

--- a/src/react/databrowser/objects/ObjectRow.jsx
+++ b/src/react/databrowser/objects/ObjectRow.jsx
@@ -5,7 +5,7 @@ import React, { memo } from 'react';
 import { toggleAllObjects, toggleObject } from '../../actions';
 import type { Action } from '../../../types/actions';
 import type { DispatchAPI } from 'redux';
-import type { Object } from '../../../types/s3';
+import type { ObjectEntity } from '../../../types/s3';
 import { areEqual } from 'react-window';
 import isDeepEqual from 'lodash.isequal';
 import memoize from 'memoize-one';
@@ -14,7 +14,7 @@ type PrepareRow = (RowType) => void;
 
 type RowType = {
     id: number,
-    original: Object,
+    original: ObjectEntity,
     cells: any,
     getRowProps: (any) => void,
 };

--- a/src/react/databrowser/objects/Objects.jsx
+++ b/src/react/databrowser/objects/Objects.jsx
@@ -6,6 +6,7 @@ import { getBucketInfo, getObjectMetadata, listObjects, resetObjectMetadata } fr
 import { useDispatch, useSelector } from 'react-redux';
 import type { AppState } from '../../../types/state';
 import FolderCreate from './FolderCreate';
+import { LIST_OBJECTS_S3_TYPE } from '../../utils/s3';
 import ObjectDelete from './ObjectDelete';
 import ObjectDetails from './ObjectDetails';
 import ObjectHead from './ObjectHead';
@@ -28,7 +29,7 @@ export default function Objects(){
     const prefixWithSlash = addTrailingSlash(prefixParam);
 
     useEffect(() => {
-        dispatch(listObjects(bucketNameParam, prefixWithSlash)).finally(() => setLoaded(true));
+        dispatch(listObjects(bucketNameParam, prefixWithSlash, LIST_OBJECTS_S3_TYPE)).finally(() => setLoaded(true));
     }, [bucketNameParam, prefixWithSlash, dispatch]);
 
     useEffect(() => {
@@ -76,7 +77,7 @@ export default function Objects(){
         <ObjectHead bucketNameParam={bucketNameParam}/>
 
         <L.Body>
-            <ObjectList toggled={toggled} objects={objects} bucketName={bucketNameParam} prefixWithSlash={prefixWithSlash} listType={listType} />
+            <ObjectList bucketInfo={bucketInfo} toggled={toggled} objects={objects} bucketName={bucketNameParam} prefixWithSlash={prefixWithSlash} listType={listType} />
             <ObjectDetails toggled={toggled} listType={listType} />
         </L.Body>
     </L.ContentContainer>;

--- a/src/react/reducers/s3.js
+++ b/src/react/reducers/s3.js
@@ -1,7 +1,7 @@
 // @flow
 import { LIST_OBJECTS_METADATA_TYPE, LIST_OBJECTS_S3_TYPE, LIST_OBJECT_VERSIONS_S3_TYPE, mergeSortedVersionsAndDeleteMarkers } from '../utils/s3';
 import { METADATA_SYSTEM_TYPE, METADATA_USER_TYPE, formatShortDate, stripQuotes, systemMetadataKeys } from '../utils';
-import type { MetadataPairs, Object, S3DeleteMarker, S3Version, TagSet, Tags } from '../../types/s3';
+import type { MetadataPairs, ObjectEntity, S3DeleteMarker, S3Version, TagSet, Tags } from '../../types/s3';
 import { List } from 'immutable';
 import type { S3Action } from '../../types/actions';
 import type { S3State } from '../../types/state';
@@ -9,7 +9,7 @@ import { initialS3State } from './initialConstants';
 
 const sortByDate = objs => objs.sort((a,b) => (new Date(b.CreationDate) - new Date(a.CreationDate)));
 
-const objects = (objs, prefix): Array<Object> => objs.filter(o => o.Key !== prefix).map(o => {
+const objects = (objs, prefix): Array<ObjectEntity> => objs.filter(o => o.Key !== prefix).map(o => {
     return {
         name: o.Key.replace(prefix, ''),
         key: o.Key,
@@ -22,7 +22,7 @@ const objects = (objs, prefix): Array<Object> => objs.filter(o => o.Key !== pref
     };
 });
 
-const folder = (objs, prefix): Array<Object> => objs.map(o => {
+const folder = (objs, prefix): Array<ObjectEntity> => objs.map(o => {
     return {
         name: o.Prefix.replace(prefix, ''),
         key: o.Prefix,
@@ -32,7 +32,7 @@ const folder = (objs, prefix): Array<Object> => objs.map(o => {
     };
 });
 
-const search = (objs): Array<Object> => objs.map(o => {
+const search = (objs): Array<ObjectEntity> => objs.map(o => {
     return {
         name: o.Key,
         key: o.Key,

--- a/src/react/utils/index.js
+++ b/src/react/utils/index.js
@@ -76,3 +76,4 @@ export function stripQuotes(s) {
 export const isEmptyItem = (item => item.key === '' && item.value === '');
 
 export const isVersioning = (type => type === 'Enabled');
+export const isVersioningDisabled = (type => type === 'Disabled');

--- a/src/types/s3.js
+++ b/src/types/s3.js
@@ -69,17 +69,17 @@ export type CommonPrefix = {|
     +Prefix: string,
 |};
 
-export type Object = {|
+export type ObjectEntity = {|
     +name: string,
     +key: string,
     +lastModified?: string,
-    +isFolder: string,
-    +size: number,
+    +isFolder: boolean,
+    +size?: number,
     +toggled: boolean,
     +signedUrl?: string,
     +isLatest: boolean,
-    +versionId: ?string,
-    +isDeleteMarker: ?boolean,
+    +versionId?: string,
+    +isDeleteMarker?: boolean,
 |};
 
 export type File = {|

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -1,7 +1,7 @@
 // @flow
 
 import type { AuthUser, UserManager as UserManagerInterface } from './auth';
-import type { BucketInfo, ListObjectsType, Object, ObjectMetadata, S3Bucket } from './s3';
+import type { BucketInfo, ListObjectsType, ObjectEntity, ObjectMetadata, S3Bucket } from './s3';
 import type { BucketList, InstanceStatus } from './stats';
 import type { ConfigurationOverlay, LocationName } from './config';
 import type { ErrorViewType, FailureType } from './ui';
@@ -106,7 +106,7 @@ export type S3State = {|
     |},
     +bucketInfo: BucketInfo | null,
     +listObjectsResults: {|
-        +list: List<Object>,
+        +list: List<ObjectEntity>,
         +nextMarker: Marker,
         +nextVersionIdMarker: Marker,
     |},


### PR DESCRIPTION
- "List Versions" toggle should be disabled if bucket versioning is “Disabled”. 
- "List Versions" toggle should be enabled if bucket versioning is “Suspended“ or “Enabled“.