### PR TITLE
ZENKO-3627: making the tooltips fit better the contents they display

### DIFF
--- a/src/react/account/AccountCreate.jsx
+++ b/src/react/account/AccountCreate.jsx
@@ -60,7 +60,7 @@ function AccountCreate() {
         <F.Form autoComplete='off' ref={formRef}>
             <F.Title> Create New Account </F.Title>
             <F.Fieldset>
-                <F.Label tooltipMessages={['Must be unique']}>
+                <F.Label tooltipMessages={['Must be unique']} tooltipWidth="6rem">
                     Name
                 </F.Label>
                 <F.Input
@@ -73,7 +73,10 @@ function AccountCreate() {
                 <F.ErrorInput id='error-name' hasError={errors.name}> {errors.name?.message} </F.ErrorInput>
             </F.Fieldset>
             <F.Fieldset>
-                <F.Label tooltipMessages={['Must be unique', 'When a new Account is created, a unique email is attached as the Root owner of this account, for initial authentication purpose']}>
+                <F.Label
+                    tooltipMessages={['Must be unique', 'When a new Account is created, a unique email is attached as the Root owner of this account, for initial authentication purpose']}
+                    tooltipWidth="20rem"
+                >
                     Root Account Email
                 </F.Label>
                 <F.Input

--- a/src/react/account/details/properties/AccountKeys.jsx
+++ b/src/react/account/details/properties/AccountKeys.jsx
@@ -1,5 +1,4 @@
 // @flow
-import { Banner, Tooltip } from '@scality/core-ui';
 import { HideMe, TextAligner } from '../../../ui-elements/Utility';
 import React, { useEffect, useMemo } from 'react';
 import Table, * as T from '../../../ui-elements/Table';
@@ -8,6 +7,7 @@ import { useDispatch, useSelector } from 'react-redux';
 import { useFilters, useFlexLayout, useSortBy, useTable } from 'react-table';
 import type { Account } from '../../../../types/account';
 import type { AppState } from '../../../../types/state';
+import { Banner } from '@scality/core-ui';
 import { Button } from '@scality/core-ui/dist/next';
 import { Clipboard } from '../../../ui-elements/Clipboard';
 import { Warning } from '../../../ui-elements/Warning';

--- a/src/react/account/details/properties/AccountKeys.jsx
+++ b/src/react/account/details/properties/AccountKeys.jsx
@@ -58,9 +58,7 @@ function AccountKeys({ account }: Props) {
             accessor: 'access_key',
             Cell({ value: access_key }: { value: string }) {
                 return <span style={{ display: 'flex', justifyContent: 'flex-start' }}>
-                    <Tooltip overlay={ access_key } placement='right'>
-                        <EllipsisCell>{ access_key }</EllipsisCell>
-                    </Tooltip>
+                    <EllipsisCell>{ access_key }</EllipsisCell>
                     <div style={{ marginLeft: spacing.sp16 }}>
                         <Clipboard text={ access_key }/>
                     </div>
@@ -86,7 +84,6 @@ function AccountKeys({ account }: Props) {
             Cell({ value: access_key }: { value: string }) {
                 return (
                     <Button
-                        label='Remove Key'
                         disabled={false}
                         icon={<i className='fas fa-trash' />}
                         onClick={() => dispatch(deleteAccountAccessKey(account.userName, access_key))}

--- a/src/react/databrowser/buckets/BucketCreate.jsx
+++ b/src/react/databrowser/buckets/BucketCreate.jsx
@@ -70,7 +70,7 @@ function BucketCreate() {
         <F.Form ref={formRef}>
             <F.Title> Create a New Bucket </F.Title>
             <F.Fieldset>
-                <F.Label tooltipMessages={['Must be unique', 'Cannot be modified after creation']}>
+                <F.Label tooltipMessages={['Must be unique', 'Cannot be modified after creation']} tooltipWidth="15rem">
                     Bucket Name
                 </F.Label>
                 <F.Input
@@ -83,7 +83,7 @@ function BucketCreate() {
                 <F.ErrorInput id='error-name' hasError={errors.name}> {errors.name?.message} </F.ErrorInput>
             </F.Fieldset>
             <F.Fieldset>
-                <F.Label tooltipMessages={['Cannot be modified after creation']}>
+                <F.Label tooltipMessages={['Cannot be modified after creation']} tooltipWidth="13rem">
                     Select Storage Location
                 </F.Label>
                 <Controller

--- a/src/react/databrowser/objects/details/Properties.jsx
+++ b/src/react/databrowser/objects/details/Properties.jsx
@@ -27,7 +27,9 @@ function Properties({ objectMetadata }: Props) {
                     </T.Row>
                     <T.Row hidden={!objectMetadata.versionId}>
                         <T.Key> Version ID </T.Key>
-                        <TruncatedValue copiable> <MiddleEllipsis text={objectMetadata.versionId} trailingCharCount={7} /> </TruncatedValue>
+                        <TruncatedValue copiable>
+                            <MiddleEllipsis text={objectMetadata.versionId} trailingCharCount={7} tooltipWidth="16rem"/>
+                        </TruncatedValue>
                         <T.ExtraCell> <Clipboard text={objectMetadata.versionId}/> </T.ExtraCell>
                     </T.Row>
                     <T.Row>

--- a/src/react/ui-elements/FormLayout.jsx
+++ b/src/react/ui-elements/FormLayout.jsx
@@ -113,21 +113,30 @@ const UlOverlay = styled.ul`
 type LabelProps = {
     children: Node,
     tooltipMessages?: Array<string>,
+    tooltipWidth?: string,
 };
 
-export const Label = ({ children, tooltipMessages }: LabelProps) => (
+export const Label = ({ children, tooltipMessages, tooltipWidth }: LabelProps) => (
     <LabelContainer>
         { children }
         {
-            tooltipMessages && tooltipMessages.length > 0 && <TooltipContainer> <Tooltip
-                overlay= {
-                    <UlOverlay>
-                        { tooltipMessages.map((message, i) => <li key={i}> {message} </li>) }
-                    </UlOverlay>}
-                placement="right"
-            >
-                <IconQuestionCircle className='fas fa-question-circle'></IconQuestionCircle>
-            </Tooltip> </TooltipContainer>
+            tooltipMessages && tooltipMessages.length > 0 && (
+                <TooltipContainer>
+                    <Tooltip
+                        overlay= {
+                            tooltipMessages.length > 1 ? (
+                                <UlOverlay>
+                                    { tooltipMessages.map((message, i) => <li key={i}> {message} </li>) }
+                                </UlOverlay>
+                            ) : tooltipMessages[0]
+                        }
+                        placement="right"
+                        overlayStyle={{ width: tooltipWidth }}
+                    >
+                        <IconQuestionCircle className='fas fa-question-circle'></IconQuestionCircle>
+                    </Tooltip>
+                </TooltipContainer>
+            )
         }
     </LabelContainer>
 );

--- a/src/react/ui-elements/Hide.jsx
+++ b/src/react/ui-elements/Hide.jsx
@@ -28,7 +28,7 @@ export function HideCredential({ credentials }: { credentials: string }) {
     const [shown, setShown] = useState(false);
     return <HideContainer>
         <HideValue shown={shown}>
-            { shown ? <MiddleEllipsis text={credentials} tooltipPlacement="top"/> : '*********' }
+            { shown ? <MiddleEllipsis text={credentials} tooltipPlacement="top" tooltipWidth="21rem"/> : '*********' }
         </HideValue>
         <HideAction onClick={() => setShown(!shown)}>
             { shown ? 'Hide' : 'Show' }

--- a/src/react/ui-elements/MiddleEllipsis.jsx
+++ b/src/react/ui-elements/MiddleEllipsis.jsx
@@ -56,6 +56,7 @@ type Props = {
     ellipsisText?: string;
     tooltipPlacement?: string;
     width?: number;
+    tooltipWidth?: string;
 };
 
 const MiddleEllipsis = ({
@@ -64,6 +65,7 @@ const MiddleEllipsis = ({
     ellipsisText = '...',
     tooltipPlacement = 'bottom',
     width,
+    tooltipWidth,
 }: Props) => {
     const [node, setNode] = useState(null);
     const [isEllipsized, setIsEllipsized] = useState(true);
@@ -108,7 +110,7 @@ const MiddleEllipsis = ({
     }, []);
 
     const content = () => (
-        <Tooltip overlay={ text } placement={ tooltipPlacement }>
+        <Tooltip overlay={ text } placement={ tooltipPlacement } overlayStyle={{ width: tooltipWidth }}>
             <StyledMiddleEllipsis ref={ ref }>
                 <MiddleEllipsisText
                     calculationDone={calculationDone}


### PR DESCRIPTION
To make the size of the tooltips consistent no matter the size of the screen, I've chosen to use rem to define the width of the tooltips.

Jira ticket: https://scality.atlassian.net/browse/ZENKO-3627