### PR TITLE
ZKUI-86 : add error message on bucket creation

### DIFF
--- a/src/react/databrowser/buckets/BucketCreate.jsx
+++ b/src/react/databrowser/buckets/BucketCreate.jsx
@@ -25,11 +25,15 @@ import ObjectLockRetentionSettings, {
 } from './ObjectLockRetentionSettings';
 import { XDM_FEATURE } from '../../../js/config';
 
+export const bucketErrorMessage =
+  'Bucket names can include only lowercase letters, numbers, dots (.), and hyphens (-)';
+
 const schema = Joi.object({
   name: Joi.string()
     .label('Name')
     .required()
     .min(3)
+    .pattern(/^[a-z0-9.-]+$/)
     .max(63),
   locationName: Joi.string().required(),
   isVersioning: Joi.boolean(),
@@ -174,8 +178,9 @@ function BucketCreate() {
                 tooltipMessages={[
                   'Must be unique',
                   'Cannot be modified after creation',
+                  bucketErrorMessage,
                 ]}
-                tooltipWidth="15rem"
+                tooltipWidth="20rem"
               >
                 Bucket Name*
               </F.Label>
@@ -190,7 +195,9 @@ function BucketCreate() {
               />
               <F.ErrorInput id="error-name" hasError={errors.name}>
                 {' '}
-                {errors.name?.message}{' '}
+                {errors.name?.type === 'string.pattern.base'
+                  ? bucketErrorMessage
+                  : errors.name?.message}{' '}
               </F.ErrorInput>
             </F.Fieldset>
             <F.Fieldset>
@@ -227,44 +234,46 @@ function BucketCreate() {
                 }}
               />
             </F.Fieldset>
-            {features.includes(XDM_FEATURE) && <F.Fieldset direction={'row'}>
-              <F.Label
-                tooltipMessages={[
-                  'Enabling Async Metadata updates automatically activates Versioning for the bucket, and you won’t be able to suspend Versioning.',
-                ]}
-                tooltipWidth="28rem"
-              >
-                Async Metadata updates
-              </F.Label>
-              <Controller
-                control={control}
-                id="isAsyncNotification"
-                name="isAsyncNotification"
-                defaultValue={false}
-                render={({ onChange, value: isAsyncNotification }) => {
-                  return (
-                    <>
-                      <Toggle
-                        disabled={!isAsyncNotificationReady}
-                        onChange={e => {
-                          onChange(e.target.checked);
-                          matchVersioning(e.target.checked);
-                        }}
-                        label={isAsyncNotification ? 'Enabled' : 'Disabled'}
-                        toggle={isAsyncNotification}
-                        placeholder="isAsyncNotification"
-                      />
-                      {watchLocationName &&
-                        isAsyncNotificationReady &&
-                        isAsyncNotification && <HelpAsyncNotification />}
-                    </>
-                  );
-                }}
-              />
-              {watchLocationName && !isAsyncNotificationReady && (
-                <HelpNonAsyncLocation />
-              )}
-            </F.Fieldset>}
+            {features.includes(XDM_FEATURE) && (
+              <F.Fieldset direction={'row'}>
+                <F.Label
+                  tooltipMessages={[
+                    'Enabling Async Metadata updates automatically activates Versioning for the bucket, and you won’t be able to suspend Versioning.',
+                  ]}
+                  tooltipWidth="28rem"
+                >
+                  Async Metadata updates
+                </F.Label>
+                <Controller
+                  control={control}
+                  id="isAsyncNotification"
+                  name="isAsyncNotification"
+                  defaultValue={false}
+                  render={({ onChange, value: isAsyncNotification }) => {
+                    return (
+                      <>
+                        <Toggle
+                          disabled={!isAsyncNotificationReady}
+                          onChange={e => {
+                            onChange(e.target.checked);
+                            matchVersioning(e.target.checked);
+                          }}
+                          label={isAsyncNotification ? 'Enabled' : 'Disabled'}
+                          toggle={isAsyncNotification}
+                          placeholder="isAsyncNotification"
+                        />
+                        {watchLocationName &&
+                          isAsyncNotificationReady &&
+                          isAsyncNotification && <HelpAsyncNotification />}
+                      </>
+                    );
+                  }}
+                />
+                {watchLocationName && !isAsyncNotificationReady && (
+                  <HelpNonAsyncLocation />
+                )}
+              </F.Fieldset>
+            )}
             <F.SessionSeperation />
             <F.Fieldset direction={'row'}>
               <F.Label>Versioning</F.Label>

--- a/src/react/databrowser/buckets/__tests__/BucketCreate.test.jsx
+++ b/src/react/databrowser/buckets/__tests__/BucketCreate.test.jsx
@@ -1,4 +1,4 @@
-import BucketCreate from '../BucketCreate';
+import BucketCreate, { bucketErrorMessage } from '../BucketCreate';
 import React from 'react';
 import { act } from 'react-dom/test-utils';
 import { reduxMountAct } from '../../../utils/test';
@@ -47,25 +47,46 @@ describe('BucketCreate', () => {
       expectedEmptyNameError: ' "Name" is not allowed to be empty ',
       expectedMinLengthNameError: null,
       expectedMaxLengthNameError: null,
+      expectedPAtternNameError: null,
     },
     {
       description:
-        'should render an input form error when submitting with an name.length < 3',
+        'should render an input form error when submitting with a name.length < 3',
       testValue: 'ab',
       expectedEmptyNameError: null,
       expectedMinLengthNameError:
         ' "Name" length must be at least 3 characters long ',
       expectedMaxLengthNameError: null,
+      expectedPAtternNameError: null,
     },
     {
       description:
-        'should render an input form error when submitting with an name.length > 63',
+        'should render an input form error when submitting with a name.length > 63',
       testValue:
-        'Z4VbHlmEKC0a8n85FEneHN6EhBwFSkmSh4tGOKy53ktdmQlwq5xJVi7hm32jFuKB',
+        'z4vbhlmekc0a8n85fenehn6ehbwfskmsh4tgoky53ktdmqlwq5xjvi7hm32jfukb',
       expectedEmptyNameError: null,
       expectedMinLengthNameError: null,
+      expectedPAtternNameError: null,
       expectedMaxLengthNameError:
         ' "Name" length must be less than or equal to 63 characters long ',
+    },
+    {
+      description:
+        'should render an input form error when submitting with a name with uppercase letters',
+      testValue: 'dozA',
+      expectedEmptyNameError: null,
+      expectedMinLengthNameError: null,
+      expectedPAtternNameError: bucketErrorMessage,
+      expectedMaxLengthNameError: null,
+    },
+    {
+      description:
+        'should render an input form error when submitting with a name with special characters',
+      testValue: 'doz_',
+      expectedEmptyNameError: null,
+      expectedMinLengthNameError: null,
+      expectedPAtternNameError: bucketErrorMessage,
+      expectedMaxLengthNameError: null,
     },
   ];
 
@@ -92,6 +113,10 @@ describe('BucketCreate', () => {
       } else if (t.expectedMaxLengthNameError !== null) {
         expect(component.find('ErrorInput#error-name').text()).toContain(
           t.expectedMaxLengthNameError,
+        );
+      } else if (t.expectedPAtternNameError !== null) {
+        expect(component.find('ErrorInput#error-name').text()).toContain(
+          t.expectedPAtternNameError,
         );
       }
       component.unmount();
@@ -124,7 +149,9 @@ describe('BucketCreate', () => {
   });
 
   it('should toggle versioning and disable it when enabling Async Metadata updates', async () => {
-    const component = await reduxMountAct(<BucketCreate />, { auth: { config: { features: [XDM_FEATURE] } } });
+    const component = await reduxMountAct(<BucketCreate />, {
+      auth: { config: { features: [XDM_FEATURE] } },
+    });
 
     await act(async () => {
       const input = component.find('input#name');


### PR DESCRIPTION
add error message and ui validation on bucket creation : `Bucket names can include only lowercase letters, numbers, dots (.), and hyphens (-)`