### PR TITLE
ARTESCA-11504: Veeam assistant skip message

### DIFF
--- a/src/react/ui-elements/Veeam/VeeamConfiguration.tsx
+++ b/src/react/ui-elements/Veeam/VeeamConfiguration.tsx
@@ -165,11 +165,23 @@ const Configuration = () => {
         close={() => setSkip(false)}
         exitAction={() => history.push('/accounts')}
         modalContent={
-          <Text>
-            Are you sure to skip this config? You’ll be able to go through this
-            flow again (in the Account page if no Account has been created,
-            otherwise on an Account edition page)
-          </Text>
+          <>
+            <Text>You may start again this Veeam configuration flow:</Text>
+            <ul>
+              <ListItem>
+                <Text>
+                  If no accounts are created, on your next login or directly
+                  from the Account page.
+                </Text>
+              </ListItem>
+              <ListItem>
+                <Text>
+                  Otherwise, if there is at least one account, on the Account
+                  list page.
+                </Text>
+              </ListItem>
+            </ul>
+          </>
         }
       />
       <Form

--- a/src/react/ui-elements/Veeam/VeeamSkipModal.tsx
+++ b/src/react/ui-elements/Veeam/VeeamSkipModal.tsx
@@ -41,7 +41,7 @@ export const VeeamSkipModal = ({
                 close();
                 exitAction();
               }}
-              label="Exit"
+              label="Exit configuration"
             />
           </Stack>
         </Wrap>


### PR DESCRIPTION

![Capture d’écran 2024-03-18 à 17 28 38](https://github.com/scality/zenko-ui/assets/135591453/6afa97ca-b021-4e50-9fa6-1eb331c6515c)
This pull request primarily focuses on improving the user interface text and instructions in the Veeam configuration flow. The changes include updating the text in `VeeamConfiguration.tsx` to provide clearer instructions on when to start the configuration flow and modifying the label of a button in `VeeamSkipModal.tsx` to better reflect its functionality.

Here are the key changes:

User interface text and instructions:

* [`src/react/ui-elements/Veeam/VeeamConfiguration.tsx`](diffhunk://#diff-1b4fc2a0632df64956dd1ed77814afc41ffcf9dd304060fa04334bd63e92e379R168-R184): The text in the configuration modal has been updated to provide clearer instructions. The new text explains when the user can start the Veeam configuration flow again, either after next login or directly from the Account page if no account has been created, or from the Account list page if there is at least one account. The previous text has been removed and replaced with a more detailed explanation in a list format.

Button labels:

* [`src/react/ui-elements/Veeam/VeeamSkipModal.tsx`](diffhunk://#diff-89639ec8487ac6a2ad7f7f2367874351828cc03b465ad90243addcdc0add778dL44-R44): The label of the exit button has been changed from "Exit" to "Exit configuration" to better reflect the action performed by the button.