### PR TITLE
Feature/artesca 16254 reorder and adjust the location type dropdown display

### DIFF
--- a/src/react/locations/LocationDetails/storageOptions.ts
+++ b/src/react/locations/LocationDetails/storageOptions.ts
@@ -33,6 +33,7 @@ export type StorageOptionValues = {
   ingestCapability?: string;
   hidden?: boolean;
   supportsVersion?: string;
+  category?: 'crr' | 'scality' | 'public-cloud' | 'on-prem';
 };
 export const storageOptions: Record<LocationTypeKey, StorageOptionValues> = {
   'location-scality-crr-v1': {
@@ -43,6 +44,7 @@ export const storageOptions: Record<LocationTypeKey, StorageOptionValues> = {
     supportsReplicationTarget: true,
     supportsReplicationSource: false,
     hasIcon: false,
+    category: 'crr',
   },
   'location-scality-hdclient-v2': {
     name: 'Storage Service for ARTESCA',
@@ -53,6 +55,7 @@ export const storageOptions: Record<LocationTypeKey, StorageOptionValues> = {
     supportsReplicationSource: true,
     hasIcon: false,
     checkCapability: 'locationTypeHyperdriveV2',
+    category: 'scality',
   },
   'location-scality-artesca-s3-v1': {
     name: 'Scality ARTESCA S3',
@@ -63,6 +66,7 @@ export const storageOptions: Record<LocationTypeKey, StorageOptionValues> = {
     supportsReplicationSource: true,
     hasIcon: false,
     checkCapability: 'locationTypeS3Custom',
+    category: 'scality',
   },
   'location-scality-ring-s3-v1': {
     name: 'Scality RING with S3 Connector',
@@ -74,6 +78,7 @@ export const storageOptions: Record<LocationTypeKey, StorageOptionValues> = {
     hasIcon: false,
     checkCapability: 'locationTypeS3Custom',
     ingestCapability: 's3cIngestLocation',
+    category: 'scality',
   },
   'location-aws-s3-v1': {
     name: 'Amazon S3',
@@ -84,6 +89,7 @@ export const storageOptions: Record<LocationTypeKey, StorageOptionValues> = {
     supportsReplicationSource: true,
     hasIcon: false,
     ingestCapability: 'awsIngestLocation',
+    category: 'public-cloud',
   },
   'location-gcp-v1': {
     name: 'Google Cloud Storage',
@@ -93,6 +99,7 @@ export const storageOptions: Record<LocationTypeKey, StorageOptionValues> = {
     supportsReplicationTarget: true,
     supportsReplicationSource: false,
     hasIcon: false,
+    category: 'public-cloud',
   },
   'location-azure-v1': {
     name: 'Microsoft Azure Blob Storage',
@@ -102,6 +109,7 @@ export const storageOptions: Record<LocationTypeKey, StorageOptionValues> = {
     supportsReplicationTarget: true,
     supportsReplicationSource: false,
     hasIcon: false,
+    category: 'public-cloud',
   },
   'location-azure-archive-v1': {
     name: 'Microsoft Azure Archive',
@@ -111,6 +119,7 @@ export const storageOptions: Record<LocationTypeKey, StorageOptionValues> = {
     supportsReplicationTarget: true,
     supportsReplicationSource: false,
     hasIcon: false,
+    category: 'public-cloud',
   },
   [JAGUAR_S3_LOCATION_KEY]: {
     name: 'Atlas Object Storage (Free Pro)',
@@ -121,6 +130,7 @@ export const storageOptions: Record<LocationTypeKey, StorageOptionValues> = {
     supportsReplicationSource: true,
     hasIcon: false,
     checkCapability: 'locationTypeS3Custom',
+    category: 'public-cloud',
   },
   [OUTSCALE_PUBLIC_S3_LOCATION_KEY]: {
     name: '3DS Outscale OOS Public',
@@ -131,6 +141,7 @@ export const storageOptions: Record<LocationTypeKey, StorageOptionValues> = {
     supportsReplicationSource: true,
     hasIcon: false,
     checkCapability: 'locationTypeS3Custom',
+    category: 'public-cloud',
   },
   [OUTSCALE_SNC_S3_LOCATION_KEY]: {
     name: '3DS Outscale OOS SNC',
@@ -141,6 +152,7 @@ export const storageOptions: Record<LocationTypeKey, StorageOptionValues> = {
     supportsReplicationSource: true,
     hasIcon: false,
     checkCapability: 'locationTypeS3Custom',
+    category: 'public-cloud',
   },
   [ORANGE_S3_LOCATION_KEY]: {
     name: 'Flexible Datastore',
@@ -151,6 +163,7 @@ export const storageOptions: Record<LocationTypeKey, StorageOptionValues> = {
     supportsReplicationSource: true,
     hasIcon: false,
     checkCapability: 'locationTypeS3Custom',
+    category: 'public-cloud',
   },
   'location-dmf-v1': {
     name: 'Tape DMF',
@@ -160,6 +173,7 @@ export const storageOptions: Record<LocationTypeKey, StorageOptionValues> = {
     supportsReplicationTarget: false,
     supportsReplicationSource: true,
     hasIcon: false,
+    category: 'on-prem',
   },
   'location-miria-v1': {
     name: 'Tape Atempo Miria',
@@ -169,6 +183,7 @@ export const storageOptions: Record<LocationTypeKey, StorageOptionValues> = {
     supportsReplicationTarget: false,
     supportsReplicationSource: true,
     hasIcon: false,
+    category: 'on-prem',
   },
   'location-file-v1': {
     name: 'Local Filesystem',
@@ -180,6 +195,7 @@ export const storageOptions: Record<LocationTypeKey, StorageOptionValues> = {
     hasIcon: false,
     checkCapability: 'locationTypeLocal',
     hidden: true,
+    category: 'on-prem',
   },
   'location-ceph-radosgw-s3-v1': {
     name: 'Ceph RADOS Gateway',
@@ -192,6 +208,7 @@ export const storageOptions: Record<LocationTypeKey, StorageOptionValues> = {
     checkCapability: 'locationTypeCephRadosGW',
     ingestCapability: 'cephIngestLocation',
     hidden: false,
+    category: 'on-prem',
   },
   'location-do-spaces-v1': {
     name: 'DigitalOcean Spaces',
@@ -203,6 +220,7 @@ export const storageOptions: Record<LocationTypeKey, StorageOptionValues> = {
     hasIcon: false,
     checkCapability: 'locationTypeDigitalOcean',
     hidden: true,
+    category: 'public-cloud',
   },
   'location-nfs-mount-v1': {
     name: 'NFS Mount',
@@ -215,6 +233,7 @@ export const storageOptions: Record<LocationTypeKey, StorageOptionValues> = {
     checkCapability: 'locationTypeNFS',
     ingestCapability: 'nfsIngestLocation',
     hidden: true,
+    category: 'on-prem',
   },
   'location-scality-sproxyd-v1': {
     name: 'Scality RING with Sproxyd Connector',
@@ -225,6 +244,7 @@ export const storageOptions: Record<LocationTypeKey, StorageOptionValues> = {
     supportsReplicationSource: true,
     hasIcon: false,
     checkCapability: 'locationTypeSproxyd',
+    category: 'on-prem',
   },
   'location-wasabi-v1': {
     name: 'Wasabi',
@@ -234,6 +254,7 @@ export const storageOptions: Record<LocationTypeKey, StorageOptionValues> = {
     supportsReplicationTarget: true,
     supportsReplicationSource: true,
     hasIcon: false,
+    category: 'public-cloud',
   },
   'location-oracle-ring-s3-v1': {
     name: 'Oracle Cloud Object Storage',
@@ -244,5 +265,6 @@ export const storageOptions: Record<LocationTypeKey, StorageOptionValues> = {
     supportsReplicationSource: true,
     hasIcon: false,
     checkCapability: 'locationTypeS3Custom',
+    category: 'public-cloud',
   },
 };

--- a/src/react/locations/LocationEditor.tsx
+++ b/src/react/locations/LocationEditor.tsx
@@ -46,6 +46,13 @@ const StyledForm = styled(Form)`
   height: calc(100vh - 48px);
 `;
 
+const StyledSelect = styled(Select)`
+  .sc-select__option--is-disabled > * {
+    font-style: italic !important;
+    padding-left: 4px !important;
+  }
+`;
+
 const makeLabel = (locationType: LocationTypeKey) => {
   const details = storageOptions[locationType];
   return details.name;
@@ -376,7 +383,7 @@ function LocationEditor() {
           required
           label="Location Type"
           content={
-            <Select
+            <StyledSelect
               id="locationType"
               placeholder="Select a location type..."
               onChange={onTypeChange}
@@ -385,24 +392,24 @@ function LocationEditor() {
               value={locationTypeKey}
             >
               {selectOptionsGrouped.flatMap((group, groupIndex) => [
-                <Select.Option
+                <StyledSelect.Option
                   key={`group-${groupIndex}`}
                   value={`__group_${groupIndex}__`}
                   disabled={true}
                 >
                   {group.label}
-                </Select.Option>,
+                </StyledSelect.Option>,
                 ...group.options.map((opt, i) => (
-                  <Select.Option
+                  <StyledSelect.Option
                     key={`${groupIndex}-${i}`}
                     value={opt.value}
                     disabled={opt.disabled}
                   >
                     {opt.label}
-                  </Select.Option>
+                  </StyledSelect.Option>
                 )),
               ])}
-            </Select>
+            </StyledSelect>
           }
         />
       </FormSection>

--- a/src/react/locations/LocationEditor.tsx
+++ b/src/react/locations/LocationEditor.tsx
@@ -25,7 +25,7 @@ import { useInstanceId } from '../next-architecture/ui/AuthProvider';
 import Loader from '../ui-elements/Loader';
 import {
   getLocationTypeKey,
-  selectStorageOptions,
+  selectStorageOptionsGrouped,
 } from '../utils/storageOptions';
 import { LocationDetails, storageOptions } from './LocationDetails';
 import LocationOptions from './LocationOptions';
@@ -74,28 +74,13 @@ function LocationEditor() {
   const [location, setLocation] = useState(
     convertToForm({ ...newLocationDetails(), ...locationEditing }),
   );
-  const selectOptions = useMemo(() => {
-    const options = selectStorageOptions(
+  const selectOptionsGrouped = useMemo(() => {
+    return selectStorageOptionsGrouped(
       capabilities,
       locations,
       makeLabel,
       !editingExisting,
     );
-
-    const hasOthersOption = options.some((opt) => opt.label === 'Others');
-    if (options.length > 0 && !hasOthersOption) {
-      return [
-        options[0],
-        {
-          label: 'Others',
-          value: 'others',
-          disabled: true,
-        },
-        ...options.slice(1),
-      ];
-    }
-
-    return options;
   }, [capabilities, editingExisting, locations]);
   useMemo(() => {
     if (locationEditing) {
@@ -399,15 +384,24 @@ function LocationEditor() {
               //@ts-expect-error fix this when you are working on it
               value={locationTypeKey}
             >
-              {selectOptions.map((opt, i) => (
+              {selectOptionsGrouped.flatMap((group, groupIndex) => [
                 <Select.Option
-                  key={i}
-                  value={opt.value}
-                  disabled={opt.disabled}
+                  key={`group-${groupIndex}`}
+                  value={`__group_${groupIndex}__`}
+                  disabled={true}
                 >
-                  {opt.label}
-                </Select.Option>
-              ))}
+                  {group.label}
+                </Select.Option>,
+                ...group.options.map((opt, i) => (
+                  <Select.Option
+                    key={`${groupIndex}-${i}`}
+                    value={opt.value}
+                    disabled={opt.disabled}
+                  >
+                    {opt.label}
+                  </Select.Option>
+                )),
+              ])}
             </Select>
           }
         />

--- a/src/react/locations/__tests__/LocationEditor.test.tsx
+++ b/src/react/locations/__tests__/LocationEditor.test.tsx
@@ -78,12 +78,14 @@ describe('LocationEditor', () => {
     await userEvent.keyboard('{arrowup}');
     expect(
       container.querySelector('.sc-select__option--is-focused')?.textContent,
-    ).toBe('Cross-Region Replication');
+    ).toBe('CRR Location');
 
     [
-      'Others',
+      'Cross-Region Replication',
+      'Scality S3 Locations',
       'Scality ARTESCA S3',
       'Scality RING with S3 Connector',
+      'Public Cloud Locations',
       'Amazon S3',
       'Google Cloud Storage',
       'Microsoft Azure Blob Storage',
@@ -92,7 +94,13 @@ describe('LocationEditor', () => {
       '3DS Outscale OOS Public',
       '3DS Outscale OOS SNC',
       'Flexible Datastore',
+      'Wasabi',
+      'Oracle Cloud Object Storage',
+      'On Prem Locations',
       'Tape DMF',
+      'Tape Atempo Miria',
+      'Ceph RADOS Gateway',
+      'Scality RING with Sproxyd Connector',
     ].forEach((locationName) => {
       fireEvent.keyDown(selector, { key: 'ArrowDown', which: 40, keyCode: 40 });
       expect(

--- a/src/react/utils/storageOptions.ts
+++ b/src/react/utils/storageOptions.ts
@@ -106,6 +106,18 @@ export const getLocationTypeShort = (
   return storageLocation?.short ?? '';
 };
 
+export type GroupedStorageOption = {
+  label: string;
+  options: Array<StorageOptionSelect>;
+};
+
+const categoryLabels = {
+  'crr': 'CRR Location',
+  'scality': 'Scality S3 Locations',
+  'public-cloud': 'Public Cloud Locations',
+  'on-prem': 'On Prem Locations',
+};
+
 export function selectStorageOptions(
   capabilities: Capabilities,
   locations?: LocationInfo[],
@@ -136,8 +148,33 @@ export function selectStorageOptions(
         value: o,
         label: labelFn ? labelFn(o) : o,
         disabled: !!check && !!capabilities && !capabilities[check],
+        category: storageOptions[o].category,
       };
     });
+}
+
+export function selectStorageOptionsGrouped(
+  capabilities: Capabilities,
+  locations?: LocationInfo[],
+  labelFn?: LabelFunction,
+  exceptHidden = true,
+): Array<GroupedStorageOption> {
+  const options = selectStorageOptions(capabilities, locations, labelFn, exceptHidden);
+  
+  const groupedOptions: Array<GroupedStorageOption> = [];
+  const categoryOrder: Array<'crr' | 'scality' | 'public-cloud' | 'on-prem'> = ['crr', 'scality', 'public-cloud', 'on-prem'];
+  
+  categoryOrder.forEach((category) => {
+    const categoryOptions = options.filter((opt) => opt.category === category);
+    if (categoryOptions.length > 0) {
+      groupedOptions.push({
+        label: categoryLabels[category],
+        options: categoryOptions,
+      });
+    }
+  });
+  
+  return groupedOptions;
 }
 export function isIngestLocation(location, capabilities) {
   const locationType = location.locationType || location.type;

--- a/src/types/storageOptionsHelper.ts
+++ b/src/types/storageOptionsHelper.ts
@@ -3,4 +3,5 @@ export type StorageOptionSelect = {
   value: string;
   label: string;
   disabled: boolean;
+  category?: 'crr' | 'scality' | 'public-cloud' | 'on-prem';
 };


### PR DESCRIPTION
# Storage Options Grouped by Category

**CRR Location**
  - Cross-Region Replication
  - Scality S3 Locations
  - Storage Service for ARTESCA
  - Scality ARTESCA S3
  - Scality RING with S3 Connector

**Public Cloud Locations**
  - Amazon S3
  - Google Cloud Storage
  - Microsoft Azure Blob Storage
  - Microsoft Azure Archive
  - Atlas Object Storage (Free Pro)
  - 3DS Outscale OOS Public
  - 3DS Outscale OOS SNC
  - Flexible Datastore
  - Wasabi
  - Oracle Cloud Object Storage

**On Prem Locations**
  - Tape DMF
  - Tape Atempo Miria
  - Ceph RADOS Gateway
  - Scality RING with Sproxyd Connector