### PR TITLE
Zk UI 82 button to delete workflow closes itself instantly

### DIFF
--- a/src/react/workflow/details/Configuration.jsx
+++ b/src/react/workflow/details/Configuration.jsx
@@ -85,6 +85,7 @@ function Configuration({
               label="Delete Workflow"
               variant="danger"
               onClick={handleOpenDeleteModal}
+              type="button"
             />
           </T.Header>
           <Replication


### PR DESCRIPTION
fix bug when clicking delete workflow.

since the button type was not specified, clicking on the button would validate the edit form workflow which would reload the page.