### PR TITLE
ZKUI-190: make sure zenko client is login before calling s3 actions

### DIFF
--- a/src/js/ZenkoClient.ts
+++ b/src/js/ZenkoClient.ts
@@ -15,12 +15,14 @@ import ZenkoClientBase from 'zenkoclient';
 class ZenkoClient extends S3Client implements ZenkoClientInterface {
   endpoint: string;
   _xmlClient: ZenkoClientBase;
+  _isLogin: boolean;
 
   constructor(endpoint) {
     super(endpoint);
     this.endpoint = endpoint;
 
     this._init();
+    this._isLogin = false;
   }
 
   _init() {
@@ -91,6 +93,8 @@ class ZenkoClient extends S3Client implements ZenkoClientInterface {
     // but seems to work for all the other S3 calls.
     // this.client.config.update({
     //     accessKeyId: accessKey, secretAccessKey: secretKey, sessionToken });
+
+    this._isLogin = true;
   }
 
   searchBucket(params: SearchParams): Promise<SearchBucketResp> {
@@ -131,6 +135,10 @@ class ZenkoClient extends S3Client implements ZenkoClientInterface {
       Site: site,
     };
     return this._jsonClient.resumeIngestionSite(params).promise();
+  }
+
+  getIsLogin() {
+    return this._isLogin;
   }
 }
 

--- a/src/types/zenko.ts
+++ b/src/types/zenko.ts
@@ -70,4 +70,5 @@ export interface ZenkoClient extends S3Client {
     KeyMarker: string | undefined;
     VersionIdMarker: string | undefined;
   }): Promise<SearchBucketVersionsResp>;
+  getIsLogin(): boolean;
 }


### PR DESCRIPTION
After we initialize zenko client, login() function is called after the
s3 acitions which casuse the error of
Missing credenticals in config, if using AWS_CONFIG_FILE, set
AWS_SDK_LOAD_CONFIG = 1.

The way we fix it is to add an internal state _isLogin, and check the
state before doing the s3 actions
