### PR TITLE
ZENKO-3628: account details in the same row than delete account button

### DIFF
--- a/src/react/account/details/properties/AccountInfo.jsx
+++ b/src/react/account/details/properties/AccountInfo.jsx
@@ -1,22 +1,30 @@
 // @noflow
+import React from 'react';
+import { useDispatch, useSelector } from 'react-redux';
+import styled from 'styled-components';
+import { Button } from '@scality/core-ui/dist/next';
+import { spacing } from '@scality/core-ui/dist/style/theme';
 
 import Table, * as T from '../../../ui-elements/TableKeyValue';
 import { closeAccountDeleteDialog, deleteAccount, openAccountDeleteDialog } from '../../../actions';
-import { useDispatch, useSelector } from 'react-redux';
 import type { Account } from '../../../../types/account';
 import type { AppState } from '../../../../types/state';
-import { Button } from '@scality/core-ui/dist/next';
 import { ButtonContainer } from '../../../ui-elements/Container';
 import { Clipboard } from '../../../ui-elements/Clipboard';
 import DeleteConfirmation from '../../../ui-elements/DeleteConfirmation';
-import React from 'react';
 import SecretKeyModal from './SecretKeyModal';
 import { formatDate } from '../../../utils';
-import styled from 'styled-components';
 
 const TableContainer = styled.div`
     display: flex;
     flex-direction: column;
+`;
+
+const TitleRow = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: ${spacing.sp16};
 `;
 
 type Props = {
@@ -47,10 +55,12 @@ function AccountInfo({ account }: Props) {
         <TableContainer>
             <DeleteConfirmation show={showDelete} cancel={handleDeleteCancel} approve={handleDeleteApprove} titleText={`Are you sure you want to delete account: ${account.userName} ?`}/>
             <SecretKeyModal account={account} />
-            <ButtonContainer>
-                <Button id='delete-account-btn' icon={<i className="fas fa-trash" />} onClick={handleDeleteClick} variant="danger" label='Delete Account' />
-            </ButtonContainer>
-            <h3>Account details</h3>
+            <TitleRow>
+                <h3>Account details</h3>
+                <ButtonContainer>
+                    <Button id='delete-account-btn' icon={<i className="fas fa-trash" />} onClick={handleDeleteClick} variant="danger" label='Delete Account' />
+                </ButtonContainer>
+            </TitleRow>
             <Table id='account-details-table'>
                 <T.Body>
                     <T.Row>

--- a/src/react/account/details/properties/AccountInfo.jsx
+++ b/src/react/account/details/properties/AccountInfo.jsx
@@ -1,30 +1,24 @@
 // @noflow
-import React from 'react';
-import { useDispatch, useSelector } from 'react-redux';
-import styled from 'styled-components';
-import { Button } from '@scality/core-ui/dist/next';
-import { spacing } from '@scality/core-ui/dist/style/theme';
-
 import Table, * as T from '../../../ui-elements/TableKeyValue';
 import { closeAccountDeleteDialog, deleteAccount, openAccountDeleteDialog } from '../../../actions';
+import { useDispatch, useSelector } from 'react-redux';
 import type { Account } from '../../../../types/account';
 import type { AppState } from '../../../../types/state';
+import { Button } from '@scality/core-ui/dist/next';
 import { ButtonContainer } from '../../../ui-elements/Container';
 import { Clipboard } from '../../../ui-elements/Clipboard';
 import DeleteConfirmation from '../../../ui-elements/DeleteConfirmation';
+import React from 'react';
 import SecretKeyModal from './SecretKeyModal';
+import { TitleRow } from '../../../ui-elements/TableKeyValue';
 import { formatDate } from '../../../utils';
+import styled from 'styled-components';
+
+
 
 const TableContainer = styled.div`
     display: flex;
     flex-direction: column;
-`;
-
-const TitleRow = styled.div`
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    margin-bottom: ${spacing.sp16};
 `;
 
 type Props = {

--- a/src/react/account/details/properties/AccountKeys.jsx
+++ b/src/react/account/details/properties/AccountKeys.jsx
@@ -17,7 +17,6 @@ import styled from 'styled-components';
 
 const TableContainer = styled.div`
     display: block;
-    width: fit-content;
     margin-top: ${spacing.sp20};
 `;
 

--- a/src/react/ui-elements/TableKeyValue.jsx
+++ b/src/react/ui-elements/TableKeyValue.jsx
@@ -64,4 +64,11 @@ const Table = styled.table`
     width: 100%;
 `;
 
+export const TitleRow = styled.div`
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: ${spacing.sp16};
+`;
+
 export default Table;


### PR DESCRIPTION
1)
![image](https://user-images.githubusercontent.com/22881801/136416129-960da032-2441-4f71-9a2e-69e2ca735d4d.png)
Becomes:
![image](https://user-images.githubusercontent.com/22881801/136416291-1b01776f-fd82-480d-8820-04ebe0e1171a.png)

2)
By removing ```width: fit-content;``` the TableContainer takes 100% of the width and the two buttons (Delete Account and Create Access Key) line up  :
![image](https://user-images.githubusercontent.com/22881801/136416868-e6e00301-f000-46b1-887e-49b98a96c60b.png)

Jira ticket: https://scality.atlassian.net/browse/ZENKO-3628

