### PR TITLE
ZENKO-347 handle IAM errors

### DIFF
--- a/src/js/IAMClient.js
+++ b/src/js/IAMClient.js
@@ -28,7 +28,7 @@ export function getAssumeRoleWithWebIdentityIAM(state: AppState, accountName: st
             };
             const iamClient = new IAMClient(auth.config.iamEndpoint);
             iamClient.login(params);
-            return Promise.resolve(iamClient);
+            return iamClient;
         });
 }
 
@@ -118,7 +118,6 @@ export default class IAMClient implements IAMClientInterface {
 // OFFLILE
 // export default class IAMClient {
 //     constructor() {
-//         console.log('CALL constructor!!!');
 //         this.users = [{
 //             UserName: 'Alice',
 //             Arn: 'arn:alice:bucket1:write:read:exec',

--- a/src/js/ZenkoClient.js
+++ b/src/js/ZenkoClient.js
@@ -10,11 +10,6 @@ import S3Client from './S3Client';
 // TODO: prevent zenkoclient from including in the bundle the full AWS SDK.
 import ZenkoClientBase from 'zenkoclient';
 
-export const zenkoError = {
-    message: 'S3 Client Api Error Response',
-    code: 500,
-};
-
 
 class ZenkoClient extends S3Client implements ZenkoClientInterface {
     endpoint: string;

--- a/src/js/mock/S3Client.js
+++ b/src/js/mock/S3Client.js
@@ -10,7 +10,7 @@ import type {
     PutObjectTaggingResponse,
     S3Client as S3ClientInterface,
 } from '../../types/s3';
-import { ApiErrorObject } from './error';
+import type { AWSError } from '../../types/aws';
 import { addTrailingSlash } from '../../react/utils';
 
 export const ownerName = 'bart';
@@ -172,9 +172,9 @@ export class MockS3Client implements S3ClientInterface {
 }
 
 export class ErrorMockS3Client implements S3ClientInterface {
-    _error: ApiErrorObject;
+    _error: AWSError;
 
-    constructor(error: ApiErrorObject) {
+    constructor(error: AWSError) {
         this._error = error;
     }
 

--- a/src/js/mock/ZenkoClient.js
+++ b/src/js/mock/ZenkoClient.js
@@ -4,7 +4,7 @@ import type {
     SearchBucketResp,
     ZenkoClient as ZenkoClientInterface,
 } from '../../types/zenko';
-import { ApiErrorObject } from './error';
+import { AWSError } from '../../types/aws';
 
 export class MockZenkoClient extends MockS3Client implements ZenkoClientInterface {
     _init(): void {}
@@ -17,9 +17,9 @@ export class MockZenkoClient extends MockS3Client implements ZenkoClientInterfac
 }
 
 export class ErrorMockZenkoClient extends ErrorMockS3Client implements ZenkoClientInterface {
-    _error: ApiErrorObject;
+    _error: AWSError;
 
-    constructor(error: ApiErrorObject) {
+    constructor(error: AWSError) {
         super(error);
         this._error = error;
     }

--- a/src/js/mock/error.js
+++ b/src/js/mock/error.js
@@ -1,14 +1,26 @@
 // @flow
+import type { AWSError } from '../../types/aws';
 
 export class ApiErrorObject extends Error {
     code: number | string;
     status: number | string;
     message: string;
+    response: Object;
 
     constructor(message: string, status: string | number) {
         super(message);
-        this.message = message;
+        this.response = {
+            body: {
+                message,
+            },
+        };
         this.status = status === undefined ? 500 : status;
-        this.code = this.status;
     }
+}
+
+export function awsErrorObject(message: string, code: string): AWSError {
+    return {
+        code,
+        message,
+    };
 }

--- a/src/react/actions/__tests__/s3bucket.test.jsx
+++ b/src/react/actions/__tests__/s3bucket.test.jsx
@@ -1,13 +1,14 @@
 import * as actions from '../s3bucket';
 import * as dispatchAction from './utils/dispatchActionsList';
 import {
+    AWS_CLIENT_ERROR_MSG,
     BUCKET_INFO_RESPONSE,
     BUCKET_NAME,
     OWNER_NAME,
     errorZenkoState,
     initState,
     testActionFunction,
-    testDispatchErrorTestFn,
+    testDispatchAWSErrorTestFn,
     testDispatchFunction,
 } from './utils/testUtil';
 
@@ -77,7 +78,7 @@ describe('s3bucket actions', () => {
             storeState: errorZenkoState(),
             expectedActions: [
                 createBucketNetworkAction,
-                dispatchAction.HANDLE_ERROR_SPEC_ACTION('S3 Client Api Error Response'),
+                dispatchAction.HANDLE_ERROR_SPEC_ACTION(AWS_CLIENT_ERROR_MSG),
                 dispatchAction.NETWORK_END_ACTION,
             ],
         },
@@ -105,7 +106,7 @@ describe('s3bucket actions', () => {
             storeState: errorZenkoState(),
             expectedActions: [
                 deleteBucketNetworkAction,
-                dispatchAction.HANDLE_ERROR_MODAL_ACTION('S3 Client Api Error Response'),
+                dispatchAction.HANDLE_ERROR_MODAL_ACTION(AWS_CLIENT_ERROR_MSG),
                 dispatchAction.NETWORK_END_ACTION,
                 dispatchAction.CLOSE_BUCKET_DELETE_DIALOG_ACTION,
             ],
@@ -126,7 +127,7 @@ describe('s3bucket actions', () => {
             storeState: errorZenkoState(),
             expectedActions: [
                 getBucketInfoNetworkAction,
-                dispatchAction.HANDLE_ERROR_SPEC_ACTION('S3 Client Api Error Response'),
+                dispatchAction.HANDLE_ERROR_SPEC_ACTION(AWS_CLIENT_ERROR_MSG),
                 dispatchAction.NETWORK_END_ACTION,
             ],
         },
@@ -149,7 +150,7 @@ describe('s3bucket actions', () => {
             storeState: errorZenkoState(),
             expectedActions: [
                 toggleBucketVersioningNetworkAction,
-                dispatchAction.HANDLE_ERROR_MODAL_ACTION('S3 Client Api Error Response'),
+                dispatchAction.HANDLE_ERROR_MODAL_ACTION(AWS_CLIENT_ERROR_MSG),
                 dispatchAction.NETWORK_END_ACTION,
             ],
         },
@@ -157,10 +158,8 @@ describe('s3bucket actions', () => {
 
     asyncTests.forEach(testDispatchFunction);
 
-    testDispatchErrorTestFn({
-        message: 'S3 Client Api Error Response',
-        code: 500,
-        status: 500,
+    testDispatchAWSErrorTestFn({
+        message: AWS_CLIENT_ERROR_MSG,
     },
     {
         it: 'listBuckets: should handle error',

--- a/src/react/actions/__tests__/s3object.test.jsx
+++ b/src/react/actions/__tests__/s3object.test.jsx
@@ -1,6 +1,7 @@
 import * as actions from '../s3object';
 import * as dispatchAction from './utils/dispatchActionsList';
 import {
+    AWS_CLIENT_ERROR_MSG,
     BUCKET_NAME, COMMON_PREFIX,
     FILE, FOLDER_NAME,
     INFO,
@@ -134,7 +135,7 @@ describe('s3object actions', () => {
             storeState: errorZenkoState(),
             expectedActions: [
                 createFolderNetworkAction,
-                dispatchAction.HANDLE_ERROR_SPEC_ACTION('S3 Client Api Error Response'),
+                dispatchAction.HANDLE_ERROR_SPEC_ACTION(AWS_CLIENT_ERROR_MSG),
                 dispatchAction.NETWORK_END_ACTION,
                 dispatchAction.CLOSE_FOLDER_CREATE_MODAL_ACTION(),
             ],
@@ -145,7 +146,7 @@ describe('s3object actions', () => {
             storeState: errorZenkoState(),
             expectedActions: [
                 createFolderNetworkAction,
-                dispatchAction.HANDLE_ERROR_SPEC_ACTION('S3 Client Api Error Response'),
+                dispatchAction.HANDLE_ERROR_SPEC_ACTION(AWS_CLIENT_ERROR_MSG),
                 dispatchAction.NETWORK_END_ACTION,
                 dispatchAction.CLOSE_FOLDER_CREATE_MODAL_ACTION(),
             ],
@@ -183,7 +184,7 @@ describe('s3object actions', () => {
             expectedActions: [
                 dispatchAction.CLOSE_OBJECT_UPLOAD_MODAL_ACTION(),
                 uploadObjectsNetworkAction,
-                dispatchAction.HANDLE_ERROR_SPEC_ACTION('S3 Client Api Error Response'),
+                dispatchAction.HANDLE_ERROR_SPEC_ACTION(AWS_CLIENT_ERROR_MSG),
                 dispatchAction.NETWORK_END_ACTION,
             ],
         },
@@ -194,7 +195,7 @@ describe('s3object actions', () => {
             expectedActions: [
                 dispatchAction.CLOSE_OBJECT_UPLOAD_MODAL_ACTION(),
                 uploadObjectsNetworkAction,
-                dispatchAction.HANDLE_ERROR_SPEC_ACTION('S3 Client Api Error Response'),
+                dispatchAction.HANDLE_ERROR_SPEC_ACTION(AWS_CLIENT_ERROR_MSG),
                 dispatchAction.NETWORK_END_ACTION,
             ],
         },
@@ -224,7 +225,7 @@ describe('s3object actions', () => {
             storeState: errorZenkoState(),
             expectedActions: [
                 listObjectsNetworkAction,
-                dispatchAction.HANDLE_ERROR_SPEC_ACTION('S3 Client Api Error Response'),
+                dispatchAction.HANDLE_ERROR_SPEC_ACTION(AWS_CLIENT_ERROR_MSG),
                 dispatchAction.NETWORK_END_ACTION,
             ],
         },
@@ -234,7 +235,7 @@ describe('s3object actions', () => {
             storeState: errorZenkoState(),
             expectedActions: [
                 listObjectsNetworkAction,
-                dispatchAction.HANDLE_ERROR_SPEC_ACTION('S3 Client Api Error Response'),
+                dispatchAction.HANDLE_ERROR_SPEC_ACTION(AWS_CLIENT_ERROR_MSG),
                 dispatchAction.NETWORK_END_ACTION,
             ],
         },
@@ -271,10 +272,10 @@ describe('s3object actions', () => {
             expectedActions: [
                 dispatchAction.CLOSE_OBJECT_DELETE_MODAL_ACTION(),
                 deleteFilesNetworkAction,
-                dispatchAction.HANDLE_ERROR_MODAL_ACTION('S3 Client Api Error Response'),
+                dispatchAction.HANDLE_ERROR_MODAL_ACTION(AWS_CLIENT_ERROR_MSG),
                 dispatchAction.NETWORK_END_ACTION,
                 listObjectsNetworkAction,
-                dispatchAction.HANDLE_ERROR_SPEC_ACTION('S3 Client Api Error Response'),
+                dispatchAction.HANDLE_ERROR_SPEC_ACTION(AWS_CLIENT_ERROR_MSG),
                 dispatchAction.NETWORK_END_ACTION,
             ],
         },
@@ -285,10 +286,10 @@ describe('s3object actions', () => {
             expectedActions: [
                 dispatchAction.CLOSE_OBJECT_DELETE_MODAL_ACTION(),
                 deleteFilesNetworkAction,
-                dispatchAction.HANDLE_ERROR_MODAL_ACTION('S3 Client Api Error Response'),
+                dispatchAction.HANDLE_ERROR_MODAL_ACTION(AWS_CLIENT_ERROR_MSG),
                 dispatchAction.NETWORK_END_ACTION,
                 listObjectsNetworkAction,
-                dispatchAction.HANDLE_ERROR_SPEC_ACTION('S3 Client Api Error Response'),
+                dispatchAction.HANDLE_ERROR_SPEC_ACTION(AWS_CLIENT_ERROR_MSG),
                 dispatchAction.NETWORK_END_ACTION,
             ],
         },
@@ -308,7 +309,7 @@ describe('s3object actions', () => {
             storeState: errorZenkoState(),
             expectedActions: [
                 gettingObjectMetadataNetworkAction,
-                dispatchAction.HANDLE_ERROR_SPEC_ACTION('S3 Client Api Error Response'),
+                dispatchAction.HANDLE_ERROR_SPEC_ACTION(AWS_CLIENT_ERROR_MSG),
                 dispatchAction.NETWORK_END_ACTION,
             ],
         },
@@ -318,7 +319,7 @@ describe('s3object actions', () => {
             storeState: errorZenkoState(),
             expectedActions: [
                 gettingObjectMetadataNetworkAction,
-                dispatchAction.HANDLE_ERROR_SPEC_ACTION('S3 Client Api Error Response'),
+                dispatchAction.HANDLE_ERROR_SPEC_ACTION(AWS_CLIENT_ERROR_MSG),
                 dispatchAction.NETWORK_END_ACTION,
             ],
         },
@@ -340,7 +341,7 @@ describe('s3object actions', () => {
             storeState: errorZenkoState(),
             expectedActions: [
                 gettingObjectMetadataNetworkAction,
-                dispatchAction.HANDLE_ERROR_MODAL_ACTION('S3 Client Api Error Response'),
+                dispatchAction.HANDLE_ERROR_MODAL_ACTION(AWS_CLIENT_ERROR_MSG),
                 dispatchAction.NETWORK_END_ACTION,
             ],
         },
@@ -374,7 +375,7 @@ describe('s3object actions', () => {
             storeState: errorZenkoState(),
             expectedActions: [
                 gettingObjectTagsNetworkAction,
-                dispatchAction.HANDLE_ERROR_MODAL_ACTION('S3 Client Api Error Response'),
+                dispatchAction.HANDLE_ERROR_MODAL_ACTION(AWS_CLIENT_ERROR_MSG),
                 dispatchAction.NETWORK_END_ACTION,
             ],
         },

--- a/src/react/actions/__tests__/workflow.test.js
+++ b/src/react/actions/__tests__/workflow.test.js
@@ -56,8 +56,6 @@ describe('workflow actions', () => {
 
     testDispatchErrorTestFn({
         message: 'Management API Error Response',
-        code: 500,
-        status: 500,
     },
     {
         it: 'searchWorkflows: should handle error',

--- a/src/react/actions/__tests__/zenko.test.js
+++ b/src/react/actions/__tests__/zenko.test.js
@@ -1,8 +1,8 @@
 import * as actions from '../zenko';
 import * as dispatchAction from './utils/dispatchActionsList';
 import {
+    AWS_CLIENT_ERROR,
     BUCKET_NAME,
-    ZENKO_ERROR,
     addNextMarkerToState,
     errorZenkoState,
     initState,
@@ -45,18 +45,18 @@ describe('zenko actions', () => {
         },
         {
             it: 'should return ZENKO_HANDLE_ERROR action',
-            fn: actions.zenkoHandleError(ZENKO_ERROR, null, null),
-            expectedActions: [dispatchAction.ZENKO_HANDLE_ERROR_ACTION(ZENKO_ERROR, null, null)],
+            fn: actions.zenkoHandleError(AWS_CLIENT_ERROR, null, null),
+            expectedActions: [dispatchAction.ZENKO_HANDLE_ERROR_ACTION(AWS_CLIENT_ERROR, null, null)],
         },
         {
             it: 'should return ZENKO_HANDLE_ERROR action with right target',
-            fn: actions.zenkoHandleError(ZENKO_ERROR, 'target', null),
-            expectedActions: [dispatchAction.ZENKO_HANDLE_ERROR_ACTION(ZENKO_ERROR, 'target', null)],
+            fn: actions.zenkoHandleError(AWS_CLIENT_ERROR, 'target', null),
+            expectedActions: [dispatchAction.ZENKO_HANDLE_ERROR_ACTION(AWS_CLIENT_ERROR, 'target', null)],
         },
         {
             it: 'should return ZENKO_HANDLE_ERROR action with right type',
-            fn: actions.zenkoHandleError(ZENKO_ERROR, null, 'type'),
-            expectedActions: [dispatchAction.ZENKO_HANDLE_ERROR_ACTION(ZENKO_ERROR, null, 'type')],
+            fn: actions.zenkoHandleError(AWS_CLIENT_ERROR, null, 'type'),
+            expectedActions: [dispatchAction.ZENKO_HANDLE_ERROR_ACTION(AWS_CLIENT_ERROR, null, 'type')],
         },
         {
             it: 'should return ZENKO_CLIENT_WRITE_SEARCHLIST action',
@@ -114,7 +114,7 @@ describe('zenko actions', () => {
                 startingSearchNetworkAction,
                 dispatchAction.ZENKO_CLEAR_ERROR_ACTION(),
                 searchingObjectsNetworkAction,
-                dispatchAction.ZENKO_HANDLE_ERROR_ACTION(ZENKO_ERROR, null, null),
+                dispatchAction.ZENKO_HANDLE_ERROR_ACTION(AWS_CLIENT_ERROR, null, null),
                 dispatchAction.NETWORK_END_ACTION,
                 dispatchAction.NETWORK_END_ACTION,
             ],
@@ -140,7 +140,7 @@ describe('zenko actions', () => {
                 continueSearchNetworkAction,
                 dispatchAction.ZENKO_CLEAR_ERROR_ACTION(),
                 searchingObjectsNetworkAction,
-                dispatchAction.ZENKO_HANDLE_ERROR_ACTION(ZENKO_ERROR, null, null),
+                dispatchAction.ZENKO_HANDLE_ERROR_ACTION(AWS_CLIENT_ERROR, null, null),
                 dispatchAction.NETWORK_END_ACTION,
                 dispatchAction.NETWORK_END_ACTION,
             ],

--- a/src/react/actions/account.js
+++ b/src/react/actions/account.js
@@ -14,7 +14,7 @@ import type {
     ThunkStatePromisedAction,
 } from '../../types/actions';
 import { getAccountIDStored, removeAccountIDStored, setAccountIDStored } from '../utils/localStorage';
-import { handleApiError, handleClientError } from './error';
+import { handleAWSClientError, handleAWSError, handleApiError, handleClientError } from './error';
 import { networkEnd, networkStart } from './network';
 import type { IamAccessKey } from '../../types/user';
 import { assumeRoleWithWebIdentity } from './sts';
@@ -153,8 +153,8 @@ export function listAccountAccessKeys(accountName: string): ThunkStatePromisedAc
         return getAssumeRoleWithWebIdentityIAM(getState(), accountName)
             .then(iamClient => iamClient.listOwnAccessKeys())
             .then(resp => dispatch(listAccountAccessKeySuccess(resp.AccessKeyMetadata)))
-            .catch(error => dispatch(handleClientError(error)))
-            .catch(error => dispatch(handleApiError(error, 'byModal')))
+            .catch(error => dispatch(handleAWSClientError(error)))
+            .catch(error => dispatch(handleAWSError(error, 'byModal')))
             .finally(() => dispatch(networkEnd()));
     };
 }
@@ -165,8 +165,8 @@ export function deleteAccountAccessKey(accountName: string, accessKey: string): 
         return getAssumeRoleWithWebIdentityIAM(getState(), accountName)
             .then(iamClient => iamClient.deleteAccessKey(accessKey))
             .then(() => dispatch(listAccountAccessKeys(accountName)))
-            .catch(error => dispatch(handleClientError(error)))
-            .catch(error => dispatch(handleApiError(error, 'byModal')))
+            .catch(error => dispatch(handleAWSClientError(error)))
+            .catch(error => dispatch(handleAWSError(error, 'byModal')))
             .finally(() => dispatch(networkEnd()));
     };
 }

--- a/src/react/actions/error.js
+++ b/src/react/actions/error.js
@@ -5,19 +5,25 @@ import type {
     ClearErrorAction,
     DispatchFunction,
     HandleErrorAction,
-    S3Error,
     ThunkNonStateAction,
 } from '../../types/actions';
-import type { ErrorViewType, FailureType } from '../../types/ui';
+import type { AWSError } from '../../types/aws';
+import type { ErrorViewType } from '../../types/ui';
 import { errorParser } from '../utils';
 import { networkAuthFailure } from './network';
-
-export const S3_FAILURE_TYPE: FailureType = 's3';
 
 export function handleApiError(error: ApiError, errorType: ErrorViewType): HandleErrorAction {
     return {
         type: 'HANDLE_ERROR',
         errorMsg: errorParser(error).message,
+        errorType,
+    };
+}
+
+export function handleAWSError(error: AWSError, errorType: ErrorViewType): HandleErrorAction {
+    return {
+        type: 'HANDLE_ERROR',
+        errorMsg: error.message,
         errorType,
     };
 }
@@ -47,12 +53,13 @@ export function handleClientError(error: ApiError): ThunkNonStateAction {
     };
 }
 
-export function handleS3Error(error: S3Error): ThunkNonStateAction {
+export function handleAWSClientError(error: AWSError): ThunkNonStateAction {
     return (dispatch: DispatchFunction) => {
         switch (error.statusCode) {
         case 401:
         case 403:
-            dispatch(networkAuthFailure(S3_FAILURE_TYPE));
+            dispatch(handleErrorMessage(error.message, 'byAuth'));
+            dispatch(networkAuthFailure());
             break;
         default:
             throw error;

--- a/src/react/actions/network.js
+++ b/src/react/actions/network.js
@@ -6,7 +6,6 @@ import type {
     NetworkActivityEndAction,
     NetworkActivityStartAction,
 } from '../../types/actions';
-import type { FailureType } from '../../types/ui';
 
 export function networkAuthReset(): NetworkActivityAuthResetAction {
     return {
@@ -14,10 +13,9 @@ export function networkAuthReset(): NetworkActivityAuthResetAction {
     };
 }
 
-export function networkAuthFailure(failureType?: FailureType): NetworkActivityAuthFailureAction {
+export function networkAuthFailure(): NetworkActivityAuthFailureAction {
     return {
         type: 'NETWORK_AUTH_FAILURE',
-        failureType,
     };
 }
 

--- a/src/react/actions/s3bucket.js
+++ b/src/react/actions/s3bucket.js
@@ -7,7 +7,7 @@ import type {
     OpenBucketDeleteDialogAction,
     ThunkStatePromisedAction,
 } from '../../types/actions';
-import { handleApiError, handleS3Error } from './error';
+import { handleAWSClientError, handleAWSError } from './error';
 import { networkEnd, networkStart } from './network';
 import { getClients } from '../utils/actions';
 import { push } from 'connected-react-router';
@@ -60,8 +60,8 @@ export function createBucket(bucket: CreateBucketRequest): ThunkStatePromisedAct
         return zenkoClient.createBucket(bucket)
             .then(() => dispatch(listBuckets()))
             .then(() => dispatch(push('/buckets')))
-            .catch(error => dispatch(handleS3Error(error)))
-            .catch(error => dispatch(handleApiError(error, 'byComponent')))
+            .catch(error => dispatch(handleAWSClientError(error)))
+            .catch(error => dispatch(handleAWSError(error, 'byComponent')))
             .finally(() => dispatch(networkEnd()));
     };
 }
@@ -73,8 +73,8 @@ export function deleteBucket(bucketName: string): ThunkStatePromisedAction{
         return zenkoClient.deleteBucket(bucketName)
             .then(() => dispatch(listBuckets()))
             .then(() => dispatch(push('/buckets')))
-            .catch(error => dispatch(handleS3Error(error)))
-            .catch(error => dispatch(handleApiError(error, 'byModal')))
+            .catch(error => dispatch(handleAWSClientError(error)))
+            .catch(error => dispatch(handleAWSError(error, 'byModal')))
             .finally(() => {
                 dispatch(networkEnd());
                 dispatch(closeBucketDeleteDialog());
@@ -88,8 +88,8 @@ export function getBucketInfo(bucketName: string): ThunkStatePromisedAction{
         dispatch(networkStart('Getting bucket information'));
         return zenkoClient.getBucketInfo(bucketName)
             .then(info => dispatch(getBucketInfoSuccess(info)))
-            .catch(error => dispatch(handleS3Error(error)))
-            .catch(error => dispatch(handleApiError(error, 'byComponent')))
+            .catch(error => dispatch(handleAWSClientError(error)))
+            .catch(error => dispatch(handleAWSError(error, 'byComponent')))
             .finally(() => dispatch(networkEnd()));
     };
 }
@@ -101,8 +101,8 @@ export function toggleBucketVersioning(bucketName: string, isVersioning: boolean
         return zenkoClient.toggleVersioning(bucketName, isVersioning)
             .then(() => dispatch(listBuckets()))
             .then(() => dispatch(getBucketInfo(bucketName)))
-            .catch(error => dispatch(handleS3Error(error)))
-            .catch(error => dispatch(handleApiError(error, 'byModal')))
+            .catch(error => dispatch(handleAWSClientError(error)))
+            .catch(error => dispatch(handleAWSError(error, 'byModal')))
             .finally(() => dispatch(networkEnd()));
     };
 }

--- a/src/react/actions/s3object.js
+++ b/src/react/actions/s3object.js
@@ -18,7 +18,7 @@ import type {
     ToggleObjectAction,
 } from '../../types/actions';
 import type { CommonPrefix, DeleteFolder, File, HeadObjectResponse, ListObjectsType, MetadataPairs, S3DeleteMarker, S3DeleteObject, S3Object, S3Version, TagSet } from '../../types/s3';
-import { handleApiError, handleS3Error } from './error';
+import { handleAWSClientError, handleAWSError } from './error';
 import { networkEnd, networkStart } from './network';
 import { LIST_OBJECT_VERSIONS_S3_TYPE } from '../utils/s3';
 import type { Marker } from '../../types/zenko';
@@ -141,8 +141,8 @@ export function createFolder(bucketName: string, prefixWithSlash: string, folder
         dispatch(networkStart('Creating folder'));
         return zenkoClient.createFolder(bucketName, prefixWithSlash, folderName)
             .then(() => dispatch(listObjects(bucketName, prefixWithSlash)))
-            .catch(error => dispatch(handleS3Error(error)))
-            .catch(error => dispatch(handleApiError(error, 'byComponent')))
+            .catch(error => dispatch(handleAWSClientError(error)))
+            .catch(error => dispatch(handleAWSError(error, 'byComponent')))
             .finally(() => {
                 dispatch(networkEnd());
                 dispatch(closeFolderCreateModal());
@@ -168,8 +168,8 @@ function _getListObjectNoVersion(bucketName: string, prefixWithSlash: string, ma
                 }
                 return dispatch(listObjectsSuccess(list, res.CommonPrefixes, res.Prefix, res.NextContinuationToken));
             })
-            .catch(error => dispatch(handleS3Error(error)))
-            .catch(error => dispatch(handleApiError(error, 'byComponent')))
+            .catch(error => dispatch(handleAWSClientError(error)))
+            .catch(error => dispatch(handleAWSError(error, 'byComponent')))
             .finally(() => dispatch(networkEnd()));
     };
 }
@@ -222,8 +222,8 @@ function _getListObjectVersion(bucketName: string, prefixWithSlash: string, mark
                 }
                 return dispatch(listObjectVersionsSuccess(list, res.DeleteMarkers, res.CommonPrefixes, res.Prefix, res.NextKeyMarker, res.NextVersionIdMarker));
             })
-            .catch(error => dispatch(handleS3Error(error)))
-            .catch(error => dispatch(handleApiError(error, 'byComponent')))
+            .catch(error => dispatch(handleAWSClientError(error)))
+            .catch(error => dispatch(handleAWSError(error, 'byComponent')))
             .finally(() => dispatch(networkEnd()));
     };
 }
@@ -265,8 +265,8 @@ export function uploadFiles(bucketName: string, prefixWithSlash: string, files: 
         dispatch(networkStart('Uploading object(s)'));
         return zenkoClient.uploadObject(bucketName, prefixWithSlash, files)
             .then(() => dispatch(listObjects(bucketName, prefixWithSlash)))
-            .catch(error => dispatch(handleS3Error(error)))
-            .catch(error => dispatch(handleApiError(error, 'byComponent')))
+            .catch(error => dispatch(handleAWSClientError(error)))
+            .catch(error => dispatch(handleAWSError(error, 'byComponent')))
             .finally(() => dispatch(networkEnd()));
     };
 }
@@ -277,8 +277,8 @@ export function deleteFiles(bucketName: string, prefixWithSlash: string, objects
         dispatch(closeObjectDeleteModal());
         dispatch(networkStart('Deleting object(s)'));
         return zenkoClient.deleteObjects(bucketName, objects, folders)
-            .catch(error => dispatch(handleS3Error(error)))
-            .catch(error => dispatch(handleApiError(error, 'byModal')))
+            .catch(error => dispatch(handleAWSClientError(error)))
+            .catch(error => dispatch(handleAWSError(error, 'byModal')))
             .finally(() => {
                 dispatch(networkEnd());
                 // make sure to list objects even if delete fails.
@@ -296,8 +296,8 @@ export function getObjectMetadata(bucketName: string, objectKey: string, version
             zenkoClient.getObjectTagging(bucketName, objectKey, versionId),
         ])
             .then(([info, tags]) => dispatch(getObjectMetadataSuccess(bucketName, objectKey, info, tags.TagSet)))
-            .catch(error => dispatch(handleS3Error(error)))
-            .catch(error => dispatch(handleApiError(error, 'byComponent')))
+            .catch(error => dispatch(handleAWSClientError(error)))
+            .catch(error => dispatch(handleAWSError(error, 'byComponent')))
             .finally(() => dispatch(networkEnd()));
     };
 }
@@ -308,8 +308,8 @@ export function putObjectMetadata(bucketName: string, objectKey: string, systemM
         dispatch(networkStart('Getting object metadata'));
         return zenkoClient.putObjectMetadata(bucketName, objectKey, systemMetadata, userMetadata)
             .then(() => dispatch(getObjectMetadata(bucketName, objectKey)))
-            .catch(error => dispatch(handleS3Error(error)))
-            .catch(error => dispatch(handleApiError(error, 'byModal')))
+            .catch(error => dispatch(handleAWSClientError(error)))
+            .catch(error => dispatch(handleAWSError(error, 'byModal')))
             .finally(() => dispatch(networkEnd()));
     };
 }
@@ -320,8 +320,8 @@ export function putObjectTagging(bucketName: string, objectKey: string, tags: Ta
         dispatch(networkStart('Getting object tags'));
         return zenkoClient.putObjectTagging(bucketName, objectKey, tags, versionId)
             .then(() => dispatch(getObjectMetadata(bucketName, objectKey, versionId)))
-            .catch(error => dispatch(handleS3Error(error)))
-            .catch(error => dispatch(handleApiError(error, 'byModal')))
+            .catch(error => dispatch(handleAWSClientError(error)))
+            .catch(error => dispatch(handleAWSError(error, 'byModal')))
             .finally(() => dispatch(networkEnd()));
     };
 }

--- a/src/react/reducers/networkActivity.js
+++ b/src/react/reducers/networkActivity.js
@@ -21,7 +21,6 @@ export default function networkActivity(state: NetworkActivityState=initialNetwo
         return {
             ...state,
             authFailure: true,
-            failureType: action.failureType,
         };
     case 'NETWORK_AUTH_RESET':
         return {

--- a/src/react/ui-elements/FormLayout.jsx
+++ b/src/react/ui-elements/FormLayout.jsx
@@ -144,9 +144,8 @@ export const Footer = styled.div`
 
 export const FooterError = styled.div`
     flex: 1 1 auto;
-
+    height: inherit;
     margin-right: ${padding.smaller};
-    word-break: break-all;
 `;
 
 export const FooterButtons = styled.div`

--- a/src/react/ui-elements/ReauthDialog.jsx
+++ b/src/react/ui-elements/ReauthDialog.jsx
@@ -1,5 +1,5 @@
 // @flow
-import { S3_FAILURE_TYPE, loadClients, networkAuthReset } from '../actions';
+import { loadClients, networkAuthReset } from '../actions';
 import { useDispatch, useSelector } from 'react-redux';
 import type { AppState } from '../../types/state';
 import { Button } from '@scality/core-ui';
@@ -8,11 +8,9 @@ import React from 'react';
 import { push } from 'connected-react-router';
 
 const DEFAULT_MESSAGE = 'We need to log you in.';
-const DEFAULT_S3_MESSAGE = 'Make sure you are using the right S3 account.';
 
 const ReauthDialog = () => {
     const needReauth = useSelector((state: AppState) => state.networkActivity.authFailure);
-    const failureType = useSelector((state: AppState) => state.networkActivity.failureType);
     const errorMessage = useSelector((state: AppState) => state.uiErrors.errorType === 'byAuth' ? state.uiErrors.errorMsg : null);
     const pathname = useSelector((state: AppState) => state.router.location.pathname);
 
@@ -23,31 +21,8 @@ const ReauthDialog = () => {
         dispatch(loadClients()).then(() => dispatch(push(pathName)));
     };
 
-    const s3Close = () => {
-        dispatch(networkAuthReset());
-        dispatch(push('/buckets'));
-    };
-
     if (!needReauth) {
         return null;
-    }
-
-    if (failureType === S3_FAILURE_TYPE) {
-        return (
-            <Modal
-                id="reauth-s3-dialog-modal"
-                close={() => s3Close()}
-                footer={
-                    <div>
-                        <Button variant="buttonDelete" onClick={() => reauth(pathname)} size="small" text='Retry'/>
-                        <Button variant="buttonPrimary" onClick={() => s3Close()} size="small" text='Back to my buckets' />
-                    </div>
-                }
-                isOpen={true}
-                title='S3 Authentication Error'>
-                { errorMessage || DEFAULT_S3_MESSAGE }
-            </Modal>
-        );
     }
 
     return (

--- a/src/react/utils/__tests__/index.test.jsx
+++ b/src/react/utils/__tests__/index.test.jsx
@@ -39,23 +39,9 @@ describe('functions utils', () => {
             expectedErrorMessage: errorMessages[1],
         },
         {
-            it: `should return the error message: "${errorMessages[1]}" if S3 api status code is 401`,
-            error: {
-                statusCode: 401,
-            },
-            expectedErrorMessage: errorMessages[1],
-        },
-        {
             it: `should return the error message: "${errorMessages[2]}" if status code is 403`,
             error: {
                 status: 403,
-            },
-            expectedErrorMessage: errorMessages[2],
-        },
-        {
-            it: `should return the error message: "${errorMessages[2]}" if S3 api status code is 403`,
-            error: {
-                statusCode: 403,
             },
             expectedErrorMessage: errorMessages[2],
         },
@@ -67,23 +53,9 @@ describe('functions utils', () => {
             expectedErrorMessage: errorMessages[3],
         },
         {
-            it: `should return the error message: "${errorMessages[3]}" if S3 api status code is 404`,
-            error: {
-                statusCode: 404,
-            },
-            expectedErrorMessage: errorMessages[3],
-        },
-        {
             it: `should return the error message: "${errorMessages[4]}" if status code is 409`,
             error: {
                 status: 409,
-            },
-            expectedErrorMessage: errorMessages[4],
-        },
-        {
-            it: `should return the error message: "${errorMessages[4]}" if S3 api status code is 409`,
-            error: {
-                statusCode: 409,
             },
             expectedErrorMessage: errorMessages[4],
         },
@@ -95,23 +67,9 @@ describe('functions utils', () => {
             expectedErrorMessage: errorMessages[5],
         },
         {
-            it: `should return the error message: "${errorMessages[5]}" if S3 api status code is 500`,
-            error: {
-                statusCode: 500,
-            },
-            expectedErrorMessage: errorMessages[5],
-        },
-        {
             it: `should return the error message: "${errorMessages[5]}" if status code is 503`,
             error: {
                 status: 503,
-            },
-            expectedErrorMessage: errorMessages[5],
-        },
-        {
-            it: `should return the error message: "${errorMessages[5]}" if S3 api status code is 503`,
-            error: {
-                statusCode: 503,
             },
             expectedErrorMessage: errorMessages[5],
         },

--- a/src/react/utils/index.js
+++ b/src/react/utils/index.js
@@ -18,23 +18,20 @@ export function errorParser(error) {
     if (error.response && error.response.body && error.response.body.message) {
         message = error.response.body.message;
     //! $FlowFixMe
+    } else if (error.status === 401) {
+        message = 'The request is missing valid authentication credentials.';
+    } else if (error.status === 403) {
+        message = 'Access to the requested item was denied.';
+    } else if (error.status === 404) {
+        message = 'The requested item does not exist.';
+    } else if (error.status === 409) {
+        message = 'An item with the same identifier already exists.';
+    } else if (error.status === 500 || error.status === 503) {
+        message = 'The server is temporarily unavailable.';
     } else if (error.message) {
         message = error.message;
-    } else if (error.status === 401 || error.statusCode === 401) {
-        message = 'The request is missing valid authentication credentials.';
-    } else if (error.status === 403 || error.statusCode === 403) {
-        message = 'Access to the requested item was denied.';
-    } else if (error.status === 404 || error.statusCode === 404) {
-        message = 'The requested item does not exist.';
-    } else if (error.status === 409 || error.statusCode === 409) {
-        message = 'An item with the same identifier already exists.';
-    } else if (error.status === 500 || error.status === 503
-        || error.statusCode === 500 || error.statusCode === 503) {
-        message = 'The server is temporarily unavailable.';
-    } else if (error.status || error.statusCode) {
-        message = `Failed with error status: ${String(error.status || error.statusCode)}`;
     } else {
-        message = 'Request failed';
+        message = `Failed with error status: ${String(error.status)}`;
     }
     return { message };
 }

--- a/src/types/actions.js
+++ b/src/types/actions.js
@@ -8,7 +8,6 @@ import type { Marker, SearchResultList, ZenkoClient } from './zenko';
 import type { APIWorkflows } from './workflow';
 import type { AppState } from './state';
 import type { AuthUser } from './auth';
-import type { FailureType } from './ui';
 import type { IamAccessKey } from './user';
 import type { ManagementClient } from './managementClient';
 import type { STSClient } from './sts';
@@ -18,10 +17,6 @@ export type GetStateFunction = () => AppState;
 
 export interface ApiError extends Error {
     status: 200 | 401 | 403 | 422 | 500 | 503;
-}
-
-export interface S3Error extends Error {
-    statusCode: 200 | 401 | 403 | 422 | 500 | 503;
 }
 
 export type PromiseAction = Promise<Action>;
@@ -281,7 +276,6 @@ export type ObjectsUIAction =
 // networkActivity actions
 export type NetworkActivityAuthFailureAction = {|
     +type: 'NETWORK_AUTH_FAILURE',
-    +failureType?: FailureType,
 |};
 
 export type NetworkActivityStartAction = {|

--- a/src/types/aws.js
+++ b/src/types/aws.js
@@ -1,0 +1,10 @@
+// @flow
+
+export type AWSError = {
+  +code: string, // a unique short code representing the error that was emitted.
+  +message: string, // a longer human readable error message
+  +retryable?: boolean, // whether the error message is retryable.
+  +statusCode?: number, // in the case of a request that reached the service, this value contains the response status code.
+  +hostname?: string, // set when a networking error occurs to easily identify the endpoint of the request.
+  +region?: string, // set when a networking error occurs to easily identify the region of the request.
+};

--- a/src/types/entities.js
+++ b/src/types/entities.js
@@ -1,5 +1,9 @@
 // @flow
 
+export type ErrorMsg = {
+    +message: string,
+};
+
 export type InstanceId = string;
 
 export type AppConfig = {

--- a/src/types/state.js
+++ b/src/types/state.js
@@ -4,9 +4,9 @@ import type { AppConfig, InstanceId, Theme } from './entities';
 import type { BucketInfo, ListObjectsType, ObjectEntity, ObjectMetadata, S3BucketList } from './s3';
 import type { BucketList, InstanceStatus, StatsSeries } from './stats';
 import type { ConfigurationOverlay, LocationName, ReplicationStreams } from './config';
-import type { ErrorViewType, FailureType } from './ui';
 import type { Marker, ZenkoClient as ZenkoClientInterface } from './zenko';
 import type { AuthUser } from './auth';
+import type { ErrorViewType } from './ui';
 import type { IamAccessKey } from './user';
 import { List } from 'immutable';
 import type { ManagementClient as ManagementClientInterface } from './managementClient';
@@ -53,7 +53,6 @@ export type InstanceStatusState = {|
 export type NetworkActivityState = {|
     +counter: number,
     +authFailure: boolean,
-    +failureType?: FailureType,
     +messages: List<string>,
 |};
 

--- a/src/types/ui.js
+++ b/src/types/ui.js
@@ -2,8 +2,6 @@
 
 export type ErrorViewType = 'byModal' | 'byComponent' | 'byAuth';
 
-export type FailureType = 's3';
-
 export type SelectOption = {|
     value: string,
     label: string,


### PR DESCRIPTION
Now that AWS IAM calls (create/list/delete access key) are being used, we should return clearer error messages.