### PR TITLE
ZKUI-153: Enable Legal Hold Setting when the bucket is versioned enable and object-lock enabled

### DIFF
--- a/src/react/databrowser/objects/details/Properties.tsx
+++ b/src/react/databrowser/objects/details/Properties.tsx
@@ -34,6 +34,11 @@ function Properties({ objectMetadata }: Props) {
   const bucketInfo = useSelector((state: AppState) => state.s3.bucketInfo);
   const prefixWithSlash = usePrefixWithSlash();
   const isLegalHoldEnabled = objectMetadata.isLegalHoldEnabled;
+  //Display Legal Hold when the Bucket is versioned and object-lock enabled.
+  const isLegalHoldSettingVisible =
+    bucketInfo?.versioning === 'Enabled' &&
+    bucketInfo?.objectLockConfiguration.ObjectLockEnabled === 'Enabled';
+
   const query = useQueryParams();
   const metadataSearch = query.get('metadatasearch');
   // In order to keep object selection between toggling show versions, add `versionId` in the query params
@@ -134,8 +139,7 @@ function Properties({ objectMetadata }: Props) {
                   )}
                 </T.GroupValues>
               </T.Row>
-              {/* Display the legal hold when the object lock is enabled at bucket level */}
-              {objectMetadata.lockStatus !== 'NONE' && (
+              {isLegalHoldSettingVisible && (
                 <T.Row>
                   <T.Key>Legal Hold</T.Key>
                   <T.Value>

--- a/src/react/databrowser/objects/details/__tests__/Properties.test.tsx
+++ b/src/react/databrowser/objects/details/__tests__/Properties.test.tsx
@@ -136,6 +136,17 @@ describe('Properties', () => {
           isLegalHoldEnabled: true,
         }}
       />,
+      {
+        s3: {
+          bucketInfo: {
+            name: 'test-bucket',
+            objectLockConfiguration: {
+              ObjectLockEnabled: 'Enabled',
+            },
+            versioning: 'Enabled',
+          },
+        },
+      },
     );
     const tableItems = component.find(T.Row);
     const seventh = tableItems.at(6);


### PR DESCRIPTION
Enable Legal Hold Setting when the bucket is versioned enable and object-lock enabled