### PR TITLE
ZKUI-387: No basepath for development when initing s3 and iam client

### DIFF
--- a/src/react/actions/auth.ts
+++ b/src/react/actions/auth.ts
@@ -97,7 +97,7 @@ export function loadAppConfig(config: AppConfig, user): ThunkNonStateAction {
           config.zenkoEndpoint,
           config.iamInternalFQDN,
           config.s3InternalFQDN,
-          config.basePath,
+          process.env.NODE_ENV === 'development' ? '' : config.basePath,
         ),
       ),
     );

--- a/src/react/next-architecture/ui/S3ClientProvider.tsx
+++ b/src/react/next-architecture/ui/S3ClientProvider.tsx
@@ -51,7 +51,7 @@ export const S3ClientProvider = ({
       s3Config.endpoint,
       iamInternalFQDN,
       s3InternalFQDN,
-      basePath,
+      process.env.NODE_ENV === 'development' ? '' : basePath,
     );
     const iamClient = new IAMClient(iamEndpoint);
 


### PR DESCRIPTION
In order to run all the UIs in local development