### PR TITLE
ZKUI-94: Add the missing nextMarker

### DIFF
--- a/src/react/reducers/s3.js
+++ b/src/react/reducers/s3.js
@@ -234,6 +234,7 @@ export default function s3(state: S3State = initialS3State, action: S3Action) {
       return {
         ...state,
         listObjectsResults: {
+          ...state.listObjectsResults,
           list: state.listObjectsResults.list.map(o =>
             o.key === action.objectKey && o.versionId === action.versionId
               ? { ...o, toggled: !o.toggled }
@@ -245,6 +246,7 @@ export default function s3(state: S3State = initialS3State, action: S3Action) {
       return {
         ...state,
         listObjectsResults: {
+          ...state.listObjectsResults,
           list: state.listObjectsResults.list.map(o => ({
             ...o,
             toggled: action.toggled,


### PR DESCRIPTION
Add the missing nextMarker which cause the the issue that we can't fetch the objects when we have more than 100.
