### PR TITLE
Wait for location to be propagated.

### DIFF
--- a/src/react/actions/__tests__/utils/dispatchActionsList.js
+++ b/src/react/actions/__tests__/utils/dispatchActionsList.js
@@ -9,6 +9,8 @@ import {
     APP_CONFIG,
     BUCKET_INFO_RESPONSE,
     INSTANCE_ID,
+    INSTANCE_STATUS_RUNNINGv1,
+    INSTANCE_STATUS_RUNNINGv2,
     LATEST_OVERLAY,
     LOGOUT_MOCK,
     THEME,
@@ -30,6 +32,7 @@ import type {
     GetBucketInfoSuccessAction,
     GetObjectMetadataSuccessAction,
     HandleErrorAction,
+    InstanceStatusAction,
     ListAccountAccessKeySuccessAction,
     ListBucketsSuccessAction,
     ListObjectsSuccessAction,
@@ -309,3 +312,10 @@ export const SEARCH_WORKFLOWS_SUCCESS_ACTION = (): SearchWorkflowsSuccessAction 
         workflows: WORKFLOWS,
     };
 };
+
+// instance status actions
+export const INSTANCE_STATUS_ACTION_RUNNINGv1: InstanceStatusAction =
+    { type: 'INSTANCE_STATUS', status: INSTANCE_STATUS_RUNNINGv1 };
+
+export const INSTANCE_STATUS_ACTION_RUNNINGv2: InstanceStatusAction =
+    { type: 'INSTANCE_STATUS', status: INSTANCE_STATUS_RUNNINGv2 };

--- a/src/react/actions/configuration.js
+++ b/src/react/actions/configuration.js
@@ -3,6 +3,8 @@
 import type { ConfigurationVersionAction, ThunkStatePromisedAction } from '../../types/actions';
 import type { ConfigurationOverlay } from '../../types/config';
 import { getClients } from '../utils/actions';
+import { loadInstanceLatestStatus } from './stats';
+import { until } from 'async';
 
 export function newConfiguration(configuration: ConfigurationOverlay): ConfigurationVersionAction {
     return {
@@ -23,4 +25,15 @@ export function updateConfiguration(): ThunkStatePromisedAction {
             });
         //! errors will be handled by caller
     };
+}
+
+export function waitForRunningConfigurationVersionUpdate(): ThunkStatePromisedAction {
+    return (dispatch, getState) => until(
+        cb => {
+            const { configuration, instanceStatus } = getState();
+            const runningVersion = instanceStatus.latest.state.runningConfigurationVersion;
+            setTimeout(cb, 500, null, runningVersion >= configuration.latest.version);
+        },
+        next => dispatch(loadInstanceLatestStatus()).then(next),
+    );
 }

--- a/src/types/config.js
+++ b/src/types/config.js
@@ -55,6 +55,7 @@ export type Endpoint = {|
 export type ReplicationStreams = Array<Replication>;
 
 export type ConfigurationOverlay = {|
+    +version: number,
     +users: Array<Account>,
     +locations: Locations,
     +endpoints: Array<Endpoint>,

--- a/src/types/stats.js
+++ b/src/types/stats.js
@@ -129,6 +129,7 @@ export type InstanceStateSnapshot = {|
         +secureChannel: boolean,
     },
     +latestConfigurationOverlay: ConfigurationOverlay,
+    +runningConfigurationVersion: number,
     +lastSeen: string,
     +serverVersion: string,
 |};


### PR DESCRIPTION
Fixes the case when creating a location and then trying to use it immediately to create a bucket or a replication policy would fail.

Most of the changes are actually to add the ability to test full-store redux, as we need to test for actions resulting from a change in the global app state.