### PR TITLE
ZKUI-126: Filter out the scality internal account

### DIFF
--- a/src/react/IAMProvider.tsx
+++ b/src/react/IAMProvider.tsx
@@ -5,6 +5,7 @@ import IAMClient, { getAssumeRoleWithWebIdentityIAM } from '../js/IAMClient';
 import { useQuery } from 'react-query';
 import { AppState } from '../types/state';
 import { selectAccountID } from './actions';
+import { useAccounts } from './utils/hooks';
 
 // Only exported to ease testing
 export const _IAMContext = createContext<null | {
@@ -34,9 +35,7 @@ const IAMProvider = ({ children }: { children: JSX.Element }) => {
 
   // FIXME Temporary fix to get the account each time you change URL
   const dispatch = useDispatch();
-  const accounts = useSelector(
-    (state: AppState) => state.configuration.latest.users,
-  );
+  const accounts = useAccounts();
   useEffect(() => {
     const account = accounts.find((a) => a.userName === accountName);
     if (!account) {

--- a/src/react/account/AccountContent.tsx
+++ b/src/react/account/AccountContent.tsx
@@ -6,27 +6,25 @@ import {
   useParams,
   useRouteMatch,
 } from 'react-router-dom';
-import { useSelector } from 'react-redux';
 import * as L from '../ui-elements/ListLayout5';
 import AccountDetails from './AccountDetails';
 import AccountHead from './AccountHead';
-import type { AppState } from '../../types/state';
 import { BreadcrumbAccount } from '../ui-elements/Breadcrumb';
 import AccountCreateUser from './AccountCreateUser';
 import AccountUpdateUser from './AccountUpdateUser';
 import AccountUserAccessKeys from './AccountUserAccessKeys';
 import CreateWorkflow from '../workflow/CreateWorkflow';
 import Workflows from '../workflow/Workflows';
+import { useAccounts } from '../utils/hooks';
 
 function AccountContent() {
-  const { accountName: accountNameParam } =
-    useParams<{ accountName: string }>();
+  const { accountName: accountNameParam } = useParams<{
+    accountName: string;
+  }>();
 
   const { path } = useRouteMatch();
   const { pathname } = useLocation();
-  const accounts = useSelector(
-    (state: AppState) => state.configuration.latest.users,
-  );
+  const accounts = useAccounts();
   const account = useMemo(
     () => accounts.find((a) => a.userName === accountNameParam),
     [accounts, accountNameParam],

--- a/src/react/account/Accounts.tsx
+++ b/src/react/account/Accounts.tsx
@@ -1,18 +1,16 @@
 import React from 'react';
 import { useLocation } from 'react-router-dom';
-import { useSelector } from 'react-redux';
 import AccountList from './AccountList';
-import type { AppState } from '../../types/state';
 import { BreadcrumbAccount } from '../ui-elements/Breadcrumb';
 import * as L from '../ui-elements/ListLayout5';
 import Header from '../ui-elements/EntityHeader';
 import MultiAccountsLogo from '../../../public/assets/logo-multi-accounts.svg';
+import { useAccounts } from '../utils/hooks';
 
 const Accounts = () => {
   const { pathname } = useLocation();
-  const accounts = useSelector(
-    (state: AppState) => state.configuration.latest.users,
-  );
+  const accounts = useAccounts();
+
   return (
     <L.Container>
       <L.BreadcrumbContainer>

--- a/src/react/databrowser/DataBrowser.tsx
+++ b/src/react/databrowser/DataBrowser.tsx
@@ -14,15 +14,15 @@ import { clearError } from '../actions';
 import { push } from 'connected-react-router';
 import ObjectLockSetting from './buckets/ObjectLockSetting';
 import ObjectLockSettingOnObject from './objects/ObjectLockSetting';
+import { useAccounts } from '../utils/hooks';
+
 export default function DataBrowser() {
   const dispatch = useDispatch();
   const accountName = useSelector(
     (state: AppState) =>
       state.auth.selectedAccount && state.auth.selectedAccount.userName,
   );
-  const accounts = useSelector(
-    (state: AppState) => state.configuration.latest.users,
-  );
+  const accounts = useAccounts();
   const hasError = useSelector(
     (state: AppState) =>
       !!state.uiErrors.errorMsg && state.uiErrors.errorType === 'byComponent',

--- a/src/react/utils/hooks.ts
+++ b/src/react/utils/hooks.ts
@@ -1,6 +1,8 @@
 import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
 import { useLocation } from 'react-router-dom';
 import { addTrailingSlash } from '.';
+import { AppState } from '../../types/state';
 export const useHeight = (myRef) => {
   const [height, setHeight] = useState(0);
   useEffect(() => {
@@ -84,4 +86,16 @@ export const useClipboard = () => {
     copy: copyToClipboard,
     copyStatus: copyStatus,
   };
+};
+
+export const useAccounts = () => {
+  const accounts = useSelector(
+    (state: AppState) => state.configuration.latest.users,
+  );
+
+  return accounts.filter(
+    (account) =>
+      account.userName !== 'scality-internal-services' ||
+      account.id !== '000000000000',
+  );
 };

--- a/src/react/workflow/Workflows.tsx
+++ b/src/react/workflow/Workflows.tsx
@@ -21,6 +21,7 @@ import {
   networkStart,
 } from '../actions';
 import { APIWorkflows } from '../../types/workflow';
+import { useAccounts } from '../utils/hooks';
 
 export function useWorkflows(
   select?: (workflows: APIWorkflows) => void,
@@ -75,9 +76,7 @@ export default function Workflows() {
     (state: AppState) =>
       state.auth.selectedAccount && state.auth.selectedAccount.userName,
   );
-  const accounts = useSelector(
-    (state: AppState) => state.configuration.latest.users,
-  );
+  const accounts = useAccounts();
   const bucketList = useSelector(
     (state: AppState) => state.s3.listBucketsResults.list,
   );


### PR DESCRIPTION
Create a hook `useAccount()` to retrieve the accounts from configurations and filter out the account `scality-internal-account`.