### PR TITLE
fix:ZENKO-3179  add copy icon to missing fields

### DIFF
--- a/src/react/ui-elements/Clipboard.jsx
+++ b/src/react/ui-elements/Clipboard.jsx
@@ -12,6 +12,7 @@ export const IconSuccess = styled.i`
 `;
 
 export const IconCopy = styled.i`
+    color: ${props => props.theme.brand.textSecondary};
     display: ${props => props.hidden ? 'none': 'block'};
 `;
 
@@ -39,7 +40,7 @@ export const Clipboard = ({ text }: { text: string }) => {
                 <Tooltip overlay= "Copied!" placement="right" >
                     <IconSuccess className='fas fa-check'></IconSuccess>
                 </Tooltip>:
-                <IconCopy hidden={!navigator || !navigator.clipboard} className='far fa-clipboard clipboard-icon-copy' onClick={copyToClipboard}></IconCopy>
+                <IconCopy hidden={!navigator || !navigator.clipboard} className='far fa-clone' onClick={copyToClipboard}></IconCopy>
         }
     </Container>;
 };

--- a/src/react/ui-elements/__tests__/Clipboard.test.jsx
+++ b/src/react/ui-elements/__tests__/Clipboard.test.jsx
@@ -1,4 +1,4 @@
-import { Clipboard, IconSuccess } from '../Clipboard';
+import { Clipboard, IconCopy, IconSuccess } from '../Clipboard';
 import { OWNER_NAME } from '../../actions/__tests__/utils/testUtil';
 import React from 'react';
 import { reduxMount } from '../../utils/test';
@@ -8,7 +8,7 @@ describe('Clipboard', () => {
         const { component } = reduxMount(<Clipboard text={OWNER_NAME}/>);
 
         expect(component.find(Clipboard)).toHaveLength(1);
-        expect(component.find('i.clipboard-icon-copy')).toHaveLength(1);
+        expect(component.find(IconCopy)).toHaveLength(1);
     });
 
     it('Clipboard should render with success icon', () => {
@@ -19,10 +19,10 @@ describe('Clipboard', () => {
         const { component } = reduxMount(<Clipboard text={OWNER_NAME}/>);
 
         expect(component.find(Clipboard)).toHaveLength(1);
-        expect(component.find('i.clipboard-icon-copy')).toHaveLength(1);
-        component.find('i.clipboard-icon-copy').simulate('click');
+        expect(component.find(IconCopy)).toHaveLength(1);
+        component.find(IconCopy).simulate('click');
         expect(writeTextFn).toHaveBeenCalledTimes(1);
         expect(component.find(IconSuccess)).toHaveLength(1);
-        expect(component.find('i.clipboard-icon-copy')).toHaveLength(0);
+        expect(component.find(IconCopy)).toHaveLength(0);
     });
 });


### PR DESCRIPTION
![Screenshot from 2021-04-15 16-48-01](https://user-images.githubusercontent.com/47044686/114898822-5eaa1b00-9e0a-11eb-95d2-c59fa4ac3a73.png)

