### PR TITLE
fix issue with Tooltip being cut

### DIFF
--- a/src/react/databrowser/objects/ObjectListTable.tsx
+++ b/src/react/databrowser/objects/ObjectListTable.tsx
@@ -5,7 +5,13 @@ import { AutoSizer } from 'react-virtualized';
 import { FixedSizeList } from 'react-window';
 import InfiniteLoader from 'react-window-infinite-loader';
 import { List } from 'immutable';
-import { FormattedDateTime, Icon, PrettyBytes, Text } from '@scality/core-ui';
+import {
+  FormattedDateTime,
+  Icon,
+  PrettyBytes,
+  Text,
+  Wrap,
+} from '@scality/core-ui';
 import { convertRemToPixels } from '@scality/core-ui/dist/utils';
 import { spacing } from '@scality/core-ui';
 import { useHistory, useParams } from 'react-router-dom';
@@ -190,7 +196,7 @@ export default function ObjectListTable({
           if (original.isFolder) {
             return (
               <span>
-                <Icon name="Folder" />
+                <Icon style={{ marginRight: spacing.r4 }} name="Folder" />
                 <T.CellClick
                   onClick={handleCellClicked(bucketName, original.key)}
                 >
@@ -321,10 +327,10 @@ export default function ObjectListTable({
               (location) => location.name === storageClass,
             )?.isCold;
           return (
-            <div>
-              {isObjectInColdStorage ? <ColdStorageIcon /> : ''}{' '}
+            <Wrap style={{ alignItems: 'center' }}>
+              {isObjectInColdStorage ? <ColdStorageIcon /> : <p></p>}
               {storageClass === 'STANDARD' ? 'default' : storageClass}
-            </div>
+            </Wrap>
           );
         },
         cellStyle: {

--- a/src/react/ui-elements/ColdStorageIcon.tsx
+++ b/src/react/ui-elements/ColdStorageIcon.tsx
@@ -4,7 +4,7 @@ const ColdStorageTemperatureToolTip = () => {
   return (
     <IconHelp
       placement="top"
-      overlayStyle={{ width: '24rem' }}
+      overlayStyle={{ textWrap: 'wrap', width: '24rem', textAlign: 'left' }}
       tooltipMessage={
         <>
           The Temperature of this Location is Cold.


### PR DESCRIPTION
Fix cold storage being cut in object list (add textwrap and align left)
Bonus : 
- Add margin after folder icon
- improve display of storage cell)

![Modified on](https://github.com/user-attachments/assets/e1e6efd5-57f0-47a3-bce3-9813952a08a3)
![image](https://github.com/user-attachments/assets/26d307cd-af74-4779-adfc-fbe4a4ea6154)
