### PR TITLE
INTEGRATION [PR#608 > development/2.1] Fix an issue where the legal hold toggle was not displayed for objects when accessing the browser directly

### DIFF
--- a/src/react/account/AccountLocations.tsx
+++ b/src/react/account/AccountLocations.tsx
@@ -5,7 +5,7 @@ import { useMetricsAdapter } from '../next-architecture/ui/MetricsAdapterProvide
 import { CellProps, CoreUIColumn } from 'react-table';
 import { Location } from '../next-architecture/domain/entities/location';
 import { getLocationType } from '../utils/storageOptions';
-import ColdStorageIcon from '../ui-elements/ColdStorageIcon';
+import { ColdStorageIcon } from '../ui-elements/ColdStorageIcon';
 import { HelpLocationTargetBucket } from '../ui-elements/Help';
 import { UsedCapacityInlinePromiseResult } from '../next-architecture/ui/metrics/LatestUsedCapacity';
 import { Warning } from '../ui-elements/Warning';

--- a/src/react/databrowser/objects/details/Properties.tsx
+++ b/src/react/databrowser/objects/details/Properties.tsx
@@ -24,6 +24,7 @@ import { Button } from '@scality/core-ui/dist/next';
 import ColdStorageIcon from '../../../ui-elements/ColdStorageIcon';
 import { DateTime } from 'luxon';
 import ObjectRestorationButtonAndModal from './ObjectRestorationButtonAndModal';
+import { useBucketDefaultRetention } from '../../../next-architecture/domain/business/buckets';
 
 type Props = {
   objectMetadata: ObjectMetadata;
@@ -38,7 +39,6 @@ function Properties({ objectMetadata }: Props) {
   const loading = useSelector(
     (state: AppState) => state.networkActivity.counter > 0,
   );
-  const bucketInfo = useSelector((state: AppState) => state.s3.bucketInfo);
   const locations = useSelector(
     (state: AppState) => state.configuration.latest.locations,
   );
@@ -47,9 +47,13 @@ function Properties({ objectMetadata }: Props) {
   const prefixWithSlash = usePrefixWithSlash();
   const isLegalHoldEnabled = objectMetadata.isLegalHoldEnabled;
   //Display Legal Hold when the Bucket is versioned and object-lock enabled.
-  const isLegalHoldSettingVisible =
-    bucketInfo?.versioning === 'Enabled' &&
-    bucketInfo?.objectLockConfiguration.ObjectLockEnabled === 'Enabled';
+  const { defaultRetention } = useBucketDefaultRetention({
+    bucketName: objectMetadata.bucketName,
+  });
+
+  const isObjectLockEnabled =
+    defaultRetention.status === 'success' &&
+    defaultRetention.value.ObjectLockEnabled === 'Enabled';
 
   const query = useQueryParams();
   const metadataSearch = query.get('metadatasearch');
@@ -157,7 +161,7 @@ function Properties({ objectMetadata }: Props) {
                     )}
                     {!objectMetadata.restore?.ongoingRequest && (
                       <ObjectRestorationButtonAndModal
-                        bucketName={bucketInfo?.name || ''}
+                        bucketName={objectMetadata.bucketName}
                         objectMetadata={objectMetadata}
                       />
                     )}
@@ -190,8 +194,7 @@ function Properties({ objectMetadata }: Props) {
                     )}
                     {objectMetadata.lockStatus === 'NONE' && 'No retention'}
                   </div>
-                  {bucketInfo?.objectLockConfiguration.ObjectLockEnabled ===
-                    'Enabled' && (
+                  {isObjectLockEnabled && (
                     <Button
                       id="edit-object-retention-setting-btn"
                       variant="outline"
@@ -208,7 +211,7 @@ function Properties({ objectMetadata }: Props) {
                   )}
                 </T.GroupValues>
               </T.Row>
-              {isLegalHoldSettingVisible && (
+              {isObjectLockEnabled && (
                 <T.Row>
                   <T.Key>Legal Hold</T.Key>
                   <T.Value>

--- a/src/react/databrowser/objects/details/__tests__/Properties.test.tsx
+++ b/src/react/databrowser/objects/details/__tests__/Properties.test.tsx
@@ -1,17 +1,47 @@
 import { OBJECT_METADATA } from '../../../../actions/__tests__/utils/testUtil';
-import { reduxMount } from '../../../../utils/testUtil';
+import {
+  TEST_API_BASE_URL,
+  reduxMount,
+  reduxRender,
+} from '../../../../utils/testUtil';
 import * as T from '../../../../ui-elements/TableKeyValue2';
 import MiddleEllipsis from '../../../../ui-elements/MiddleEllipsis';
 import Properties from '../Properties';
 import router from 'react-router';
 import { DateTime } from 'luxon';
 
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { screen, waitFor } from '@testing-library/react';
+
+//Mock getObjectLockConfiguration for bucket 'bucket'
+const server = setupServer(
+  rest.get(`${TEST_API_BASE_URL}/bucket?object-lock`, (req, res, ctx) => {
+    return res(
+      ctx.xml(`
+      <ObjectLockConfiguration>
+        <ObjectLockEnabled>Enabled</ObjectLockEnabled>
+        <Rule>
+          <DefaultRetention>
+            <Mode>COMPLIANCE</Mode>
+            <Days>1</Days>
+          </DefaultRetention>
+        </Rule>
+      </ObjectLockConfiguration>
+      `),
+    );
+  }),
+);
+
 describe('Properties', () => {
   beforeAll(() => {
     jest.spyOn(router, 'useLocation').mockReturnValue({
       pathname: `/buckets/test/objects?prefix=${OBJECT_METADATA.objectKey}`,
     });
+    server.listen({ onUnhandledRequest: 'error' });
   });
+  afterEach(() => server.resetHandlers());
+  afterAll(() => server.close());
   it('should render', () => {
     jest.spyOn(router, 'useParams').mockReturnValue({
       '0': undefined,
@@ -63,8 +93,8 @@ describe('Properties', () => {
       OBJECT_METADATA.eTag,
     );
   });
-  it('should render expected values when object is locked', () => {
-    const { component } = reduxMount(
+  it('should render expected values when object is locked', async () => {
+    reduxRender(
       <Properties
         objectMetadata={{
           ...OBJECT_METADATA,
@@ -85,19 +115,16 @@ describe('Properties', () => {
         },
       },
     );
-    const tableItems = component.find(T.Row);
-    const seventh = tableItems.at(7);
-    expect(seventh.find(T.Key).text()).toContain('Lock');
-    expect(seventh.find(T.GroupValues).text()).toContain('Locked (governance)');
-    expect(seventh.find(T.GroupValues).text()).toContain(
-      'until 2020-10-17 10:06:54',
+    expect(screen.getByText('Lock')).toBeInTheDocument();
+    expect(screen.getByText(/governance/)).toBeInTheDocument();
+    expect(screen.getByText(/until 2020-10-17 10:06:54/)).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument(),
     );
-    expect(
-      seventh.find('button#edit-object-retention-setting-btn').prop('label'),
-    ).toBe('Edit');
+    expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
   });
-  it('should render expected values when lock is released', () => {
-    const { component } = reduxMount(
+  it('should render expected values when lock is released', async () => {
+    reduxRender(
       <Properties
         objectMetadata={{
           ...OBJECT_METADATA,
@@ -108,29 +135,19 @@ describe('Properties', () => {
           },
         }}
       />,
-      {
-        s3: {
-          bucketInfo: {
-            name: 'test-bucket',
-            objectLockConfiguration: {
-              ObjectLockEnabled: 'Enabled',
-            },
-          },
-        },
-      },
     );
-    const tableItems = component.find(T.Row);
-    const seventh = tableItems.at(7);
-    expect(seventh.find(T.Key).text()).toContain('Lock');
-    expect(seventh.find(T.GroupValues).text()).toContain(
-      'Released since 2020-10-17 10:06:54',
-    );
+
+    expect(screen.getByText('Lock')).toBeInTheDocument();
     expect(
-      seventh.find('button#edit-object-retention-setting-btn').prop('label'),
-    ).toBe('Edit');
+      screen.getByText(/Released since 2020-10-17 10:06:54/),
+    ).toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument(),
+    );
+    expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
   });
-  it('should render expected legal hold value when the object lock is set', () => {
-    const { component } = reduxMount(
+  it('should render expected legal hold value when the object lock is set', async () => {
+    reduxRender(
       <Properties
         objectMetadata={{
           ...OBJECT_METADATA,
@@ -142,22 +159,12 @@ describe('Properties', () => {
           isLegalHoldEnabled: true,
         }}
       />,
-      {
-        s3: {
-          bucketInfo: {
-            name: 'test-bucket',
-            objectLockConfiguration: {
-              ObjectLockEnabled: 'Enabled',
-            },
-            versioning: 'Enabled',
-          },
-        },
-      },
     );
-    const tableItems = component.find(T.Row);
-    const eighth = tableItems.at(8);
-    expect(eighth.find(T.Key).text()).toContain('Legal Hold');
-    expect(eighth.find(T.Value).text()).toContain('Active');
+    await waitFor(() =>
+      expect(screen.getByText('Legal Hold')).toBeInTheDocument(),
+    );
+    expect(screen.getByText('Legal Hold')).toBeInTheDocument();
+    expect(screen.getByText('Active')).toBeInTheDocument(); //Todo improve this check, later on we can have more than 1 thing being "Active"
   });
 
   it('should render expected location and temperature field if the location is cold location', async () => {


### PR DESCRIPTION
This pull request has been created automatically.
It is linked to its parent pull request #608.

**Do not edit this pull request directly.**
If you need to amend/cancel the changeset on branch
`w/2.1/bugfix/ZKUI-366`, please follow this
procedure:

```bash
 $ git fetch
 $ git checkout w/2.1/bugfix/ZKUI-366
 $ # <amend or cancel the changeset by _adding_ new commits>
 $ git push origin w/2.1/bugfix/ZKUI-366
```

Please always comment pull request #608 instead of this one.