### PR TITLE
ZKUI-238: Enable previous version for transition edition under certain conditions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "zenko-ui",
-  "version": "1.5.0-preview.10",
+  "version": "1.5.0-preview.11",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "zenko-ui",
-      "version": "1.5.0-preview.10",
+      "version": "1.5.0-preview.11",
       "license": "ISC",
       "dependencies": {
         "@fortawesome/fontawesome-free": "^5.10.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "zenko-ui",
-  "version": "1.5.0-preview.10",
+  "version": "1.5.0-preview.11",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/react/workflow/TransitionForm.tsx
+++ b/src/react/workflow/TransitionForm.tsx
@@ -64,7 +64,7 @@ export const TransitionForm = ({
 
   const { errors } = formState;
   const isEditing = !!getValues(`${prefix}workflowId`);
-
+  const applyToVersion = getValues(`${prefix}applyToVersion`);
   const locationName = watch(`${prefix}locationName`);
   const triggerDelayDays = watch(`${prefix}triggerDelayDays`);
 
@@ -73,8 +73,11 @@ export const TransitionForm = ({
   const isSourceBucketVersionned = sourceBucket
     ? isVersioning(sourceBucket.VersionStatus)
     : false;
+  // Disable the previous version if the bucket is not versionned and the default value is `Current version`
+  const isPreviousVersionDisabled =
+    !isSourceBucketVersionned && applyToVersion === 'current';
   useMemo(() => {
-    if (!isSourceBucketVersionned) {
+    if (!isSourceBucketVersionned && !isEditing) {
       setValue(`${prefix}applyToVersion`, 'current');
     }
   }, [isSourceBucketVersionned]);
@@ -280,15 +283,15 @@ export const TransitionForm = ({
                       id="previous"
                       value="previous"
                       {...register(`${prefix}applyToVersion`)}
-                      disabled={!isSourceBucketVersionned}
+                      disabled={isPreviousVersionDisabled}
                     />
                     <Box
                       ml={1}
-                      style={{ opacity: isSourceBucketVersionned ? 1 : 0.5 }}
+                      style={{ opacity: isPreviousVersionDisabled ? 0.5 : 1 }}
                     >
                       Previous version
                     </Box>
-                    {!isSourceBucketVersionned ? (
+                    {isPreviousVersionDisabled ? (
                       <>
                         <IconHelp
                           tooltipMessage={


### PR DESCRIPTION
If the `applyToVersion` in the existing workflow is `Previous version`
it should be selected in the form.

We disable the `Previous version` for the edition when 2 conditions are met:
1. the bucket is not versioned
2. the default value is `Current version`