### PR TITLE
Fix the page fully reload upon token renewal and assume role after account creation

### DIFF
--- a/src/react/account/AccountCreate.tsx
+++ b/src/react/account/AccountCreate.tsx
@@ -17,6 +17,7 @@ import { joiResolver } from '@hookform/resolvers/joi';
 import { useForm } from 'react-hook-form';
 import { useOutsideClick } from '../utils/hooks';
 import { useQueryClient } from 'react-query';
+import { useSetAssumedRole } from '../DataServiceRoleProvider';
 
 const regexpEmailAddress = /^\S+@\S+.\S+$/;
 const regexpName = /^[\w+=,.@ -]+$/;
@@ -59,6 +60,7 @@ function AccountCreate() {
   );
   const dispatch = useDispatch();
   const queryClient = useQueryClient();
+  const setRole = useSetAssumedRole();
   const token = useSelector((state: AppState) => state.oidc.user?.access_token);
   const onSubmit = ({ name, email }: AccountFormField) => {
     clearServerError();
@@ -66,7 +68,7 @@ function AccountCreate() {
       Name: name,
       email,
     };
-    dispatch(createAccount(payload, queryClient, token));
+    dispatch(createAccount(payload, queryClient, token, setRole));
   };
 
   const handleCancel: MouseEventHandler<HTMLButtonElement> = (e) => {

--- a/src/react/utils/hooks.ts
+++ b/src/react/utils/hooks.ts
@@ -203,7 +203,7 @@ export const useAccounts = (
     ApiError
   >(
     {
-      queryKey: ['WebIdentityRoles', token],
+      queryKey: ['WebIdentityRoles'],
       queryFn: () => {
         notifyLoadingAccounts();
         return getRolesForWebIdentity(iamEndpoint, notFalsyTypeGuard(token));


### PR DESCRIPTION
This PR fixed two issues explained below:

1. Zenko UI gets fully reload upon token renewal is caused by the wrongly added `token` within queryKey when fetching `WebIdentityRoles`. However it is totally unnecessary.


2. After account creation, we switch to the new account so we should assume role again which is missing before, cause the issue that we still load the IAM User/ policy of previous account.