### PR TITLE
ZKUI-327: Init the domain for accounts, buckets and locations and pensieve metric adaptor

### DIFF
--- a/src/react/next-architecture/adaptors/metrics/IMetricsAdaptor.ts
+++ b/src/react/next-architecture/adaptors/metrics/IMetricsAdaptor.ts
@@ -1,0 +1,27 @@
+import { Bucket } from 'aws-sdk/clients/s3';
+import { LatestUsedCapacity } from '../../domain/entities/metrics';
+
+export type BucketLatestUsedCapacity = {
+  bucketName: string;
+} & LatestUsedCapacity;
+export type AccountLatestUsedCapacity = {
+  accountId: string;
+} & LatestUsedCapacity;
+export type LocationLatestUsedCapacity = {
+  locationId: string;
+} & LatestUsedCapacity;
+
+export interface IMetricsAdaptor {
+  listBucketsLatestUsedCapacity(
+    buckets: Bucket[],
+  ): Promise<BucketLatestUsedCapacity[]>;
+  listLocationsLatestUsedCapacity(
+    locationIds: string[],
+  ): Promise<LocationLatestUsedCapacity[]>;
+  listAccountLocationsLatestUsedCapacity(
+    accountId: string,
+  ): Promise<LocationLatestUsedCapacity[]>;
+  listAccountsLatestUsedCapacity(
+    accountIds: string[],
+  ): Promise<AccountLatestUsedCapacity[]>;
+}

--- a/src/react/next-architecture/adaptors/metrics/PensieveMetricsAdaptor.ts
+++ b/src/react/next-architecture/adaptors/metrics/PensieveMetricsAdaptor.ts
@@ -1,0 +1,30 @@
+import { Bucket } from 'aws-sdk/clients/s3';
+import {
+  AccountLatestUsedCapacity,
+  BucketLatestUsedCapacity,
+  LocationLatestUsedCapacity,
+  IMetricsAdaptor,
+} from './IMetricsAdaptor';
+
+export class PensieveMetricsAdaptor implements IMetricsAdaptor {
+  listAccountLocationsLatestUsedCapacity(
+    accountId: string,
+  ): Promise<LocationLatestUsedCapacity[]> {
+    throw new Error('Method not implemented.');
+  }
+  async listAccountsLatestUsedCapacity(
+    accountIds: string[],
+  ): Promise<AccountLatestUsedCapacity[]> {
+    throw new Error('Method not implemented.');
+  }
+  async listBucketsLatestUsedCapacity(
+    buckets: Bucket[],
+  ): Promise<BucketLatestUsedCapacity[]> {
+    throw new Error('Method not implemented.');
+  }
+  async listLocationsLatestUsedCapacity(
+    locationIds: string[],
+  ): Promise<LocationLatestUsedCapacity[]> {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/src/react/next-architecture/domain/business/accounts.ts
+++ b/src/react/next-architecture/domain/business/accounts.ts
@@ -1,0 +1,29 @@
+import { IMetricsAdaptor } from '../../adaptors/metrics/IMetricsAdaptor';
+import { AccountsPromiseResult } from '../entities/account';
+
+/**
+ * The hook returns all the accounts and the storage metric for the first 20 accounts.
+ * @param metricsAdaptor
+ */
+export const useListAccounts = ({
+  metricsAdaptor,
+}: {
+  metricsAdaptor: IMetricsAdaptor;
+}): AccountsPromiseResult => {
+  throw new Error('Method not implemented.');
+};
+
+/**
+ * The hook returns the latest used capacity for a specific account.
+ * @param metricsAdaptor
+ * @param accountId
+ */
+export const useAccountLatestUsedCapacity = ({
+  metricsAdaptor,
+  accountId,
+}: {
+  metricsAdaptor: IMetricsAdaptor;
+  accountId: string;
+}): AccountsPromiseResult => {
+  throw new Error('Method not implemented.');
+};

--- a/src/react/next-architecture/domain/business/buckets.ts
+++ b/src/react/next-architecture/domain/business/buckets.ts
@@ -1,0 +1,44 @@
+import { IMetricsAdaptor } from '../../adaptors/metrics/IMetricsAdaptor';
+import {
+  BucketLatestUsedCapacityPromiseResult,
+  BucketLocationConstraintPromiseResult,
+  BucketsPromiseResult,
+} from '../entities/bucket';
+
+/**
+ * The hook returns the full list of buckets plus the locations and metrcis of the first 20 buckets.
+ */
+export const useListBucketsForCurrentAccount = ({
+  metricsAdaptor,
+}: {
+  metricsAdaptor: IMetricsAdaptor;
+}): BucketsPromiseResult => {
+  throw new Error('Method not implemented.');
+};
+
+/**
+ * The hook returns the location constraint for a specific bucket.
+ * It will be called within the Table Cell on demande.
+ * @param bucketName name of the bucket
+ */
+export const useBucketLocationConstraint = ({
+  bucketName,
+}: {
+  bucketName: string;
+}): BucketLocationConstraintPromiseResult => {
+  throw new Error('Method not implemented.');
+};
+
+/**
+ * The hook returns the latest used capacity for a specific bucket.
+ * @param bucketName name of the bucket
+ */
+export const useBucketLatestUsedCapacity = ({
+  metricsAdaptor,
+  bucketName,
+}: {
+  metricsAdaptor: IMetricsAdaptor;
+  bucketName: string;
+}): BucketLatestUsedCapacityPromiseResult => {
+  throw new Error('Method not implemented.');
+};

--- a/src/react/next-architecture/domain/business/locations.ts
+++ b/src/react/next-architecture/domain/business/locations.ts
@@ -1,0 +1,22 @@
+import { IMetricsAdaptor } from '../../adaptors/metrics/IMetricsAdaptor';
+import { LocationsPromiseResult } from '../entities/location';
+
+/**
+ * The hook returns all the locations and it's metrics
+ * @param metricsAdaptor
+ */
+export const useListLocations = ({
+  metricsAdaptor,
+}: {
+  metricsAdaptor: IMetricsAdaptor;
+}): LocationsPromiseResult => {
+  throw new Error('Method not implemented.');
+};
+
+export const useListLocationsForCurrentAccount = ({
+  metricsAdaptor,
+}: {
+  metricsAdaptor: IMetricsAdaptor;
+}): LocationsPromiseResult => {
+  throw new Error('Method not implemented.');
+};

--- a/src/react/next-architecture/domain/entities/account.ts
+++ b/src/react/next-architecture/domain/entities/account.ts
@@ -1,0 +1,16 @@
+import { LatestUsedCapacity } from './metrics';
+import { PromiseResult } from './promise';
+
+export type AccountLatestUsedCapacityPromiseResult = {
+  usedCapacity: PromiseResult<LatestUsedCapacity>;
+};
+
+type Account = {
+  id: string;
+  accountName: string;
+  creationDate: Date;
+} & AccountLatestUsedCapacityPromiseResult;
+
+export type AccountsPromiseResult = {
+  accounts: PromiseResult<Account[]>;
+};

--- a/src/react/next-architecture/domain/entities/bucket.ts
+++ b/src/react/next-architecture/domain/entities/bucket.ts
@@ -1,0 +1,20 @@
+import { LatestUsedCapacity } from './metrics';
+import { PromiseResult } from './promise';
+
+export type BucketLocationConstraintPromiseResult = {
+  locationConstraint: PromiseResult<string>;
+};
+
+export type BucketLatestUsedCapacityPromiseResult = {
+  usedCapacity: PromiseResult<LatestUsedCapacity>;
+};
+
+type Bucket = BucketLocationConstraintPromiseResult & {
+  bucketName: string;
+  creationDate: Date;
+  usedCapacity: PromiseResult<LatestUsedCapacity>;
+};
+
+export type BucketsPromiseResult = {
+  buckets: PromiseResult<Bucket[]>;
+};

--- a/src/react/next-architecture/domain/entities/location.ts
+++ b/src/react/next-architecture/domain/entities/location.ts
@@ -1,0 +1,14 @@
+import { LatestUsedCapacity } from './metrics';
+import { PromiseResult } from './promise';
+
+type Location = {
+  id: string;
+  name: string;
+  type: string;
+  usedCapacity: PromiseResult<LatestUsedCapacity>;
+  targetBucket?: string;
+};
+
+export type LocationsPromiseResult = {
+  locations: PromiseResult<Location[]>;
+};

--- a/src/react/next-architecture/domain/entities/metrics.ts
+++ b/src/react/next-architecture/domain/entities/metrics.ts
@@ -1,0 +1,12 @@
+export type LatestUsedCapacity =
+  | {
+      type: 'noMetrics';
+    }
+  | {
+      type: 'hasMetrics';
+      usedCapacity: {
+        current: number;
+        nonCurrent: number;
+      };
+      measuredOn: Date;
+    };

--- a/src/react/next-architecture/domain/entities/promise.ts
+++ b/src/react/next-architecture/domain/entities/promise.ts
@@ -1,0 +1,27 @@
+type Idle = 'idle';
+type Loading = 'loading';
+type NotResolved = Idle | Loading;
+type Success = 'success';
+type Error = 'error';
+
+export type PromiseStatus = NotResolved | Success | Error;
+
+interface PromiseSucceedResult<T> {
+  status: Success;
+  value: T;
+}
+
+interface PromiseRejectedResult {
+  status: Error;
+  title: string;
+  reason: string;
+}
+
+interface PromiseNotResolved {
+  status: NotResolved;
+}
+
+export type PromiseResult<T> =
+  | PromiseNotResolved
+  | PromiseSucceedResult<T>
+  | PromiseRejectedResult;

--- a/src/react/next-architecture/ui/MetricsAdaptorProvider.tsx
+++ b/src/react/next-architecture/ui/MetricsAdaptorProvider.tsx
@@ -1,0 +1,30 @@
+import { createContext, useContext } from 'react';
+import { PensieveMetricsAdaptor } from '../adaptors/metrics/PensieveMetricsAdaptor';
+import { IMetricsAdaptor } from '../adaptors/metrics/IMetricsAdaptor';
+
+const _MetricsAdaptorContext = createContext<null | {
+  metricsAdaptor: IMetricsAdaptor;
+}>(null);
+
+export const useMetricsAdaptor = (): IMetricsAdaptor => {
+  const context = useContext(_MetricsAdaptorContext);
+
+  if (!context) {
+    throw new Error(
+      'The useMetricsAdaptor hook can only be used within MetricsAdaptorProvider.',
+    );
+  }
+
+  return context.metricsAdaptor;
+};
+
+const MetricsAdaptorProvider = ({ children }: { children: JSX.Element }) => {
+  // We only need to change to SCUBA Adaptor later on.
+  const metricsAdaptor = new PensieveMetricsAdaptor();
+  return (
+    <_MetricsAdaptorContext.Provider value={{ metricsAdaptor }}>
+      {children}
+    </_MetricsAdaptorContext.Provider>
+  );
+};
+export default MetricsAdaptorProvider;


### PR DESCRIPTION
We created `next-architecture` folder which contains `adaptor`, `domain` and `ui`. 
Eventually we will remove this layer. 