### PR TITLE
ZENKO-3180: Update version of core-ui to v0.14.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2118,8 +2118,8 @@
       }
     },
     "@scality/core-ui": {
-      "version": "github:scality/core-ui#2c243cc89c135985f6a4ff3a8c5cbfd817a5d0c1",
-      "from": "github:scality/core-ui#v0.10.0"
+      "version": "github:scality/core-ui#5458ab9b640642771936e573091bcd1a2fc36d15",
+      "from": "github:scality/core-ui#v0.14.1"
     },
     "@sindresorhus/is": {
       "version": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "@fortawesome/fontawesome-free": "5.7.2",
     "@hapi/joi": "^17.1.1",
     "@hookform/resolvers": "^0.1.0",
-    "@scality/core-ui": "github:scality/core-ui.git#v0.10.0",
+    "@scality/core-ui": "github:scality/core-ui.git#v0.14.1",
     "async": "^3.2.0",
     "aws-sdk": "^2.616.0",
     "connected-react-router": "^6.7.0",


### PR DESCRIPTION
Update core-ui version from v0.10.0 to v0.14.1.