### PR TITLE
ZKUI 57-Add query params in the url

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2175,6 +2175,19 @@
         "type-detect": "4.0.8"
       }
     },
+    "@testing-library/react-hooks": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-hooks/-/react-hooks-7.0.2.tgz",
+      "integrity": "sha512-dYxpz8u9m4q1TuzfcUApqi8iFfR6R0FaMbr2hjZJy1uC8z+bO/K4v8Gs9eogGKYQop7QsrBTFkv/BCF7MzD2Cg==",
+      "dev": true,
+      "requires": {
+        "@babel/runtime": "^7.12.5",
+        "@types/react": ">=16.9.0",
+        "@types/react-dom": ">=16.9.0",
+        "@types/react-test-renderer": ">=16.9.0",
+        "react-error-boundary": "^3.1.0"
+      }
+    },
     "@types/anymatch": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -2315,6 +2328,47 @@
       "version": "1.19.1",
       "resolved": "https://registry.npmjs.org/@types/prettier/-/prettier-1.19.1.tgz",
       "integrity": "sha512-5qOlnZscTn4xxM5MeGXAMOsIOIKIbh9e85zJWfBRVPlRMEVawzoPhINYbRGkBZCI8LxvBe7tJCdWiarA99OZfQ==",
+      "dev": true
+    },
+    "@types/prop-types": {
+      "version": "15.7.4",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "17.0.38",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.38.tgz",
+      "integrity": "sha512-SI92X1IA+FMnP3qM5m4QReluXzhcmovhZnLNm3pyeQlooi02qI7sLiepEYqT678uNiyc25XfCqxREFpy3W7YhQ==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-dom": {
+      "version": "17.0.11",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-17.0.11.tgz",
+      "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/react-test-renderer": {
+      "version": "17.0.1",
+      "resolved": "https://registry.npmjs.org/@types/react-test-renderer/-/react-test-renderer-17.0.1.tgz",
+      "integrity": "sha512-3Fi2O6Zzq/f3QR9dRnlnHso9bMl7weKCviFmfF6B4LS1Uat6Hkm15k0ZAQuDz+UBq6B3+g+NM6IT2nr5QgPzCw==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
       "dev": true
     },
     "@types/sinonjs__fake-timers": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1370,6 +1370,19 @@
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
       "integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
     },
+    "@floating-ui/core": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-0.3.1.tgz",
+      "integrity": "sha512-ensKY7Ub59u16qsVIFEo2hwTCqZ/r9oZZFh51ivcLGHfUwTn8l1Xzng8RJUe91H/UP8PeqeBronAGx0qmzwk2g=="
+    },
+    "@floating-ui/dom": {
+      "version": "0.1.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-0.1.10.tgz",
+      "integrity": "sha512-4kAVoogvQm2N0XE0G6APQJuCNuErjOfPW8Ux7DFxh8+AfugWflwVJ5LDlHOwrwut7z/30NUvdtHzQ3zSip4EzQ==",
+      "requires": {
+        "@floating-ui/core": "^0.3.0"
+      }
+    },
     "@fortawesome/fontawesome-common-types": {
       "version": "0.2.36",
       "resolved": "https://registry.npmjs.org/@fortawesome/fontawesome-common-types/-/fontawesome-common-types-0.2.36.tgz",
@@ -2157,8 +2170,11 @@
       }
     },
     "@scality/core-ui": {
-      "version": "github:scality/core-ui#5c6cc7581ced2ba71572828c806d7d589ccce94d",
-      "from": "github:scality/core-ui#v0.21.8"
+      "version": "github:scality/core-ui#89a79f1041709827da43caf6a4bae4e58e3d24f6",
+      "from": "github:scality/core-ui#v0.28.0",
+      "requires": {
+        "@floating-ui/dom": "^0.1.10"
+      }
     },
     "@sindresorhus/is": {
       "version": "0.7.0",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "@fortawesome/react-fontawesome": "^0.1.14",
     "@hapi/joi": "^17.1.1",
     "@hookform/resolvers": "^0.1.0",
-    "@scality/core-ui": "github:scality/core-ui.git#v0.21.8",
+    "@scality/core-ui": "github:scality/core-ui.git#v0.28.0",
     "async": "^3.2.0",
     "aws-sdk": "^2.616.0",
     "connected-react-router": "^6.7.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@babel/preset-env": "^7.8.4",
     "@babel/preset-flow": "^7.8.3",
     "@babel/preset-react": "^7.8.3",
+    "@testing-library/react-hooks": "^7.0.2",
     "@welldone-software/why-did-you-render": "^4.0.5",
     "babel-eslint": "^10.0.3",
     "babel-loader": "^8.0.6",

--- a/src/js/utils.js
+++ b/src/js/utils.js
@@ -12,3 +12,11 @@ export function chunkArray(
 
   return tempArray;
 }
+
+export function removeTrailingSlash(prefix: string): string {
+  if (prefix.slice(-1) === '/') {
+    return prefix.slice(0, -1);
+  } else {
+    return prefix;
+  }
+}

--- a/src/react/databrowser/objects/MetadataSearch.jsx
+++ b/src/react/databrowser/objects/MetadataSearch.jsx
@@ -48,8 +48,8 @@ type Props = {
   errorZenkoMsg: ?string,
 };
 const MetadataSearch = ({ isMetadataType, errorZenkoMsg }: Props) => {
-  const [inputText, setInputText] = useState('');
   const [hintsShown, setHintsShown] = useState(false);
+
   const dispatch: DispatchAPI<Action> = useDispatch();
   const query = useQuery();
   const { pathname } = useLocation();
@@ -58,6 +58,8 @@ const MetadataSearch = ({ isMetadataType, errorZenkoMsg }: Props) => {
   const suggestionsRef = useRef(null);
   const inputRef = useRef<SearchMetadataInput<> | null>(null);
   useOutsideClick(suggestionsRef, () => setHintsShown(false));
+  const searchInput = query.get('metadatasearch');
+  const [inputText, setInputText] = useState(searchInput || '');
 
   const handleChange = e => {
     setInputText(e.target.value);
@@ -99,7 +101,7 @@ const MetadataSearch = ({ isMetadataType, errorZenkoMsg }: Props) => {
 
   return (
     <SearchMetadataContainer
-      isHidden={prefixWithSlash ? 1 : 0}
+      isHidden={prefixWithSlash && !searchInput ? 1 : 0}
       onSubmit={handleSubmit}
     >
       <SearchMetadataInputAndIcon>

--- a/src/react/databrowser/objects/ObjectDetails.jsx
+++ b/src/react/databrowser/objects/ObjectDetails.jsx
@@ -1,13 +1,13 @@
 // @flow
+import React from 'react';
+import type { Node } from 'react';
 import type { AppState } from '../../../types/state';
 import { ContentSection } from '../../ui-elements/ListLayout2';
 import { CustomTabs } from '../../ui-elements/Tabs';
 import { List } from 'immutable';
 import type { ListObjectsType } from '../../../types/s3';
 import Metadata from './details/Metadata';
-import type { Node } from 'react';
 import Properties from './details/Properties';
-import React from 'react';
 import Tags from './details/Tags';
 import { Warning } from '../../ui-elements/Warning';
 import { useLocation } from 'react-router-dom';
@@ -46,8 +46,8 @@ function ObjectDetails({ toggled, listType }: Props) {
   const objectMetadata = useSelector(
     (state: AppState) => state.s3.objectMetadata,
   );
-
   const tabName = query.get('tab');
+  const queryObject = Object.fromEntries(query.entries());
 
   const details = () => {
     if (toggled.size > 1) {
@@ -71,17 +71,25 @@ function ObjectDetails({ toggled, listType }: Props) {
   return (
     <ContentSection>
       <CustomTabs>
-        <CustomTabs.Tab label="Summary" path={pathname}>
+        <CustomTabs.Tab
+          label="Summary"
+          path={pathname}
+          query={{ ...queryObject, ...{ tab: null } }}
+        >
           {details()}
         </CustomTabs.Tab>
         <CustomTabs.Tab
           label="Metadata"
           path={pathname}
-          query={{ tab: 'metadata' }}
+          query={{ ...queryObject, ...{ tab: 'metadata' } }}
         >
           {details()}
         </CustomTabs.Tab>
-        <CustomTabs.Tab label="Tags" path={pathname} query={{ tab: 'tags' }}>
+        <CustomTabs.Tab
+          label="Tags"
+          path={pathname}
+          query={{ ...queryObject, ...{ tab: 'tags' } }}
+        >
           {details()}
         </CustomTabs.Tab>
       </CustomTabs>

--- a/src/react/databrowser/objects/ObjectList.jsx
+++ b/src/react/databrowser/objects/ObjectList.jsx
@@ -9,12 +9,10 @@ import type {
 } from '../../../types/s3';
 import {
   LIST_OBJECTS_METADATA_TYPE,
-  LIST_OBJECTS_S3_TYPE,
   LIST_OBJECT_VERSIONS_S3_TYPE,
 } from '../../utils/s3';
 import { isVersioningDisabled, maybePluralize } from '../../utils';
 import {
-  listObjects,
   openFolderCreateModal,
   openObjectDeleteModal,
   openObjectUploadModal,
@@ -27,6 +25,9 @@ import ObjectListTable from './ObjectListTable';
 import React from 'react';
 import { Toggle } from '@scality/core-ui';
 import { WarningMetadata } from '../../ui-elements/Warning';
+import { push } from 'connected-react-router';
+import { useQuery } from '../../utils/hooks';
+import { useLocation } from 'react-router';
 
 type Props = {
   objects: List<ObjectEntity>,
@@ -46,6 +47,9 @@ export default function ObjectList({
   bucketInfo,
 }: Props) {
   const dispatch = useDispatch();
+  const { pathname } = useLocation();
+  const query = useQuery();
+
   const errorZenkoMsg = useSelector(
     (state: AppState) => state.zenko.error.message,
   );
@@ -82,8 +86,6 @@ export default function ObjectList({
         <MetadataSearch
           errorZenkoMsg={errorZenkoMsg}
           isMetadataType={isMetadataType}
-          bucketName={bucketName}
-          prefixWithSlash={prefixWithSlash}
         />
         <T.ButtonContainer>
           <T.ExtraButton
@@ -114,10 +116,11 @@ export default function ObjectList({
             toggle={isVersioningType}
             label="List Versions"
             onChange={() => {
-              const type = isVersioningType
-                ? LIST_OBJECTS_S3_TYPE
-                : LIST_OBJECT_VERSIONS_S3_TYPE;
-              dispatch(listObjects(bucketName, prefixWithSlash, type));
+              query.set('showversions', !isVersioningType ? 'true' : 'false');
+              if (isVersioningType) {
+                query.delete('versionId');
+              }
+              dispatch(push(`${pathname}?${query.toString()}`));
             }}
           />
         </T.ButtonContainer>

--- a/src/react/databrowser/objects/ObjectRow.jsx
+++ b/src/react/databrowser/objects/ObjectRow.jsx
@@ -2,13 +2,17 @@
 
 import * as T from '../../ui-elements/Table';
 import React, { memo } from 'react';
-import { toggleAllObjects, toggleObject } from '../../actions';
+import { toggleAllObjects } from '../../actions';
 import type { Action } from '../../../types/actions';
 import type { DispatchAPI } from 'redux';
 import type { ObjectEntity } from '../../../types/s3';
 import { areEqual } from 'react-window';
 import isDeepEqual from 'lodash.isequal';
 import memoize from 'memoize-one';
+import { useLocation } from 'react-router';
+import { useQuery } from '../../utils/hooks';
+import { push } from 'connected-react-router';
+import { removeTrailingSlash } from '../../../js/utils';
 
 type PrepareRow = RowType => void;
 
@@ -58,9 +62,23 @@ const Row = ({
   const row = rows[index];
   prepareRow(row);
 
+  const { pathname } = useLocation();
+  const query = useQuery();
+
   const handleClick = () => {
     dispatch(toggleAllObjects(false));
-    dispatch(toggleObject(row.original.key, row.original.versionId));
+    query.set('prefix', removeTrailingSlash(row.original.key));
+    if (row.original.key.slice(-1) === '/') {
+      query.set('isFolder', true);
+    } else {
+      query.delete('isFolder');
+    }
+    if (row.original.versionId) {
+      query.set('versionId', row.original.versionId);
+    } else {
+      query.delete('versionId');
+    }
+    dispatch(push(`${pathname}?${query.toString()}`));
   };
 
   return (

--- a/src/react/databrowser/objects/ObjectRow.jsx
+++ b/src/react/databrowser/objects/ObjectRow.jsx
@@ -64,6 +64,9 @@ const Row = ({
 
   const { pathname } = useLocation();
   const query = useQuery();
+  const versionId = query.get('versionId');
+  const objectKey = query.get('prefix');
+  const isListVersions = query.get('showversions') === 'true';
 
   const handleClick = () => {
     dispatch(toggleAllObjects(false));
@@ -80,10 +83,12 @@ const Row = ({
     }
     dispatch(push(`${pathname}?${query.toString()}`));
   };
-
+  const isRowSelected = isListVersions
+    ? row.original.versionId === versionId && objectKey === row.original.key
+    : objectKey === row.original.key;
   return (
     <T.Row
-      isSelected={row.original.toggled}
+      isSelected={row.original.toggled || isRowSelected}
       onClick={handleClick}
       {...row.getRowProps({ style })}
     >

--- a/src/react/databrowser/objects/ObjectUpload.jsx
+++ b/src/react/databrowser/objects/ObjectUpload.jsx
@@ -14,6 +14,7 @@ import { maybePluralize } from '../../utils';
 import { spacing } from '@scality/core-ui/dist/style/theme';
 import styled from 'styled-components';
 import { useDropzone } from 'react-dropzone';
+import { usePrefixWithSlash } from '../../utils/hooks';
 
 const DropZone = styled.div`
   flex: 1;
@@ -118,9 +119,8 @@ export const NoFile = ({ open }: NoFileProps) => (
 
 type Props = {
   bucketName: string,
-  prefixWithSlash: string,
 };
-const ObjectUpload = ({ bucketName, prefixWithSlash }: Props) => {
+const ObjectUpload = ({ bucketName }: Props) => {
   const [acceptedFiles, setAcceptedFiles] = useState([]);
   const [fileRejections, setFileRejections] = useState([]);
   const show = useSelector(
@@ -128,6 +128,7 @@ const ObjectUpload = ({ bucketName, prefixWithSlash }: Props) => {
   );
   const dispatch: DispatchAPI<Action> = useDispatch();
 
+  const prefixWithSlash = usePrefixWithSlash();
   const onDrop = (accepted, rejections) => {
     if (accepted.length > 0) {
       const filtered = accepted.filter(

--- a/src/react/databrowser/objects/Objects.jsx
+++ b/src/react/databrowser/objects/Objects.jsx
@@ -33,13 +33,24 @@ export default function Objects() {
   const listType = useSelector((state: AppState) => state.s3.listObjectsType);
   const bucketInfo = useSelector((state: AppState) => state.s3.bucketInfo);
 
-  const toggled = useMemo(() => objects.filter(o => o.toggled), [objects]);
-  const { bucketName: bucketNameParam } = useParams();
-  const prefixWithSlash = usePrefixWithSlash();
-
   const query = useQuery();
   const isShowVersions = query.get('showversions') === 'true';
   const searchInput = query.get('metadatasearch');
+  const objectKey = query.get('prefix');
+  const versionId = query.get('versionId');
+
+  const toggled = useMemo(
+    () =>
+      objects.filter(
+        o =>
+          o.toggled ||
+          (!isShowVersions && o.key === objectKey) ||
+          (isShowVersions && o.key === objectKey && o.versionId === versionId),
+      ),
+    [objects, isShowVersions, objectKey, versionId],
+  );
+  const { bucketName: bucketNameParam } = useParams();
+  const prefixWithSlash = usePrefixWithSlash();
 
   useEffect(() => {
     if (searchInput) {

--- a/src/react/databrowser/objects/__tests__/MetadataSearch.test.jsx
+++ b/src/react/databrowser/objects/__tests__/MetadataSearch.test.jsx
@@ -1,26 +1,29 @@
-import * as zenkoActions from '../../../actions/zenko';
 import { Hint, Hints, HintsTitle } from '../../../ui-elements/Input';
 import MetadataSearch, { METADATA_SEARCH_HINT_ITEMS } from '../MetadataSearch';
 import { BUCKET_NAME } from '../../../actions/__tests__/utils/testUtil';
 import React from 'react';
 import { SearchButton } from '../../../ui-elements/Table';
 import { reduxMount } from '../../../utils/test';
+import router from 'react-router';
+import * as redux from 'react-redux';
 
 describe('Metadata Search', () => {
-  const newSearchListingMock = jest.spyOn(zenkoActions, 'newSearchListing');
+  const useDispatchSpy = jest.spyOn(redux, 'useDispatch');
+  const mockDispatchFn = jest.fn();
+  useDispatchSpy.mockReturnValue(mockDispatchFn);
 
+  beforeAll(() => {
+    jest
+      .spyOn(router, 'useLocation')
+      .mockReturnValue({ pathname: `/buckets/${BUCKET_NAME}/objects` });
+  });
   afterEach(() => {
     jest.clearAllMocks();
   });
 
   it('should render MetadataSearch component', () => {
     const { component } = reduxMount(
-      <MetadataSearch
-        isMetadataType={false}
-        bucketName={BUCKET_NAME}
-        prefixWithSlash=""
-        errorZenkoMsg={null}
-      />,
+      <MetadataSearch isMetadataType={false} errorZenkoMsg={null} />,
     );
 
     expect(component.find(MetadataSearch).isEmptyRender()).toBe(false);
@@ -28,12 +31,7 @@ describe('Metadata Search', () => {
 
   it('should render search button disabled by default', () => {
     const { component } = reduxMount(
-      <MetadataSearch
-        isMetadataType={false}
-        bucketName={BUCKET_NAME}
-        prefixWithSlash=""
-        errorZenkoMsg={null}
-      />,
+      <MetadataSearch isMetadataType={false} errorZenkoMsg={null} />,
     );
 
     const button = component.find(SearchButton);
@@ -43,12 +41,7 @@ describe('Metadata Search', () => {
 
   it('should render dropdown menu correctly', () => {
     const { component } = reduxMount(
-      <MetadataSearch
-        isMetadataType={false}
-        bucketName={BUCKET_NAME}
-        prefixWithSlash=""
-        errorZenkoMsg={null}
-      />,
+      <MetadataSearch isMetadataType={false} errorZenkoMsg={null} />,
     );
 
     const input = component.find('input');
@@ -75,12 +68,7 @@ describe('Metadata Search', () => {
 
   it('should render the right item and the right text in the input bar; button should also be clickable and call newSearchListing function', () => {
     const { component } = reduxMount(
-      <MetadataSearch
-        isMetadataType={false}
-        bucketName={BUCKET_NAME}
-        prefixWithSlash=""
-        errorZenkoMsg={null}
-      />,
+      <MetadataSearch isMetadataType={false} errorZenkoMsg={null} />,
     );
 
     // open dropdown menu
@@ -106,9 +94,17 @@ describe('Metadata Search', () => {
     expect(button).toHaveLength(1);
     expect(button.prop('disabled')).toBe(false);
 
-    // check if newSearchListingMock is called when submitting form
-    expect(newSearchListingMock).toHaveBeenCalledTimes(0);
+    // check the dispatch action is with the correct URL
     button.simulate('submit');
-    expect(newSearchListingMock).toHaveBeenCalledTimes(1);
+    const expectedAction = {
+      payload: {
+        args: [
+          `/buckets/${BUCKET_NAME}/objects?metadatasearch=key+like+%2Fpdf%24%2F`,
+        ],
+        method: 'push',
+      },
+      type: '@@router/CALL_HISTORY_METHOD',
+    };
+    expect(mockDispatchFn).toHaveBeenCalledWith(expectedAction);
   });
 });

--- a/src/react/databrowser/objects/__tests__/ObjectList.test.jsx
+++ b/src/react/databrowser/objects/__tests__/ObjectList.test.jsx
@@ -13,8 +13,15 @@ import { BUCKET_NAME } from '../../../actions/__tests__/utils/testUtil';
 import { List } from 'immutable';
 import ObjectList from '../ObjectList';
 import React from 'react';
+import router from 'react-router';
 
 describe('ObjectList', () => {
+  beforeAll(() => {
+    jest
+      .spyOn(router, 'useLocation')
+      .mockReturnValue({ pathname: '/buckets/test/objects' });
+  });
+
   afterEach(() => {
     jest.clearAllMocks();
   });

--- a/src/react/databrowser/objects/__tests__/ObjectUpload.test.jsx
+++ b/src/react/databrowser/objects/__tests__/ObjectUpload.test.jsx
@@ -4,8 +4,14 @@ import { BUCKET_NAME } from '../../../actions/__tests__/utils/testUtil';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { reduxMount } from '../../../utils/test';
+import router from 'react-router';
 
 describe('ObjectUpload', () => {
+  beforeAll(() => {
+    jest.spyOn(router, 'useLocation').mockReturnValue({
+      pathname: '/buckets/test/objects',
+    });
+  });
   const closeObjectUploadModalMock = jest.spyOn(
     s3object,
     'closeObjectUploadModal',
@@ -18,7 +24,7 @@ describe('ObjectUpload', () => {
 
   it('should render ObjectUpload component', () => {
     const { component } = reduxMount(
-      <ObjectUpload bucketName={BUCKET_NAME} prefixWithSlash="" />,
+      <ObjectUpload bucketName={BUCKET_NAME} />,
       {
         uiObjects: {
           showObjectUpload: true,
@@ -31,7 +37,7 @@ describe('ObjectUpload', () => {
 
   it('should render an empty ObjectUpload component if showFolderCreate equals to false', () => {
     const { component } = reduxMount(
-      <ObjectUpload bucketName={BUCKET_NAME} prefixWithSlash="" />,
+      <ObjectUpload bucketName={BUCKET_NAME} />,
       {
         uiObjects: {
           showObjectUpload: false,
@@ -49,7 +55,7 @@ describe('ObjectUpload', () => {
     );
 
     const { component } = reduxMount(
-      <ObjectUpload bucketName={BUCKET_NAME} prefixWithSlash="" />,
+      <ObjectUpload bucketName={BUCKET_NAME} />,
       {
         uiObjects: {
           showObjectUpload: true,
@@ -69,7 +75,7 @@ describe('ObjectUpload', () => {
     const uploadFilesMock = jest.spyOn(s3object, 'uploadFiles');
 
     const { component } = reduxMount(
-      <ObjectUpload bucketName={BUCKET_NAME} prefixWithSlash="" />,
+      <ObjectUpload bucketName={BUCKET_NAME} />,
       {
         uiObjects: {
           showObjectUpload: true,
@@ -86,7 +92,7 @@ describe('ObjectUpload', () => {
 
   it('should render NoFile component', () => {
     const { component } = reduxMount(
-      <ObjectUpload bucketName={BUCKET_NAME} prefixWithSlash="" />,
+      <ObjectUpload bucketName={BUCKET_NAME} />,
       {
         uiObjects: {
           showObjectUpload: true,
@@ -108,7 +114,7 @@ describe('ObjectUpload', () => {
   tests.forEach((t, index) => {
     it(t, async () => {
       const { component } = reduxMount(
-        <ObjectUpload bucketName={BUCKET_NAME} prefixWithSlash="" />,
+        <ObjectUpload bucketName={BUCKET_NAME} />,
         {
           uiObjects: {
             showObjectUpload: true,

--- a/src/react/databrowser/objects/details/Properties.jsx
+++ b/src/react/databrowser/objects/details/Properties.jsx
@@ -36,7 +36,7 @@ function Properties({ objectMetadata }: Props) {
   const prefixWithSlash = usePrefixWithSlash();
   const isLegalHoldEnabled = objectMetadata.isLegalHoldEnabled;
   const query = useQuery();
-
+  const metadataSearch = query.get('metadatasearch');
   // In order to keep object selection between toggling show versions, add `versionId` in the query params
   useEffect(() => {
     if (objectMetadata.versionId && objectMetadata.versionId !== 'null') {
@@ -136,6 +136,7 @@ function Properties({ objectMetadata }: Props) {
                               objectMetadata.versionId,
                               !isLegalHoldEnabled,
                               prefixWithSlash,
+                              metadataSearch,
                             ),
                           )
                         }

--- a/src/react/databrowser/objects/details/Properties.jsx
+++ b/src/react/databrowser/objects/details/Properties.jsx
@@ -39,8 +39,10 @@ function Properties({ objectMetadata }: Props) {
 
   // In order to keep object selection between toggling show versions, add `versionId` in the query params
   useEffect(() => {
-    query.set('versionId', objectMetadata.versionId);
-    dispatch(push(`${pathname}?${query.toString()}`));
+    if (objectMetadata.versionId && objectMetadata.versionId !== 'null') {
+      query.set('versionId', objectMetadata.versionId);
+      dispatch(push(`${pathname}?${query.toString()}`));
+    }
   }, [objectMetadata.versionId]);
 
   return (

--- a/src/react/databrowser/objects/details/Properties.jsx
+++ b/src/react/databrowser/objects/details/Properties.jsx
@@ -4,14 +4,16 @@ import { Clipboard } from '../../../ui-elements/Clipboard';
 import MiddleEllipsis from '../../../ui-elements/MiddleEllipsis';
 import type { ObjectMetadata } from '../../../../types/s3';
 import { PrettyBytes, Toggle } from '@scality/core-ui';
-import React from 'react';
+import React, { useEffect } from 'react';
 import { formatShortDate } from '../../../utils';
 import styled from 'styled-components';
 import { useDispatch, useSelector } from 'react-redux';
 import { putObjectLegalHold } from '../../../actions/s3object';
-import { usePrefixWithSlash } from '../../../utils/hooks';
+import { usePrefixWithSlash, useQuery } from '../../../utils/hooks';
 import { spacing } from '@scality/core-ui/dist/style/theme';
 import { AppState } from '../../../../types/state';
+import { push } from 'connected-react-router';
+import { useLocation } from 'react-router';
 type Props = {
   objectMetadata: ObjectMetadata,
 };
@@ -26,11 +28,20 @@ const Icon = styled.i`
 
 function Properties({ objectMetadata }: Props) {
   const dispatch = useDispatch();
+  const { pathname } = useLocation();
+
   const loading = useSelector(
     (state: AppState) => state.networkActivity.counter > 0,
   );
   const prefixWithSlash = usePrefixWithSlash();
   const isLegalHoldEnabled = objectMetadata.isLegalHoldEnabled;
+  const query = useQuery();
+
+  // In order to keep object selection between toggling show versions, add `versionId` in the query params
+  useEffect(() => {
+    query.set('versionId', objectMetadata.versionId);
+    dispatch(push(`${pathname}?${query.toString()}`));
+  }, [objectMetadata.versionId]);
 
   return (
     <div>

--- a/src/react/databrowser/objects/details/__tests__/Properties.test.jsx
+++ b/src/react/databrowser/objects/details/__tests__/Properties.test.jsx
@@ -7,8 +7,15 @@ import Properties from '../Properties';
 import router from 'react-router';
 
 describe('Properties', () => {
+  beforeAll(() => {
+    jest.spyOn(router, 'useLocation').mockReturnValue({
+      pathname: `/buckets/test/objects?prefix=${OBJECT_METADATA.objectKey}`,
+    });
+  });
+
   it('Properties should render', () => {
     jest.spyOn(router, 'useParams').mockReturnValue({ '0': undefined });
+
     const { component } = reduxMount(
       <Properties objectMetadata={OBJECT_METADATA} />,
     );

--- a/src/react/ui-elements/MiddleEllipsis.jsx
+++ b/src/react/ui-elements/MiddleEllipsis.jsx
@@ -29,7 +29,7 @@ export const ellipseNode = (
     const childWidth = childNode.offsetWidth;
     const containerWidth = parentNode.offsetWidth;
 
-    if (childWidth > containerWidth) {
+    if (childWidth > containerWidth && originalText) {
       const txtContent = originalText;
       const avgLetterSize = childWidth / txtContent.length;
       const txtWidthEllipsisInPX = ellipsisText.length * avgLetterSize;

--- a/src/react/utils/__tests__/hooks.test.jsx
+++ b/src/react/utils/__tests__/hooks.test.jsx
@@ -1,8 +1,10 @@
 import * as hooks from '../hooks';
 import React, { useRef } from 'react';
-import { useHeight, useOutsideClick } from '../hooks';
+import { useHeight, useOutsideClick, usePrefixWithSlash } from '../hooks';
 import { act } from 'react-dom/test-utils';
 import { mount } from 'enzyme';
+import router from 'react-router';
+import { renderHook } from '@testing-library/react-hooks';
 
 const originalOffsetHeight = Object.getOwnPropertyDescriptor(
   HTMLElement.prototype,
@@ -94,5 +96,46 @@ describe('hooks', () => {
     component.find('button').simulate('click');
 
     expect(useOutsideClickMock).toHaveBeenCalled();
+  });
+});
+
+describe('usePrefixWithSlash', () => {
+  test('should return empty string in root path of the bucket', () => {
+    jest
+      .spyOn(router, 'useLocation')
+      .mockReturnValue({ pathname: '/buckets/test/objects' });
+
+    const { result } = renderHook(() => usePrefixWithSlash());
+    expect(result.current).toBe('');
+  });
+
+  test('should return empty string when an object is select in the root of bucket', () => {
+    jest.spyOn(router, 'useLocation').mockReturnValue({
+      pathname: '/buckets/test/objects',
+      search: 'prefix=object1',
+    });
+
+    const { result } = renderHook(() => usePrefixWithSlash());
+    expect(result.current).toBe('');
+  });
+
+  test('should return foldername with trailing slash when inside a folder', () => {
+    jest.spyOn(router, 'useLocation').mockReturnValue({
+      pathname: '/buckets/test/objects',
+      search: 'prefix=folder/',
+    });
+
+    const { result } = renderHook(() => usePrefixWithSlash());
+    expect(result.current).toBe('folder/');
+  });
+
+  test('should return foldername with trailing slash when inside a folder and select an object', () => {
+    jest.spyOn(router, 'useLocation').mockReturnValue({
+      pathname: '/buckets/test/objects',
+      search: 'prefix=folder/object',
+    });
+
+    const { result } = renderHook(() => usePrefixWithSlash());
+    expect(result.current).toBe('folder/');
   });
 });

--- a/src/react/utils/hooks.js
+++ b/src/react/utils/hooks.js
@@ -1,6 +1,5 @@
 import { useEffect, useState } from 'react';
 import { useLocation } from 'react-router-dom';
-import { useParams } from 'react-router';
 import { addTrailingSlash } from '.';
 
 export const useHeight = myRef => {
@@ -46,6 +45,21 @@ export const useQuery = () => {
 };
 
 export const usePrefixWithSlash = () => {
-  const { '0': prefixParam } = useParams();
-  return addTrailingSlash(prefixParam);
+  const query = useQuery();
+  const prefix = query.get('prefix');
+
+  if (!prefix) {
+    return '';
+  }
+  // If the prefix includes both folder and object, we have to remove the last part of the path which is the object key
+  if (prefix && prefix.slice(-1) !== '/') {
+    const prefixArr = prefix.split('/');
+    prefixArr.pop();
+    if (!prefixArr.length) {
+      return '';
+    }
+    return addTrailingSlash(prefixArr.join('/'));
+  } else {
+    return prefix;
+  }
 };


### PR DESCRIPTION
Add the following props in the query params:
- showversions
- prefix
- versionId
- metadatasearch

With this PR, we centralize the  **listObject** action only in one place.

Note that this PR will change the behaviors:
- We will keep the current object selection when toggling the list versions.


Note that:
**We bumb the core-ui version with v0.28.0**