### PR TITLE
ZENKO-3413: adjust date format for tables

### DIFF
--- a/src/react/account/details/properties/AccountKeys.jsx
+++ b/src/react/account/details/properties/AccountKeys.jsx
@@ -1,14 +1,14 @@
 // @flow
 import { Banner, Button, Tooltip } from '@scality/core-ui';
+import { HideMe, TextAligner } from '../../../ui-elements/Utility';
 import React, { useEffect, useMemo } from 'react';
 import Table, * as T from '../../../ui-elements/Table';
 import { deleteAccountAccessKey, listAccountAccessKeys, openAccountKeyCreateModal } from '../../../actions';
 import { useDispatch, useSelector } from 'react-redux';
-import { useFilters, useSortBy, useTable } from 'react-table';
+import { useFilters, useFlexLayout, useSortBy, useTable } from 'react-table';
 import type { Account } from '../../../../types/account';
 import type { AppState } from '../../../../types/state';
 import { Clipboard } from '../../../ui-elements/Clipboard';
-import { HideMe } from '../../../ui-elements/Utility';
 import { Warning } from '../../../ui-elements/Warning';
 import { formatShortDate } from '../../../utils';
 import { padding } from '@scality/core-ui/dist/style/theme';
@@ -69,7 +69,13 @@ function AccountKeys({ account }: Props) {
         {
             Header: 'Created On',
             accessor: 'created_at',
-            Cell({ value: created_at }: { value: Date }) { return formatShortDate(new Date(created_at)); },
+            headerStyle: { textAlign: 'right' },
+            Cell({ value: created_at }: { value: Date }) {
+                return <TextAligner alignment='right'>
+                    {formatShortDate(new Date(created_at))}
+                </TextAligner>;
+            },
+            width: 80,
         },
         {
             id: 'actions',
@@ -78,19 +84,17 @@ function AccountKeys({ account }: Props) {
             disableSortBy: true,
             Cell({ value: access_key }: { value: string }){
                 return (
-                    <T.Actions>
-                        <Tooltip overlay='Remove Key' placement='left'>
-                            <T.ActionButton
-                                title='Remove Key'
-                                disabled={false}
-                                icon={<i className='fas fa-trash' />}
-                                onClick={() => dispatch(deleteAccountAccessKey(account.userName, access_key))}
-                                size='small'
-                                variant="buttonDelete"
-                                text=''
-                            />
-                        </Tooltip>
-                    </T.Actions>
+                    <Tooltip overlay='Remove Key' placement='right'>
+                        <Button
+                            title='Remove Key'
+                            disabled={false}
+                            icon={<i className='fas fa-trash' />}
+                            onClick={() => dispatch(deleteAccountAccessKey(account.userName, access_key))}
+                            size='small'
+                            variant='buttonDelete'
+                            text=''
+                        />
+                    </Tooltip>
                 );
             },
         },
@@ -116,7 +120,7 @@ function AccountKeys({ account }: Props) {
         disableSortRemove: true,
         autoResetFilters: false,
         autoResetSortBy: false,
-    }, useFilters, useSortBy);
+    }, useFilters, useSortBy, useFlexLayout);
 
     return (
         <TableContainer>
@@ -140,18 +144,21 @@ function AccountKeys({ account }: Props) {
                     <T.Head>
                         { headerGroups.map((headerGroup, index) => (
                             <T.HeadRow key={ index } { ...headerGroup.getHeaderGroupProps() }>
-                                { headerGroup.headers.map(column => (
-                                    <T.HeadCell key={ column.id } { ...column.getHeaderProps(column.getSortByToggleProps({ title: '' })) }>
-                                        { column.render('Header') }
-                                        <T.Icon>
-                                            { !column.disableSortBy && (column.isSorted
-                                                ? column.isSortedDesc
-                                                    ? <i className='fas fa-sort-down'/>
-                                                    : <i className='fas fa-sort-up'/>
-                                                : <i className='fas fa-sort'/>) }
-                                        </T.Icon>
-                                    </T.HeadCell>
-                                )) }
+                                { headerGroup.headers.map(column => {
+                                    const headerProps = column.getHeaderProps(column.getSortByToggleProps({ title: '' }));
+                                    return (
+                                        <T.HeadCell key={ column.id } { ...headerProps } style={{ ...column.headerStyle, ...headerProps.style }}>
+                                            { column.render('Header') }
+                                            <T.Icon>
+                                                { !column.disableSortBy && (column.isSorted
+                                                    ? column.isSortedDesc
+                                                        ? <i className='fas fa-sort-down'/>
+                                                        : <i className='fas fa-sort-up'/>
+                                                    : <i className='fas fa-sort'/>) }
+                                            </T.Icon>
+                                        </T.HeadCell>
+                                    );
+                                }) }
                             </T.HeadRow>
                         )) }
                     </T.Head>

--- a/src/react/account/details/properties/AccountKeys.jsx
+++ b/src/react/account/details/properties/AccountKeys.jsx
@@ -10,7 +10,7 @@ import type { AppState } from '../../../../types/state';
 import { Clipboard } from '../../../ui-elements/Clipboard';
 import { HideMe } from '../../../ui-elements/Utility';
 import { Warning } from '../../../ui-elements/Warning';
-import { formatDate } from '../../../utils';
+import { formatShortDate } from '../../../utils';
 import { padding } from '@scality/core-ui/dist/style/theme';
 import styled from 'styled-components';
 
@@ -69,7 +69,7 @@ function AccountKeys({ account }: Props) {
         {
             Header: 'Created On',
             accessor: 'created_at',
-            Cell({ value: created_at }: { value: Date }) { return formatDate(new Date(created_at)); },
+            Cell({ value: created_at }: { value: Date }) { return formatShortDate(new Date(created_at)); },
         },
         {
             id: 'actions',

--- a/src/react/account/details/properties/__tests__/AccountKeys.test.jsx
+++ b/src/react/account/details/properties/__tests__/AccountKeys.test.jsx
@@ -4,7 +4,7 @@ import { HideMe } from '../../../../ui-elements/Utility';
 import React from 'react';
 import { Warning } from '../../../../ui-elements/Warning';
 import { accountAccessKeys } from '../../../../../js/mock/IAMClient';
-import { formatDate } from '../../../../utils';
+import { formatShortDate } from '../../../../utils';
 import { reduxMount } from '../../../../utils/test';
 
 const account1 = {
@@ -38,13 +38,13 @@ describe('AccountKeys', () => {
         const firstColumns = firstRow.find(T.Cell).map(column => column.text());
         expect(firstColumns.length).toEqual(3);
         expect(firstColumns[0]).toEqual(accountAccessKeys[1].AccessKeyId);
-        expect(firstColumns[1]).toEqual(formatDate(new Date(accountAccessKeys[1].CreateDate)));
+        expect(firstColumns[1]).toEqual(formatShortDate(new Date(accountAccessKeys[1].CreateDate)));
 
         const secondRow = rows.at(1);
         const secondColumns = secondRow.find(T.Cell).map(column => column.text());
         expect(secondColumns.length).toEqual(3);
         expect(secondColumns[0]).toEqual(accountAccessKeys[0].AccessKeyId);
-        expect(secondColumns[1]).toEqual(formatDate(new Date(accountAccessKeys[0].CreateDate)));
+        expect(secondColumns[1]).toEqual(formatShortDate(new Date(accountAccessKeys[0].CreateDate)));
     });
 
     it('should render notification whenever there is at least 1 Root Access Key', () => {
@@ -67,7 +67,7 @@ describe('AccountKeys', () => {
         const columns = row.find(T.Cell).map(column => column.text());
         expect(columns.length).toEqual(3);
         expect(columns[0]).toEqual(accessKey.AccessKeyId);
-        expect(columns[1]).toEqual(formatDate(new Date(accessKey.CreateDate)));
+        expect(columns[1]).toEqual(formatShortDate(new Date(accessKey.CreateDate)));
 
         // Check if there is the notification
         expect(component.find(HideMe).prop('isHidden')).toBeFalsy();

--- a/src/react/databrowser/buckets/BucketList.jsx
+++ b/src/react/databrowser/buckets/BucketList.jsx
@@ -8,6 +8,7 @@ import { useFilters, useSortBy, useTable } from 'react-table';
 import { AutoSizer } from 'react-virtualized';
 import { FixedSizeList } from 'react-window';
 import type { S3BucketList } from '../../../types/s3';
+import { TextAligner } from '../../ui-elements/Utility';
 import { formatShortDate } from '../../utils';
 import { getLocationTypeFromName } from '../../utils/storageOptions';
 import { push } from 'connected-react-router';
@@ -46,7 +47,12 @@ export default function BucketList({ selectedBucketName, buckets, locations }: P
         {
             Header: 'Created on',
             accessor: 'CreationDate',
-            Cell: ({ value }) => { return formatShortDate(new Date(value));},
+            headerStyle: { textAlign: 'right', paddingRight: '32px' },
+            Cell({ value }: { value: string }) { return (
+                <TextAligner alignment='right' style={{ paddingRight: '16px' }}>
+                    {formatShortDate(new Date(value))}
+                </TextAligner>
+            );},
         },
     ], [locations, handleCellClicked]);
 
@@ -75,18 +81,21 @@ export default function BucketList({ selectedBucketName, buckets, locations }: P
                 <T.Head>
                     {headerGroups.map(headerGroup => (
                         <T.HeadRow key={headerGroup.id} {...headerGroup.getHeaderGroupProps()}>
-                            {headerGroup.headers.map(column => (
-                                <T.HeadCell key={column.id} {...column.getHeaderProps(column.getSortByToggleProps({ title: '' }))} >
-                                    {column.render('Header')}
-                                    <T.Icon>
-                                        {!column.disableSortBy && (column.isSorted
-                                            ? column.isSortedDesc
-                                                ? <i className='fas fa-sort-down' />
-                                                : <i className='fas fa-sort-up' />
-                                            : <i className='fas fa-sort' />)}
-                                    </T.Icon>
-                                </T.HeadCell>
-                            ))}
+                            {headerGroup.headers.map(column => {
+                                const headerProps = column.getHeaderProps(column.getSortByToggleProps({ title: '' }));
+                                return (
+                                    <T.HeadCell key={column.id} {...headerProps} style={{ ...column.headerStyle, ...headerProps.style }}>
+                                        {column.render('Header')}
+                                        <T.Icon>
+                                            {!column.disableSortBy && (column.isSorted
+                                                ? column.isSortedDesc
+                                                    ? <i className='fas fa-sort-down' />
+                                                    : <i className='fas fa-sort-up' />
+                                                : <i className='fas fa-sort' />)}
+                                        </T.Icon>
+                                    </T.HeadCell>
+                                );
+                            })}
                         </T.HeadRow>
                     ))}
                 </T.Head>

--- a/src/react/databrowser/buckets/BucketList.jsx
+++ b/src/react/databrowser/buckets/BucketList.jsx
@@ -8,7 +8,7 @@ import { useFilters, useSortBy, useTable } from 'react-table';
 import { AutoSizer } from 'react-virtualized';
 import { FixedSizeList } from 'react-window';
 import type { S3BucketList } from '../../../types/s3';
-import { formatDate } from '../../utils';
+import { formatShortDate } from '../../utils';
 import { getLocationTypeFromName } from '../../utils/storageOptions';
 import { push } from 'connected-react-router';
 import { useDispatch } from 'react-redux';
@@ -46,7 +46,7 @@ export default function BucketList({ selectedBucketName, buckets, locations }: P
         {
             Header: 'Created on',
             accessor: 'CreationDate',
-            Cell: ({ value }) => { return formatDate(new Date(value));},
+            Cell: ({ value }) => { return formatShortDate(new Date(value));},
         },
     ], [locations, handleCellClicked]);
 

--- a/src/react/databrowser/buckets/__tests__/BucketList.test.jsx
+++ b/src/react/databrowser/buckets/__tests__/BucketList.test.jsx
@@ -3,15 +3,16 @@ import { List } from 'immutable';
 import { MemoryRouter } from 'react-router-dom';
 import React from 'react';
 import { Row } from '../../../ui-elements/Table';
+import { formatShortDate } from '../../../utils';
 import { reduxMount } from '../../../utils/test';
 
 describe('BucketList', () => {
     const buckets = List([{
-        CreationDate: 'Wed Oct 07 2020 16:35:57',
+        CreationDate: '2020-04-19T16:15:29+00:00',
         LocationConstraint: 'us-east-1',
         Name: 'bucket1',
     }, {
-        CreationDate: 'Wed Oct 07 2020 16:35:57',
+        CreationDate: '2020-04-19T16:15:29+00:00',
         LocationConstraint: 'us-east-1',
         Name: 'bucket2',
     }]);
@@ -37,7 +38,7 @@ describe('BucketList', () => {
         const firstBucketCellDate = firstRow.find('Cell').at(2);
         expect(firstBucketCellLink.text()).toContain('bucket1');
         expect(firstBucketCellLocation.text()).toBe('us-east-1 / Local Filesystem');
-        expect(firstBucketCellDate.text()).toBe('Wed Oct 07 2020 16:35:57');
+        expect(firstBucketCellDate.text()).toBe(formatShortDate(new Date(buckets.get(0).CreationDate)));
 
         const secondRow = rows.at(1);
         const secondBucketCellLink = secondRow.find('Cell').at(0);
@@ -45,7 +46,7 @@ describe('BucketList', () => {
         const secondBucketCellDate = component.find('Cell').at(2);
         expect(secondBucketCellLink.text()).toContain('bucket2');
         expect(secondBucketCellLocation.text()).toBe('us-east-1 / Local Filesystem');
-        expect(secondBucketCellDate.text()).toBe('Wed Oct 07 2020 16:35:57');
+        expect(secondBucketCellDate.text()).toBe(formatShortDate(new Date(buckets.get(1).CreationDate)));
     });
 
     it('should select row if the bucket name specified in the parameter matches one of the bucket names listed', () => {

--- a/src/react/ui-elements/Table.jsx
+++ b/src/react/ui-elements/Table.jsx
@@ -41,6 +41,7 @@ export const Head = styled.thead`
 `;
 
 export const HeadRow = styled.tr`
+    align-items: center;
     width:100%;
     cursor: pointer;
 


### PR DESCRIPTION
Date format updated from 
![image](https://user-images.githubusercontent.com/44285344/117266403-857dcf00-ae55-11eb-912b-5dd1af5ae4e7.png)
to
![image](https://user-images.githubusercontent.com/44285344/117266445-8dd60a00-ae55-11eb-9099-8e9a8d66db5d.png)

(only for tables)

Tables updated:
* AccountKeys / Created On
* Bucket Browsing / Created On
