### PR TITLE
ZKUI-287: Replace the version with git sha as the output of build

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -1,13 +1,17 @@
 const path = require('path');
 const HtmlWebPackPlugin = require('html-webpack-plugin');
-const {version} = require('./package.json');
+
+const revision = require('child_process')
+  .execSync('git rev-parse HEAD')
+  .toString()
+  .trim();
 
 module.exports = {
   entry: {
     zenko_ui: './src/react/App',
   },
   output: {
-    filename: `js/[name].${version}.js`,
+    filename: `js/[name].${revision}.js`,
     path: path.resolve(__dirname, 'public/assets'),
     publicPath: '/',
   },


### PR DESCRIPTION
In this case, we don't need to bump the version in the package when we do the release.