### PR TITLE
ZKUI-283 - fix databrowser refresh button

### DIFF
--- a/src/react/databrowser/DataBrowser.tsx
+++ b/src/react/databrowser/DataBrowser.tsx
@@ -1,17 +1,17 @@
-import * as L from '../ui-elements/ListLayout2';
 import { Route, Switch, useLocation } from 'react-router-dom';
 import { useParams, useRouteMatch } from 'react-router';
 import { useDispatch, useSelector } from 'react-redux';
+import { push } from 'connected-react-router';
+
+import * as L from '../ui-elements/ListLayout2';
 import type { AppState } from '../../types/state';
 import { Breadcrumb, breadcrumbPathsBuckets } from '../ui-elements/Breadcrumb';
 import Buckets from './buckets/Buckets';
 import { EmptyStateContainer } from '../ui-elements/Container';
 import ListLayoutButtons from './HeaderButtons';
 import Objects from './objects/Objects';
-import React from 'react';
 import { Warning } from '../ui-elements/Warning';
 import { clearError } from '../actions';
-import { push } from 'connected-react-router';
 import ObjectLockSetting from './buckets/ObjectLockSetting';
 import ObjectLockSettingOnObject from './objects/ObjectLockSetting';
 import { useAccounts, useQueryParams } from '../utils/hooks';
@@ -74,10 +74,7 @@ export default function DataBrowser() {
             accountName,
           )}
         />
-        <Switch>
-          <Route exact path={`${path}/:bucketName/retention-setting`} />
-          <Route path={`${path}/:bucketName`} component={ListLayoutButtons} />
-        </Switch>
+        <Route path={`${path}/:bucketName`} component={ListLayoutButtons} />
       </L.BreadcrumbContainer>
       <Switch>
         <Route

--- a/src/react/databrowser/HeaderButtons.tsx
+++ b/src/react/databrowser/HeaderButtons.tsx
@@ -1,4 +1,3 @@
-import React, { useMemo } from 'react';
 import { matchPath, useLocation, useParams } from 'react-router-dom';
 import { Button } from '@scality/core-ui/dist/next';
 import { ButtonsContainer } from '../ui-elements/Container';
@@ -6,14 +5,15 @@ import { listBuckets } from '../actions/s3bucket';
 import { listObjects } from '../actions/s3object';
 import { useDispatch } from 'react-redux';
 import { usePrefixWithSlash } from '../utils/hooks';
+
 export function RefreshButton() {
-  const { bucketName } = useParams();
+  const { bucketName } = useParams<{ bucketName: string }>();
   const { pathname } = useLocation();
   const prefixWithSlash = usePrefixWithSlash();
   const dispatch = useDispatch();
   const isBrowsingObjects = !!matchPath(
     pathname,
-    '/buckets/:bucketName/objects',
+    '/accounts/:accountName/buckets/:bucketName/objects',
   );
 
   const handleRefreshClick = () => {


### PR DESCRIPTION
This button was broken since we move databrowser path to `'/accounts/:accountName/buckets/:bucketName/objects'`