### PR TITLE
ZKUI-158: Update Pensieve API client

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,5 +112,8 @@
     "vega-lite": "^4.0.0-beta.10",
     "vega-tooltip": "^0.28.0",
     "zenkoclient": "github:scality/zenkoclient#1.2.0"
+  },
+  "msw": {
+    "workerDirectory": "public/assets"
   }
 }

--- a/public/assets/mockServiceWorker.js
+++ b/public/assets/mockServiceWorker.js
@@ -1,0 +1,338 @@
+/* eslint-disable */
+/* tslint:disable */
+
+/**
+ * Mock Service Worker (0.36.8).
+ * @see https://github.com/mswjs/msw
+ * - Please do NOT modify this file.
+ * - Please do NOT serve this file on production.
+ */
+
+const INTEGRITY_CHECKSUM = '02f4ad4a2797f85668baf196e553d929'
+const bypassHeaderName = 'x-msw-bypass'
+const activeClientIds = new Set()
+
+self.addEventListener('install', function () {
+  return self.skipWaiting()
+})
+
+self.addEventListener('activate', async function (event) {
+  return self.clients.claim()
+})
+
+self.addEventListener('message', async function (event) {
+  const clientId = event.source.id
+
+  if (!clientId || !self.clients) {
+    return
+  }
+
+  const client = await self.clients.get(clientId)
+
+  if (!client) {
+    return
+  }
+
+  const allClients = await self.clients.matchAll()
+
+  switch (event.data) {
+    case 'KEEPALIVE_REQUEST': {
+      sendToClient(client, {
+        type: 'KEEPALIVE_RESPONSE',
+      })
+      break
+    }
+
+    case 'INTEGRITY_CHECK_REQUEST': {
+      sendToClient(client, {
+        type: 'INTEGRITY_CHECK_RESPONSE',
+        payload: INTEGRITY_CHECKSUM,
+      })
+      break
+    }
+
+    case 'MOCK_ACTIVATE': {
+      activeClientIds.add(clientId)
+
+      sendToClient(client, {
+        type: 'MOCKING_ENABLED',
+        payload: true,
+      })
+      break
+    }
+
+    case 'MOCK_DEACTIVATE': {
+      activeClientIds.delete(clientId)
+      break
+    }
+
+    case 'CLIENT_CLOSED': {
+      activeClientIds.delete(clientId)
+
+      const remainingClients = allClients.filter((client) => {
+        return client.id !== clientId
+      })
+
+      // Unregister itself when there are no more clients
+      if (remainingClients.length === 0) {
+        self.registration.unregister()
+      }
+
+      break
+    }
+  }
+})
+
+// Resolve the "main" client for the given event.
+// Client that issues a request doesn't necessarily equal the client
+// that registered the worker. It's with the latter the worker should
+// communicate with during the response resolving phase.
+async function resolveMainClient(event) {
+  const client = await self.clients.get(event.clientId)
+
+  if (client.frameType === 'top-level') {
+    return client
+  }
+
+  const allClients = await self.clients.matchAll()
+
+  return allClients
+    .filter((client) => {
+      // Get only those clients that are currently visible.
+      return client.visibilityState === 'visible'
+    })
+    .find((client) => {
+      // Find the client ID that's recorded in the
+      // set of clients that have registered the worker.
+      return activeClientIds.has(client.id)
+    })
+}
+
+async function handleRequest(event, requestId) {
+  const client = await resolveMainClient(event)
+  const response = await getResponse(event, client, requestId)
+
+  // Send back the response clone for the "response:*" life-cycle events.
+  // Ensure MSW is active and ready to handle the message, otherwise
+  // this message will pend indefinitely.
+  if (client && activeClientIds.has(client.id)) {
+    ;(async function () {
+      const clonedResponse = response.clone()
+      sendToClient(client, {
+        type: 'RESPONSE',
+        payload: {
+          requestId,
+          type: clonedResponse.type,
+          ok: clonedResponse.ok,
+          status: clonedResponse.status,
+          statusText: clonedResponse.statusText,
+          body:
+            clonedResponse.body === null ? null : await clonedResponse.text(),
+          headers: serializeHeaders(clonedResponse.headers),
+          redirected: clonedResponse.redirected,
+        },
+      })
+    })()
+  }
+
+  return response
+}
+
+async function getResponse(event, client, requestId) {
+  const { request } = event
+  const requestClone = request.clone()
+  const getOriginalResponse = () => fetch(requestClone)
+
+  // Bypass mocking when the request client is not active.
+  if (!client) {
+    return getOriginalResponse()
+  }
+
+  // Bypass initial page load requests (i.e. static assets).
+  // The absence of the immediate/parent client in the map of the active clients
+  // means that MSW hasn't dispatched the "MOCK_ACTIVATE" event yet
+  // and is not ready to handle requests.
+  if (!activeClientIds.has(client.id)) {
+    return await getOriginalResponse()
+  }
+
+  // Bypass requests with the explicit bypass header
+  if (requestClone.headers.get(bypassHeaderName) === 'true') {
+    const cleanRequestHeaders = serializeHeaders(requestClone.headers)
+
+    // Remove the bypass header to comply with the CORS preflight check.
+    delete cleanRequestHeaders[bypassHeaderName]
+
+    const originalRequest = new Request(requestClone, {
+      headers: new Headers(cleanRequestHeaders),
+    })
+
+    return fetch(originalRequest)
+  }
+
+  // Send the request to the client-side MSW.
+  const reqHeaders = serializeHeaders(request.headers)
+  const body = await request.text()
+
+  const clientMessage = await sendToClient(client, {
+    type: 'REQUEST',
+    payload: {
+      id: requestId,
+      url: request.url,
+      method: request.method,
+      headers: reqHeaders,
+      cache: request.cache,
+      mode: request.mode,
+      credentials: request.credentials,
+      destination: request.destination,
+      integrity: request.integrity,
+      redirect: request.redirect,
+      referrer: request.referrer,
+      referrerPolicy: request.referrerPolicy,
+      body,
+      bodyUsed: request.bodyUsed,
+      keepalive: request.keepalive,
+    },
+  })
+
+  switch (clientMessage.type) {
+    case 'MOCK_SUCCESS': {
+      return delayPromise(
+        () => respondWithMock(clientMessage),
+        clientMessage.payload.delay,
+      )
+    }
+
+    case 'MOCK_NOT_FOUND': {
+      return getOriginalResponse()
+    }
+
+    case 'NETWORK_ERROR': {
+      const { name, message } = clientMessage.payload
+      const networkError = new Error(message)
+      networkError.name = name
+
+      // Rejecting a request Promise emulates a network error.
+      throw networkError
+    }
+
+    case 'INTERNAL_ERROR': {
+      const parsedBody = JSON.parse(clientMessage.payload.body)
+
+      console.error(
+        `\
+[MSW] Uncaught exception in the request handler for "%s %s":
+
+${parsedBody.location}
+
+This exception has been gracefully handled as a 500 response, however, it's strongly recommended to resolve this error, as it indicates a mistake in your code. If you wish to mock an error response, please see this guide: https://mswjs.io/docs/recipes/mocking-error-responses\
+`,
+        request.method,
+        request.url,
+      )
+
+      return respondWithMock(clientMessage)
+    }
+  }
+
+  return getOriginalResponse()
+}
+
+self.addEventListener('fetch', function (event) {
+  const { request } = event
+  const accept = request.headers.get('accept') || ''
+
+  // Bypass server-sent events.
+  if (accept.includes('text/event-stream')) {
+    return
+  }
+
+  // Bypass navigation requests.
+  if (request.mode === 'navigate') {
+    return
+  }
+
+  // Opening the DevTools triggers the "only-if-cached" request
+  // that cannot be handled by the worker. Bypass such requests.
+  if (request.cache === 'only-if-cached' && request.mode !== 'same-origin') {
+    return
+  }
+
+  // Bypass all requests when there are no active clients.
+  // Prevents the self-unregistered worked from handling requests
+  // after it's been deleted (still remains active until the next reload).
+  if (activeClientIds.size === 0) {
+    return
+  }
+
+  const requestId = uuidv4()
+
+  return event.respondWith(
+    handleRequest(event, requestId).catch((error) => {
+      if (error.name === 'NetworkError') {
+        console.warn(
+          '[MSW] Successfully emulated a network error for the "%s %s" request.',
+          request.method,
+          request.url,
+        )
+        return
+      }
+
+      // At this point, any exception indicates an issue with the original request/response.
+      console.error(
+        `\
+[MSW] Caught an exception from the "%s %s" request (%s). This is probably not a problem with Mock Service Worker. There is likely an additional logging output above.`,
+        request.method,
+        request.url,
+        `${error.name}: ${error.message}`,
+      )
+    }),
+  )
+})
+
+function serializeHeaders(headers) {
+  const reqHeaders = {}
+  headers.forEach((value, name) => {
+    reqHeaders[name] = reqHeaders[name]
+      ? [].concat(reqHeaders[name]).concat(value)
+      : value
+  })
+  return reqHeaders
+}
+
+function sendToClient(client, message) {
+  return new Promise((resolve, reject) => {
+    const channel = new MessageChannel()
+
+    channel.port1.onmessage = (event) => {
+      if (event.data && event.data.error) {
+        return reject(event.data.error)
+      }
+
+      resolve(event.data)
+    }
+
+    client.postMessage(JSON.stringify(message), [channel.port2])
+  })
+}
+
+function delayPromise(cb, duration) {
+  return new Promise((resolve) => {
+    setTimeout(() => resolve(cb()), duration)
+  })
+}
+
+function respondWithMock(clientMessage) {
+  return new Response(clientMessage.payload.body, {
+    ...clientMessage.payload,
+    headers: clientMessage.payload.headers,
+  })
+}
+
+function uuidv4() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    const r = (Math.random() * 16) | 0
+    const v = c == 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
+}

--- a/src/js/managementClient/api.ts
+++ b/src/js/managementClient/api.ts
@@ -313,34 +313,22 @@ export namespace BucketWorkflowExpirationV1 {
 export interface BucketWorkflowTransitionV1 extends BucketWorkflowV1 {
     /**
      * 
-     * @type {Array<any>}
+     * @type {string}
      * @memberof BucketWorkflowTransitionV1
      */
-    currentVersionLocations?: Array<any>;
+    applyToVersions?: BucketWorkflowTransitionV1.ApplyToVersionsEnum;
     /**
      * 
      * @type {string}
      * @memberof BucketWorkflowTransitionV1
      */
-    currentVersionTriggerDelayDate?: string;
+    triggerDelayDate?: string;
     /**
      * 
      * @type {number}
      * @memberof BucketWorkflowTransitionV1
      */
-    currentVersionTriggerDelayDays?: number;
-    /**
-     * 
-     * @type {Array<any>}
-     * @memberof BucketWorkflowTransitionV1
-     */
-    previousVersionLocations?: Array<any>;
-    /**
-     * 
-     * @type {number}
-     * @memberof BucketWorkflowTransitionV1
-     */
-    previousVersionTriggerDelayDays?: number;
+    triggerDelayDays?: number;
 }
 
 /**
@@ -348,6 +336,14 @@ export interface BucketWorkflowTransitionV1 extends BucketWorkflowV1 {
  * @namespace BucketWorkflowTransitionV1
  */
 export namespace BucketWorkflowTransitionV1 {
+    /**
+     * @export
+     * @enum {string}
+     */
+    export enum ApplyToVersionsEnum {
+        Current = <any> 'current',
+        Previous = <any> 'previous'
+    }
 }
 
 /**
@@ -1358,6 +1354,21 @@ export namespace LocationAzureV1 {
 /**
  * 
  * @export
+ * @interface LocationDmfV1
+ */
+export interface LocationDmfV1 extends LocationV1 {
+}
+
+/**
+ * @export
+ * @namespace LocationDmfV1
+ */
+export namespace LocationDmfV1 {
+}
+
+/**
+ * 
+ * @export
  * @interface LocationFileV1
  */
 export interface LocationFileV1 extends LocationV1 {
@@ -1409,6 +1420,12 @@ export interface LocationV1 {
      * @memberof LocationV1
      */
     isBuiltin?: boolean;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof LocationV1
+     */
+    isCold?: boolean;
     /**
      * 
      * @type {boolean}
@@ -1471,7 +1488,8 @@ export namespace LocationV1 {
         ScalityHdclientV1 = <any> 'location-scality-hdclient-v1',
         ScalityHdclientV2 = <any> 'location-scality-hdclient-v2',
         CephRadosgwS3V1 = <any> 'location-ceph-radosgw-s3-v1',
-        NfsMountV1 = <any> 'location-nfs-mount-v1'
+        NfsMountV1 = <any> 'location-nfs-mount-v1',
+        DmfV1 = <any> 'location-dmf-v1'
     }
 }
 
@@ -2037,6 +2055,14 @@ export namespace ScheduleV1 {
         Enabled = <any> 'enabled',
         Disabled = <any> 'disabled'
     }
+}
+
+/**
+ * Search Workflow List
+ * @export
+ * @interface SearchWorkflowsListV1
+ */
+export interface SearchWorkflowsListV1 extends Array<any> {
 }
 
 /**
@@ -5259,7 +5285,7 @@ export const UiFacingApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        searchWorkflows(accountId: string, instanceId: string, roleName?: string, filters?: Filters, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<Array<any>> {
+        searchWorkflows(accountId: string, instanceId: string, roleName?: string, filters?: Filters, options?: any): (fetch?: FetchAPI, basePath?: string) => Promise<SearchWorkflowsListV1> {
             const localVarFetchArgs = UiFacingApiFetchParamCreator(configuration).searchWorkflows(accountId, instanceId, roleName, filters, options);
             return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
                 return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {

--- a/src/js/managementClient/api.ts
+++ b/src/js/managementClient/api.ts
@@ -316,6 +316,12 @@ export interface BucketWorkflowTransitionV1 extends BucketWorkflowV1 {
      * @type {string}
      * @memberof BucketWorkflowTransitionV1
      */
+    locationName?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof BucketWorkflowTransitionV1
+     */
     applyToVersions?: BucketWorkflowTransitionV1.ApplyToVersionsEnum;
     /**
      * 

--- a/src/js/mock/managementClientColdStorageMSWHandlers.ts
+++ b/src/js/mock/managementClientColdStorageMSWHandlers.ts
@@ -1,0 +1,285 @@
+import { rest } from 'msw';
+
+/**
+ * /!\ Prerequisites: Can be changed below /!\
+ *   - Account named "pat"
+ *   - Bucket name "test"
+ */
+
+const ACCOUNT_NAME = 'pat';
+const BUCKET_NAME = 'test';
+
+export const getColdStorageHandlers = (baseUrl: string, instanceId: string) => [
+  //Config overlay mock below
+  rest.get(`${baseUrl}/api/v1/config/overlay/view/${instanceId}`, (req, res, ctx) =>
+    res(
+      ctx.json({
+        browserAccess: { enabled: true },
+        endpoints: [
+          {
+            hostname: 'zenko-cloudserver-replicator',
+            isBuiltin: true,
+            locationName: 'us-east-1',
+          },
+          { hostname: 's3.zenko.local', locationName: 'us-east-1' },
+          { hostname: 'test.local', locationName: 'us-east-1' },
+        ],
+        instanceId,
+        locations: {
+          'europe25-myroom-cold': {
+            locationType: 'location-dmf-v1',
+            name: 'europe25-myroom-cold',
+            isCold: true,
+            details: {
+              endpoint: 'ws://tape.myroom.europe25.cnes:8181',
+              repoId: ['repoId'],
+              nsId: 'nsId',
+              username: 'username',
+              password: 'password',
+            },
+          },
+          'chapter-ux': {
+            details: {
+              accessKey: 'AMFFHQC1TTUIQ9K6B7LO',
+              bootstrapList: [],
+              bucketName: 'replication-for-chapter-ux',
+              endpoint: 'http://s3.workloadplane.scality.local',
+              region: 'us-east-1',
+              secretKey: '*****',
+            },
+            locationType: 'location-scality-artesca-s3-v1',
+            name: 'chapter-ux',
+            objectId: '4ab68d3f-9eec-11ec-ae58-6e38b828d159',
+          },
+          'ring-nick': {
+            details: {
+              accessKey: 'CO558N0OWLDBUULGAAUU',
+              bootstrapList: [],
+              bucketMatch: true,
+              bucketName: 'xdm-chapter-ux-test',
+              endpoint: 'http://10.200.3.166',
+              region: 'us-east-1',
+              secretKey: '*****',
+            },
+            locationType: 'location-scality-ring-s3-v1',
+            name: 'ring-nick',
+            objectId: '99a06f79-c62c-11ec-b993-7e8a0ab79998',
+          },
+          'us-east-1': {
+            isBuiltin: true,
+            locationType: 'location-file-v1',
+            name: 'us-east-1',
+            objectId: '95dbedf5-9888-11ec-8565-1ac2af7d1e53',
+          },
+        },
+        replicationStreams: [],
+        updatedAt: '2022-04-27T13:18:58Z',
+        users: [
+          {
+            arn: 'arn:aws:iam::000000000000:/scality-internal-services/',
+            canonicalId:
+              '04c6c688782f2b395faac05295cf05e41e05929b7992a20b5d680d36efea577c',
+            createDate: '2022-02-28T11:21:07.000Z',
+            email: 'scality@internal',
+            id: '000000000000',
+            userName: 'scality-internal-services',
+          },
+          {
+            arn: 'arn:aws:iam::064609833007:/no-bucket/',
+            canonicalId:
+              '1e3492312ab47ab0785e3411824352a8fa8aab68cece94973af04167926b8f2c',
+            createDate: '2022-03-18T12:51:44.000Z',
+            email: 'no-bucket@test.com',
+            id: '064609833007',
+            userName: 'no-bucket',
+          },
+          {
+            arn: 'arn:aws:iam::152883654752:/created-by-storage-account-owner/',
+            canonicalId:
+              'ec0d7198d88e327d3dea039682b619f13b84915e52f826b806b4ef9dab3d8c14',
+            createDate: '2022-05-10T11:40:48.000Z',
+            email: 'cheng@scality.com',
+            id: '152883654752',
+            userName: 'created-by-storage-account-owner',
+          },
+          {
+            arn: 'arn:aws:iam::377232323695:/yanjin/',
+            canonicalId:
+              '8c3b89e95e9768755365a8c2d528e71bc7b1cab781ac118b0824cefe21abaf29',
+            createDate: '2022-04-29T09:35:35.000Z',
+            email: 'yanjin.cheng@scality.com',
+            id: '377232323695',
+            userName: 'yanjin',
+          },
+          {
+            arn: 'arn:aws:iam::621762876784:/Asmaa/',
+            canonicalId:
+              '268ba54d07bb0c538dc76ddcac41164346b9e40726ac49642cb9ab54200639cd',
+            createDate: '2022-03-02T09:08:41.000Z',
+            email: 'asmaa.el.mokhtari@scality.com',
+            id: '621762876784',
+            userName: 'Asmaa',
+          },
+          {
+            arn: 'arn:aws:iam::650126396693:/replication/',
+            canonicalId:
+              '3386f3d3b01cd125379943c25aea17149011b64479a5d01eb74dfcfe9129ee97',
+            createDate: '2022-03-07T11:08:28.000Z',
+            email: 'invalid@invalid',
+            id: '650126396693',
+            userName: 'replication',
+          },
+          {
+            arn: 'arn:aws:iam::904321757948:/account-1/',
+            canonicalId:
+              'b9f93485ea8d62f2e6f780fa93c0da76849ee0c317c3fc892902b9179390efee',
+            createDate: '2022-03-31T14:16:58.000Z',
+            email: 'test@test.com',
+            id: '904321757948',
+            userName: 'account-1',
+          },
+          {
+            arn: 'arn:aws:iam::970343539682:/test/',
+            canonicalId:
+              '47e1f39353f2c3b0579a544e12491057e1fec175895b75467463cffdd004897d',
+            createDate: '2022-03-02T08:06:05.000Z',
+            email: 'test@invalid',
+            id: '970343539682',
+            userName: 'test',
+          },
+          {
+            arn: 'arn:aws:iam::998935415244:/pat/',
+            canonicalId:
+              'b41319703eadc6d8aecfd996eea678f10ab2f32c0d730403afdd5f8775c7a44e',
+            createDate: '2022-03-07T16:29:54.000Z',
+            email: 'invalid@pat.com',
+            id: '998935415244',
+            userName: 'pat',
+          },
+        ],
+        version: 12,
+      }),
+    ),
+  ),
+
+  //Locations mocks below
+  rest.post(
+    `${baseUrl}/api/v1/instance/${instanceId}/locations`,
+    (req, res, ctx) =>
+      res(
+        ctx.json({
+          locationType: 'location-dmf-v1',
+          name: 'europe25-myroom-cold',
+          isCold: true,
+          details: {
+            endpoint: 'ws://tape.myroom.europe25.cnes:8181',
+            repoId: ['repoId'],
+            nsId: 'nsId',
+            username: 'username',
+            password: 'password',
+          },
+        }),
+      ),
+  ),
+
+  rest.put(
+    `${baseUrl}/api/v1/instance/${instanceId}/location/europe25-myroom-cold`,
+    (req, res, ctx) =>
+      res(
+        ctx.json({
+          locationType: 'location-dmf-v1',
+          name: 'europe25-myroom-cold',
+          isCold: true,
+          details: {
+            endpoint: 'ws://tape.myroom.europe25.cnes:8181',
+            repoId: ['repoId'],
+            nsId: 'nsId',
+            username: 'username',
+            password: 'password',
+          },
+        }),
+      ),
+  ),
+
+  //Transitions mocks below
+  rest.post(
+    `${baseUrl}/api/v1/instance/${instanceId}/account/${ACCOUNT_NAME}/workflow/search`,
+    (req, res, ctx) =>
+      res(
+        ctx.json([
+          {
+            replication: {
+              destination: { locations: [{ name: 'location-aws-s3' }] },
+              name: null,
+              source: {
+                bucketName: 'test-post-react-hook-form',
+                prefix: 'tester',
+              },
+              streamId: '0d55a1d7-349c-4e79-932b-a502bcc45a8f',
+              version: null,
+            },
+          },
+          {
+            transition: {
+              bucketName: BUCKET_NAME,
+              workflowId: '0d55a1d7-349c-4e79-932b-b502bcc45a8f',
+              applyToVersions: 'current',
+              type: 'bucket-workflow-transition-v2',
+              triggerDelayDays: 15,
+              locationName: 'dmf-location',
+              enabled: true,
+            },
+          },
+          {
+            transition: {
+              bucketName: BUCKET_NAME,
+              workflowId: '1e55a1d7-349c-4e79-932b-b502bcc45a8f',
+              applyToVersions: 'previous',
+              type: 'bucket-workflow-transition-v2',
+              triggerDelayDays: 15,
+              locationName: 'dmf-location',
+              enabled: true,
+            },
+          },
+        ]),
+      ),
+  ),
+  rest.post(
+    `${baseUrl}/api/v1/config/instance/{instanceId}/bucket/{bucketName}/workflow/transition`,
+    (req, res, ctx) =>
+      res(
+        ctx.json([
+          {
+            bucketName: BUCKET_NAME,
+            workflowId: '1e55a1d7-349c-4e79-932b-b502bcc45a8f',
+            applyToVersions: 'previous',
+            type: 'bucket-workflow-transition-v2',
+            triggerDelayDays: 15,
+            locationName: 'dmf-location',
+            enabled: true,
+          },
+        ]),
+      ),
+  ),
+  rest.put(
+    `${baseUrl}/api/v1/config/instance/${instanceId}/bucket/${BUCKET_NAME}/workflow/transition/1e55a1d7-349c-4e79-932b-b502bcc45a8f`,
+    (req, res, ctx) =>
+      res(
+        ctx.json([
+          {
+            bucketName: BUCKET_NAME,
+            workflowId: '1e55a1d7-349c-4e79-932b-b502bcc45a8f',
+            applyToVersions: 'previous',
+            type: 'bucket-workflow-transition-v2',
+            triggerDelayDays: 15,
+            locationName: 'dmf-location',
+            enabled: true,
+          },
+        ]),
+      ),
+  ),
+  rest.delete(
+    `${baseUrl}/api/v1/config/instance/${instanceId}/bucket/${BUCKET_NAME}/workflow/transition/1e55a1d7-349c-4e79-932b-b502bcc45a8f`,
+    (req, res, ctx) => res(ctx.status(200)),
+  ),
+];

--- a/src/js/mock/mswBrowserMocks.ts
+++ b/src/js/mock/mswBrowserMocks.ts
@@ -1,0 +1,11 @@
+// src/mocks/browser.js
+import { setupWorker } from 'msw';
+import { getColdStorageHandlers } from './managementClientColdStorageMSWHandlers';
+
+// This configures a Service Worker with the given request handlers.
+export const worker = setupWorker(
+  ...getColdStorageHandlers(
+    'http://management.zenko.local',
+    'a5536227-39e1-4e7c-be68-29a19b404131',
+  ),
+);

--- a/src/react/App.tsx
+++ b/src/react/App.tsx
@@ -14,6 +14,12 @@ import ZenkoUI from './ZenkoUI';
 //         [require('react-redux/lib'), 'useSelector'],
 //     ],
 // });
+if (process.env.NODE_ENV === 'development') {
+  (async () => {
+    const { worker } = await import('../js/mock/mswBrowserMocks');
+    worker.start();
+  })();
+}
 export const queryClient = new QueryClient();
 const  rootElement = document.getElementById('app')
 rootElement && ReactDOM.render(

--- a/src/react/backend/location/LocationDetails/LocationDetailsAws.tsx
+++ b/src/react/backend/location/LocationDetails/LocationDetailsAws.tsx
@@ -6,13 +6,9 @@ import {
   Input,
   Label,
 } from '../../../ui-elements/FormLayout';
-import type { LocationDetails } from '../../../../types/config';
 import React from 'react';
-type Props = {
-  details: LocationDetails;
-  onChange: (details: LocationDetails) => void;
-  editingExisting: boolean;
-};
+import { LocationDetailsFormProps } from '.';
+
 type State = {
   serverSideEncryption: boolean;
   bucketMatch: boolean;
@@ -27,15 +23,15 @@ const INIT_STATE: State = {
   secretKey: '',
   bucketName: '',
 };
-export default class LocationDetailsAws extends React.Component<Props, State> {
-  constructor(props: Props) {
+export default class LocationDetailsAws extends React.Component<LocationDetailsFormProps, State> {
+  constructor(props: LocationDetailsFormProps) {
     super(props);
     this.state = Object.assign({}, INIT_STATE, this.props.details);
     // XXX disable changing it if not provided
     this.state.secretKey = '';
   }
 
-  onChange = (e: React.SyntheticEvent<HTMLInputElement>) => {
+  onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const target = e.target;
     const value = target.type === 'checkbox' ? target.checked : target.value;
     this.setState({
@@ -52,7 +48,7 @@ export default class LocationDetailsAws extends React.Component<Props, State> {
     this.updateForm();
   }
 
-  shouldComponentUpdate(nextProps: Props, nextState: State) {
+  shouldComponentUpdate(nextProps: LocationDetailsFormProps, nextState: State) {
     return this.state !== nextState;
   }
 

--- a/src/react/backend/location/LocationDetails/LocationDetailsAwsCustom.tsx
+++ b/src/react/backend/location/LocationDetails/LocationDetailsAwsCustom.tsx
@@ -7,8 +7,6 @@ import {
   Label,
 } from '../../../ui-elements/FormLayout';
 import { HelpLocationCreationAsyncNotification } from '../../../ui-elements/Help';
-import type { InstanceStateSnapshot } from '../../../../types/stats';
-import type { LocationDetails } from '../../../../types/config';
 import React, { useEffect, useState } from 'react';
 import { isIngestSource } from '../../../utils/storageOptions';
 import { storageOptions } from './storageOptions';
@@ -16,13 +14,7 @@ import { useSelector } from 'react-redux';
 import type { AppState } from '../../../../types/state';
 import { XDM_FEATURE } from '../../../../js/config';
 import SpacedBox from '@scality/core-ui/dist/components/spacedbox/SpacedBox';
-type Props = {
-  editingExisting: boolean;
-  details: LocationDetails;
-  onChange: (details: LocationDetails) => void;
-  locationType: string;
-  capabilities: Pick<InstanceStateSnapshot, 'capabilities'>;
-};
+import { LocationDetailsFormProps } from '.';
 type State = {
   bucketMatch: boolean;
   accessKey: string;
@@ -43,13 +35,13 @@ export default function LocationDetailsAwsCustom({
   editingExisting,
   locationType,
   onChange,
-}: Props) {
+}: LocationDetailsFormProps) {
   const [formState, setFormState] = useState<State>(() => ({
     ...Object.assign({}, INIT_STATE, details),
     secretKey: '',
   }));
 
-  const onFormItemChange = (e: React.SyntheticEvent<HTMLInputElement>) => {
+  const onFormItemChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const target = e.target;
     const value = target.type === 'checkbox' ? target.checked : target.value;
     setFormState({ ...formState, [target.name]: value });

--- a/src/react/backend/location/LocationDetails/LocationDetailsAzure.tsx
+++ b/src/react/backend/location/LocationDetails/LocationDetailsAzure.tsx
@@ -5,12 +5,8 @@ import {
   Input,
   Label,
 } from '../../../ui-elements/FormLayout';
-import type { LocationDetails } from '../../../../types/config';
 import React from 'react';
-type Props = {
-  details: LocationDetails;
-  onChange: (details: LocationDetails) => void;
-};
+import { LocationDetailsFormProps } from '.';
 type State = {
   bucketMatch: boolean;
   accessKey: string;
@@ -26,16 +22,16 @@ const INIT_STATE: State = {
   endpoint: '',
 };
 export default class LocationDetailsAzure extends React.Component<
-  Props,
+  LocationDetailsFormProps,
   State
 > {
-  constructor(props: Props) {
+  constructor(props: LocationDetailsFormProps) {
     super(props);
     this.state = Object.assign({}, INIT_STATE, this.props.details);
     this.state.secretKey = '';
   }
 
-  onChange = (e: React.SyntheticEvent<HTMLInputElement>) => {
+  onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const target = e.target;
     const value = target.type === 'checkbox' ? target.checked : target.value;
     this.setState({
@@ -52,7 +48,7 @@ export default class LocationDetailsAzure extends React.Component<
     this.updateForm();
   }
 
-  shouldComponentUpdate(nextProps: Props, nextState: State) {
+  shouldComponentUpdate(nextProps: LocationDetailsFormProps, nextState: State) {
     return this.state !== nextState;
   }
 

--- a/src/react/backend/location/LocationDetails/LocationDetailsDOSpaces.tsx
+++ b/src/react/backend/location/LocationDetails/LocationDetailsDOSpaces.tsx
@@ -5,12 +5,8 @@ import {
   Input,
   Label,
 } from '../../../ui-elements/FormLayout';
-import type { LocationDetails } from '../../../../types/config';
 import React from 'react';
-type Props = {
-  details: LocationDetails;
-  onChange: (details: LocationDetails) => void;
-};
+import { LocationDetailsFormProps } from '.';
 type State = {
   bucketMatch: boolean;
   accessKey: string;
@@ -26,17 +22,17 @@ const INIT_STATE: State = {
   endpoint: '',
 };
 export default class LocationDetailsDOSpaces extends React.Component<
-  Props,
+  LocationDetailsFormProps,
   State
 > {
-  constructor(props: Props) {
+  constructor(props: LocationDetailsFormProps) {
     super(props);
     this.state = Object.assign({}, INIT_STATE, this.props.details);
     // XXX disable changing it if not provided
     this.state.secretKey = '';
   }
 
-  onChange = (e: React.SyntheticEvent<HTMLInputElement>) => {
+  onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const target = e.target;
     const value = target.type === 'checkbox' ? target.checked : target.value;
     this.setState({
@@ -53,7 +49,7 @@ export default class LocationDetailsDOSpaces extends React.Component<
     this.updateForm();
   }
 
-  shouldComponentUpdate(nextProps: Props, nextState: State) {
+  shouldComponentUpdate(nextProps: LocationDetailsFormProps, nextState: State) {
     return this.state !== nextState;
   }
 

--- a/src/react/backend/location/LocationDetails/LocationDetailsGcp.tsx
+++ b/src/react/backend/location/LocationDetails/LocationDetailsGcp.tsx
@@ -5,12 +5,9 @@ import {
   Input,
   Label,
 } from '../../../ui-elements/FormLayout';
-import type { LocationDetails } from '../../../../types/config';
 import React from 'react';
-type Props = {
-  details: LocationDetails;
-  onChange: (details: LocationDetails) => void;
-};
+import { LocationDetailsFormProps } from '.';
+
 type State = {
   bucketMatch: boolean;
   accessKey: string;
@@ -25,14 +22,14 @@ const INIT_STATE: State = {
   bucketName: '',
   mpuBucketName: '',
 };
-export default class LocationDetailsGcp extends React.Component<Props, State> {
-  constructor(props: Props) {
+export default class LocationDetailsGcp extends React.Component<LocationDetailsFormProps, State> {
+  constructor(props: LocationDetailsFormProps) {
     super(props);
     this.state = Object.assign({}, INIT_STATE, this.props.details);
     this.state.secretKey = '';
   }
 
-  onChange = (e: React.SyntheticEvent<HTMLInputElement>) => {
+  onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const target = e.target;
     const value = target.type === 'checkbox' ? target.checked : target.value;
     this.setState({
@@ -49,7 +46,7 @@ export default class LocationDetailsGcp extends React.Component<Props, State> {
     this.updateForm();
   }
 
-  shouldComponentUpdate(nextProps: Props, nextState: State) {
+  shouldComponentUpdate(nextProps: LocationDetailsFormProps, nextState: State) {
     return this.state !== nextState;
   }
 

--- a/src/react/backend/location/LocationDetails/LocationDetailsHyperdriveV2.tsx
+++ b/src/react/backend/location/LocationDetails/LocationDetailsHyperdriveV2.tsx
@@ -1,10 +1,7 @@
 import { Fieldset, InputList, Label } from '../../../ui-elements/FormLayout';
-import type { LocationDetails } from '../../../../types/config';
 import React from 'react';
-type Props = {
-  details: LocationDetails;
-  onChange: (details: LocationDetails) => void;
-};
+import { LocationDetailsFormProps } from '.';
+
 type State = {
   bootstrapList: Array<string>;
 };
@@ -13,10 +10,10 @@ const INIT_STATE = {
 };
 const MAX_HYPERDRIVE = 10;
 export default class LocationDetailsHyperdriveV2 extends React.Component<
-  Props,
+  LocationDetailsFormProps,
   State
 > {
-  constructor(props: Props) {
+  constructor(props: LocationDetailsFormProps) {
     super(props);
     this.state = Object.assign({}, INIT_STATE, this.props.details);
   }
@@ -27,7 +24,7 @@ export default class LocationDetailsHyperdriveV2 extends React.Component<
     });
   };
 
-  componentDidUpdate(prevProps: Props, prevState: State) {
+  componentDidUpdate(prevProps: LocationDetailsFormProps, prevState: State) {
     if (this.state !== prevState) {
       this.props.onChange(this.state);
     }

--- a/src/react/backend/location/LocationDetails/LocationDetailsNFS.tsx
+++ b/src/react/backend/location/LocationDetails/LocationDetailsNFS.tsx
@@ -7,11 +7,7 @@ import {
 import type { LocationDetails } from '../../../../types/config';
 import React from 'react';
 import urlParse from 'url-parse';
-type Props = {
-  editingExisting: boolean;
-  details: LocationDetails;
-  onChange: (details: LocationDetails) => void;
-};
+import { LocationDetailsFormProps } from '.';
 type State = {
   protocol: 'tcp' | 'udp';
   version: 'v3' | 'v4';
@@ -86,8 +82,8 @@ const NFS_VERSIONS: Array<Options> = ['v3', 'v4'].map((ver) => {
     label: ver.toUpperCase(),
   };
 });
-export default class LocationDetailsNFS extends React.Component<Props, State> {
-  constructor(props: Props) {
+export default class LocationDetailsNFS extends React.Component<LocationDetailsFormProps, State> {
+  constructor(props: LocationDetailsFormProps) {
     super(props);
     this.state = Object.assign(
       {},
@@ -96,7 +92,7 @@ export default class LocationDetailsNFS extends React.Component<Props, State> {
     );
   }
 
-  onChange = (e: React.SyntheticEvent<HTMLInputElement>) => {
+  onChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const target = e.target;
     let value;
 
@@ -144,7 +140,7 @@ export default class LocationDetailsNFS extends React.Component<Props, State> {
     this.updateForm();
   }
 
-  shouldComponentUpdate(nextProps: Props, nextState: State) {
+  shouldComponentUpdate(nextProps: LocationDetailsFormProps, nextState: State) {
     return this.state !== nextState;
   }
 

--- a/src/react/backend/location/LocationDetails/index.ts
+++ b/src/react/backend/location/LocationDetails/index.ts
@@ -1,2 +1,13 @@
+import { LocationDetails } from '../../../../types/config';
+import { InstanceStateSnapshot } from '../../../../types/stats';
+
 export * from './storageOptions';
 export { default as LocationDetails } from './LocationDetails';
+
+export type LocationDetailsFormProps = {
+    editingExisting: boolean;
+    details: LocationDetails;
+    onChange: (details: LocationDetails) => void;
+    locationType: string;
+    capabilities: Pick<InstanceStateSnapshot, 'capabilities'>;
+  };

--- a/src/react/ui-elements/FormLayout.tsx
+++ b/src/react/ui-elements/FormLayout.tsx
@@ -101,10 +101,18 @@ export const WarningInput = ({ children, hasError }: ErrorInputProps) => (
   <WarningInputContainer>{hasError && children}</WarningInputContainer>
 );
 // * Label
-const LabelContainer = styled.label`
+const LabelContainer = styled.label<{required?: boolean}>`
   display: flex;
   align-items: center;
   width: 35%;
+  ${(props) =>
+    props.required
+      ? `
+        &:after {
+            content: '*';
+        }
+    `
+      : ''}
 `;
 const TooltipContainer = styled.div`
   margin-left: ${spacing.sp8};
@@ -121,6 +129,7 @@ type LabelProps = {
   tooltipMessages?: JSX.Element[]|Array<string>;
   tooltipWidth?: string;
   style?: CSSStyleSheet;
+  required?: boolean;
 } & LabelHTMLAttributes<HTMLLabelElement>;
 export const Label = ({
   children,


### PR DESCRIPTION
Regenerate Pensieve API client with new Transition Workflow definition.

Steps:
 - Get the swagger spec of Pensieve API (PENSIEVE-API/swagger.json)
 - Load swagger specification on editor.swagger.io
 - Click Generate Client > typescript-fetch
 - Replace the files in src/js/managementClient by the generated ones
 - Replace the following code block:

```ts
export class RequiredError extends Error {
    name: "RequiredError"
    constructor(public field: string, msg?: string) {
        super(msg);
    }
}
```

By

```ts
export class RequiredError extends window.Error {
    name: "RequiredError"
    constructor(public field: string, msg?: string) {
        super(msg);
    }
}
```