### PR TITLE
Download certificate in modal

### DIFF
--- a/src/react/truststore/CertificateDetails.tsx
+++ b/src/react/truststore/CertificateDetails.tsx
@@ -1,11 +1,11 @@
-import { ConstrainedText, Modal, Stack, Text } from '@scality/core-ui';
+import { ConstrainedText, Icon, Modal, Stack, Text } from '@scality/core-ui';
 import React from 'react';
 import { ModalBody } from '../ui-elements/Modal';
 import { ParsedCertificate } from '@scality/certchain';
 import styled from 'styled-components';
 import { Box, CopyButton } from '@scality/core-ui/dist/next';
 import { Button } from '@scality/core-ui/dist/components/buttonv2/Buttonv2.component';
-import { formatExpiryDate } from './utils';
+import { downloadCertificate, formatExpiryDate } from './utils';
 
 const CertificateViewFieldWrapper = styled.div`
   width: 12rem;
@@ -172,20 +172,40 @@ const CertificateDetails = ({
               gap="r16"
               key={`${certificate.name}-${index}`}
             >
-              <Text
-                isEmphazed
-                color="textPrimary"
+              <Box
                 style={{
-                  textAlign: 'center',
-                  paddingBottom: '1rem',
+                  marginBottom: '0.5rem',
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'center',
+                  height: '2rem',
+                  position: 'relative',
                 }}
               >
-                {`${certificate.name}`}
-                {selectedCertificate.length > 1 &&
-                selectedCertificate.length === index + 1
-                  ? ' (Root certificate)'
-                  : ''}
-              </Text>
+                <Box position="absolute" style={{ top: 0, right: 0 }}>
+                  <Button
+                    icon={<Icon name="Download" />}
+                    variant="secondary"
+                    onClick={() => downloadCertificate(certificate)}
+                    tooltip={{
+                      overlay: `Download ${certificate.name} certificate`,
+                    }}
+                  />
+                </Box>
+                <Text
+                  isEmphazed
+                  color="textPrimary"
+                  style={{
+                    textAlign: 'center',
+                  }}
+                >
+                  {`${certificate.name}`}
+                  {selectedCertificate.length > 1 &&
+                  selectedCertificate.length === index + 1
+                    ? ' (Root certificate)'
+                    : ''}
+                </Text>
+              </Box>
               {certificatePropertiesWithLabels.map((property) => (
                 <CertificateDetailRow
                   key={property.property + index}

--- a/src/react/truststore/Truststore.tsx
+++ b/src/react/truststore/Truststore.tsx
@@ -1,4 +1,3 @@
-import { ParsedCertificate } from '@scality/certchain';
 import {
   AppContainer,
   Icon,
@@ -24,13 +23,14 @@ import { getZenkoCRQuery } from '../queries';
 import { TableHeaderWrapper } from '../ui-elements/Table';
 import CertificateDetails from './CertificateDetails';
 import {
+  CertificateWithPEM,
   useParseBundleCertificates,
   useParseSecretCertificates,
 } from './hooks';
 import { formatExpiryDate } from './utils';
 
 const formatCertificateDataForTable = (
-  parsedCertificates: ParsedCertificate[][],
+  parsedCertificates: CertificateWithPEM[][],
 ) => {
   const formattedCertificateData: CertificateData[] = parsedCertificates.map(
     (certificateBundle) => {
@@ -53,7 +53,7 @@ const formatCertificateDataForTable = (
 type CertificateData = {
   metadata: string[];
   expireOn: Date[];
-  certificates: ParsedCertificate[];
+  certificates: CertificateWithPEM[];
 };
 
 const skipTLSVerificationTooltipMessage = (
@@ -86,7 +86,7 @@ const Truststore = () => {
   const [isCertificateDetailsModalOpen, setIsCertificateDetailsModalOpen] =
     useState(false);
   const [selectedCertificate, setSelectedCertificate] = useState<
-    ParsedCertificate[] | null
+    CertificateWithPEM[] | null
   >(null);
   const navigate = useBasenameRelativeNavigate();
   const {

--- a/src/react/truststore/__tests__/CertificateDetails.test.tsx
+++ b/src/react/truststore/__tests__/CertificateDetails.test.tsx
@@ -51,6 +51,11 @@ describe('CertificateDetails', () => {
       screen.getByText('TEST CERTIFICATE COMMON NAME'),
     ).toBeInTheDocument();
     expect(screen.getByText('Test CA')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: /Download TEST CERTIFICATE NAME certificate/i,
+      }),
+    ).toBeInTheDocument();
   });
 
   it('should not render modal when closed', () => {

--- a/src/react/truststore/__tests__/Truststore.test.tsx
+++ b/src/react/truststore/__tests__/Truststore.test.tsx
@@ -11,6 +11,7 @@ import {
 import {
   useParseBundleCertificates,
   useParseSecretCertificates,
+  CertificateWithPEM,
 } from '../hooks';
 import { ParsedCertificate } from '@scality/certchain';
 import { debug } from 'jest-preview';
@@ -53,8 +54,12 @@ describe('Truststore', () => {
       screen.getByRole('button', { name: /View Details/i }),
     deleteButton: () => screen.getByRole('button', { name: /Delete/i }),
   };
+
+  const MOCK_PEM_CERT =
+    '-----BEGIN CERTIFICATE-----\nMockCert1\n-----END CERTIFICATE-----';
+
   const now = new Date();
-  const mockCertificate1: ParsedCertificate = {
+  const mockCertificate1: CertificateWithPEM = {
     name: 'Test Certificate 1',
     authority: 'Test Authority 1',
     expiresOn: new Date('2026-10-05T00:00:00Z'),
@@ -72,6 +77,7 @@ describe('Truststore', () => {
     certificateHash: 'abc123',
     publicKey:
       '-----BEGIN PUBLIC KEY-----\nMockPublicKey1\n-----END PUBLIC KEY-----',
+    originalPEM: MOCK_PEM_CERT,
   };
 
   // Mock Zenko CR data with certificates
@@ -267,12 +273,13 @@ describe('Truststore', () => {
 
   it('should display earliest expiration date when multiple certificates in chain', async () => {
     //S
-    const mockCertificate2: ParsedCertificate = {
+    const mockCertificate2: CertificateWithPEM = {
       ...mockCertificate1,
       name: 'Root CA',
       authority: 'Root CA',
       expiresOn: new Date(2035, 10, 6), // Later than mockCertificate1
       commonName: 'root.example.com',
+      originalPEM: MOCK_PEM_CERT,
     };
 
     mockUseParseBundleCertificates.mockReturnValue({
@@ -298,11 +305,12 @@ describe('Truststore', () => {
 
   it('should display certificate common names with chevron separators', async () => {
     //S
-    const mockCertificate2: ParsedCertificate = {
+    const mockCertificate2: CertificateWithPEM = {
       ...mockCertificate1,
       name: 'Intermediate CA',
       authority: 'Root CA',
       commonName: 'intermediate.example.com',
+      originalPEM: MOCK_PEM_CERT,
     };
 
     mockUseParseBundleCertificates.mockReturnValue({

--- a/src/react/truststore/__tests__/hooks.test.ts
+++ b/src/react/truststore/__tests__/hooks.test.ts
@@ -66,6 +66,16 @@ const mockCertificate2: ParsedCertificate = {
     '-----BEGIN PUBLIC KEY-----\nMockPublicKey2\n-----END PUBLIC KEY----- ',
 };
 
+// Common PEM certificate strings used across tests
+const MOCK_PEM_CERT_1 =
+  '-----BEGIN CERTIFICATE-----\nMockCert1\n-----END CERTIFICATE-----';
+const MOCK_PEM_CERT_2 =
+  '-----BEGIN CERTIFICATE-----\nMockCert2\n-----END CERTIFICATE-----';
+const MOCK_PEM_INVALID =
+  '-----BEGIN CERTIFICATE-----\nInvalidCert\n-----END CERTIFICATE-----';
+const MOCK_PEM_BUNDLE_CERT =
+  '-----BEGIN CERTIFICATE-----\nBundleCert\n-----END CERTIFICATE-----';
+
 describe('useParseBundleCertificates', () => {
   beforeEach(() => {
     jest.clearAllMocks();
@@ -80,8 +90,7 @@ describe('useParseBundleCertificates', () => {
 
   it('should parse a single certificate bundle successfully', async () => {
     const mockCertificateBundle = {
-      'ca.crt':
-        '-----BEGIN CERTIFICATE-----\nMockCert1\n-----END CERTIFICATE-----',
+      'ca.crt': MOCK_PEM_CERT_1,
     };
 
     const certificateBundles: ZenkoCRCertificateBundle[] = [
@@ -90,7 +99,7 @@ describe('useParseBundleCertificates', () => {
 
     mockExtractPemParts.mockReturnValue([
       {
-        pem: '-----BEGIN CERTIFICATE-----\nMockCert1\n-----END CERTIFICATE-----',
+        pem: MOCK_PEM_CERT_1,
         base64Cert: 'MockCert1',
       },
     ]);
@@ -107,23 +116,21 @@ describe('useParseBundleCertificates', () => {
       expect(result.current.isLoading).toBe(false);
     });
 
-    expect(result.current.parsedCertificates).toEqual([[mockCertificate1]]);
+    expect(result.current.parsedCertificates).toEqual([
+      [{ ...mockCertificate1, originalPEM: MOCK_PEM_CERT_1 }],
+    ]);
     expect(mockExtractPemParts).toHaveBeenCalledWith(
       mockCertificateBundle['ca.crt'],
     );
-    expect(mockParseCertificateFromPEM).toHaveBeenCalledWith(
-      '-----BEGIN CERTIFICATE-----\nMockCert1\n-----END CERTIFICATE-----',
-    );
+    expect(mockParseCertificateFromPEM).toHaveBeenCalledWith(MOCK_PEM_CERT_1);
   });
 
   it('should parse multiple certificate bundles successfully', async () => {
     const mockCertificateBundle1 = {
-      'ca.crt':
-        '-----BEGIN CERTIFICATE-----\nMockCert1\n-----END CERTIFICATE-----',
+      'ca.crt': MOCK_PEM_CERT_1,
     };
     const mockCertificateBundle2 = {
-      'ca.crt':
-        '-----BEGIN CERTIFICATE-----\nMockCert2\n-----END CERTIFICATE-----',
+      'ca.crt': MOCK_PEM_CERT_2,
     };
 
     const certificateBundles: ZenkoCRCertificateBundle[] = [
@@ -135,13 +142,13 @@ describe('useParseBundleCertificates', () => {
     mockExtractPemParts
       .mockReturnValueOnce([
         {
-          pem: '-----BEGIN CERTIFICATE-----\nMockCert1\n-----END CERTIFICATE-----',
+          pem: MOCK_PEM_CERT_1,
           base64Cert: 'MockCert1',
         },
       ])
       .mockReturnValueOnce([
         {
-          pem: '-----BEGIN CERTIFICATE-----\nMockCert2\n-----END CERTIFICATE-----',
+          pem: MOCK_PEM_CERT_2,
           base64Cert: 'MockCert2',
         },
       ]);
@@ -159,15 +166,14 @@ describe('useParseBundleCertificates', () => {
     });
 
     expect(result.current.parsedCertificates).toEqual([
-      [mockCertificate1],
-      [mockCertificate2],
+      [{ ...mockCertificate1, originalPEM: MOCK_PEM_CERT_1 }],
+      [{ ...mockCertificate2, originalPEM: MOCK_PEM_CERT_2 }],
     ]);
   });
 
   it('should parse a bundle with multiple certificates (certificate chain)', async () => {
     const mockCertificateBundle = {
-      'ca.crt':
-        '-----BEGIN CERTIFICATE-----\nMockCert1\n-----END CERTIFICATE-----\n-----BEGIN CERTIFICATE-----\nMockCert2\n-----END CERTIFICATE-----',
+      'ca.crt': `${MOCK_PEM_CERT_1}\n${MOCK_PEM_CERT_2}`,
     };
 
     const certificateBundles: ZenkoCRCertificateBundle[] = [
@@ -177,11 +183,11 @@ describe('useParseBundleCertificates', () => {
     // Setup mocks - extractPemParts returns 2 certificates from 1 bundle
     mockExtractPemParts.mockReturnValue([
       {
-        pem: '-----BEGIN CERTIFICATE-----\nMockCert1\n-----END CERTIFICATE-----',
+        pem: MOCK_PEM_CERT_1,
         base64Cert: 'MockCert1',
       },
       {
-        pem: '-----BEGIN CERTIFICATE-----\nMockCert2\n-----END CERTIFICATE-----',
+        pem: MOCK_PEM_CERT_2,
         base64Cert: 'MockCert2',
       },
     ]);
@@ -199,14 +205,16 @@ describe('useParseBundleCertificates', () => {
     });
 
     expect(result.current.parsedCertificates).toEqual([
-      [mockCertificate1, mockCertificate2],
+      [
+        { ...mockCertificate1, originalPEM: MOCK_PEM_CERT_1 },
+        { ...mockCertificate2, originalPEM: MOCK_PEM_CERT_2 },
+      ],
     ]);
   });
 
   it('should handle parsing errors', async () => {
     const mockCertificateBundle = {
-      'ca.crt':
-        '-----BEGIN CERTIFICATE-----\nInvalidCert\n-----END CERTIFICATE-----',
+      'ca.crt': MOCK_PEM_INVALID,
     };
 
     const consoleErrorSpy = jest
@@ -220,7 +228,7 @@ describe('useParseBundleCertificates', () => {
     // Setup mocks to throw error
     mockExtractPemParts.mockReturnValue([
       {
-        pem: '-----BEGIN CERTIFICATE-----\nInvalidCert\n-----END CERTIFICATE-----',
+        pem: MOCK_PEM_INVALID,
         base64Cert: 'InvalidCert',
       },
     ]);
@@ -280,9 +288,7 @@ describe('useParseSecretCertificates', () => {
     ];
 
     // Base64 encoded PEM certificate
-    const certificatePEM =
-      '-----BEGIN CERTIFICATE-----\nMockCert1\n-----END CERTIFICATE-----';
-    const base64Cert = Buffer.from(certificatePEM).toString('base64');
+    const base64Cert = Buffer.from(MOCK_PEM_CERT_1).toString('base64');
 
     mockUseK8sSecretQueries.mockReturnValue({
       status: 'success',
@@ -309,7 +315,7 @@ describe('useParseSecretCertificates', () => {
 
     mockExtractPemParts.mockReturnValue([
       {
-        pem: certificatePEM,
+        pem: MOCK_PEM_CERT_1,
         base64Cert: 'MockCert1',
       },
     ]);
@@ -321,13 +327,13 @@ describe('useParseSecretCertificates', () => {
 
     await waitFor(() => {
       expect(result.current.parsedSecretCertificates).toEqual([
-        [mockCertificate1],
+        [{ ...mockCertificate1, originalPEM: MOCK_PEM_CERT_1 }],
       ]);
     });
 
     expect(result.current.isLoading).toBe(false);
-    expect(mockExtractPemParts).toHaveBeenCalledWith(certificatePEM);
-    expect(mockParseCertificateFromPEM).toHaveBeenCalledWith(certificatePEM);
+    expect(mockExtractPemParts).toHaveBeenCalledWith(MOCK_PEM_CERT_1);
+    expect(mockParseCertificateFromPEM).toHaveBeenCalledWith(MOCK_PEM_CERT_1);
   });
 
   it('should parse multiple secret certificates successfully', async () => {
@@ -342,12 +348,8 @@ describe('useParseSecretCertificates', () => {
       },
     ];
 
-    const certificatePEM1 =
-      '-----BEGIN CERTIFICATE-----\nMockCert1\n-----END CERTIFICATE-----';
-    const certificatePEM2 =
-      '-----BEGIN CERTIFICATE-----\nMockCert2\n-----END CERTIFICATE-----';
-    const base64Cert1 = Buffer.from(certificatePEM1).toString('base64');
-    const base64Cert2 = Buffer.from(certificatePEM2).toString('base64');
+    const base64Cert1 = Buffer.from(MOCK_PEM_CERT_1).toString('base64');
+    const base64Cert2 = Buffer.from(MOCK_PEM_CERT_2).toString('base64');
 
     mockUseK8sSecretQueries.mockReturnValue({
       status: 'success',
@@ -380,13 +382,13 @@ describe('useParseSecretCertificates', () => {
     mockExtractPemParts
       .mockReturnValueOnce([
         {
-          pem: certificatePEM1,
+          pem: MOCK_PEM_CERT_1,
           base64Cert: 'MockCert1',
         },
       ])
       .mockReturnValueOnce([
         {
-          pem: certificatePEM2,
+          pem: MOCK_PEM_CERT_2,
           base64Cert: 'MockCert2',
         },
       ]);
@@ -401,8 +403,8 @@ describe('useParseSecretCertificates', () => {
 
     await waitFor(() => {
       expect(result.current.parsedSecretCertificates).toEqual([
-        [mockCertificate1],
-        [mockCertificate2],
+        [{ ...mockCertificate1, originalPEM: MOCK_PEM_CERT_1 }],
+        [{ ...mockCertificate2, originalPEM: MOCK_PEM_CERT_2 }],
       ]);
     });
 
@@ -417,9 +419,7 @@ describe('useParseSecretCertificates', () => {
       },
     ];
 
-    const certificatePEM =
-      '-----BEGIN CERTIFICATE-----\nMockCert1\n-----END CERTIFICATE-----';
-    const base64Cert = Buffer.from(certificatePEM).toString('base64');
+    const base64Cert = Buffer.from(MOCK_PEM_CERT_1).toString('base64');
 
     mockUseK8sSecretQueries.mockReturnValue({
       status: 'success',
@@ -446,7 +446,7 @@ describe('useParseSecretCertificates', () => {
 
     mockExtractPemParts.mockReturnValue([
       {
-        pem: certificatePEM,
+        pem: MOCK_PEM_CERT_1,
         base64Cert: 'MockCert1',
       },
     ]);
@@ -458,7 +458,7 @@ describe('useParseSecretCertificates', () => {
 
     await waitFor(() => {
       expect(result.current.parsedSecretCertificates).toEqual([
-        [mockCertificate1],
+        [{ ...mockCertificate1, originalPEM: MOCK_PEM_CERT_1 }],
       ]);
     });
 
@@ -473,9 +473,7 @@ describe('useParseSecretCertificates', () => {
       },
     ];
 
-    const certificatePEM =
-      '-----BEGIN CERTIFICATE-----\nMockCert1\n-----END CERTIFICATE-----\n' +
-      '-----BEGIN CERTIFICATE-----\nMockCert2\n-----END CERTIFICATE-----';
+    const certificatePEM = `${MOCK_PEM_CERT_1}\n${MOCK_PEM_CERT_2}`;
     const base64Cert = Buffer.from(certificatePEM).toString('base64');
 
     mockUseK8sSecretQueries.mockReturnValue({
@@ -504,11 +502,11 @@ describe('useParseSecretCertificates', () => {
     // extractPemParts returns 2 certificates from 1 bundle
     mockExtractPemParts.mockReturnValue([
       {
-        pem: '-----BEGIN CERTIFICATE-----\nMockCert1\n-----END CERTIFICATE-----',
+        pem: MOCK_PEM_CERT_1,
         base64Cert: 'MockCert1',
       },
       {
-        pem: '-----BEGIN CERTIFICATE-----\nMockCert2\n-----END CERTIFICATE-----',
+        pem: MOCK_PEM_CERT_2,
         base64Cert: 'MockCert2',
       },
     ]);
@@ -523,7 +521,10 @@ describe('useParseSecretCertificates', () => {
 
     await waitFor(() => {
       expect(result.current.parsedSecretCertificates).toEqual([
-        [mockCertificate1, mockCertificate2],
+        [
+          { ...mockCertificate1, originalPEM: MOCK_PEM_CERT_1 },
+          { ...mockCertificate2, originalPEM: MOCK_PEM_CERT_2 },
+        ],
       ]);
     });
 
@@ -699,9 +700,7 @@ describe('useParseSecretCertificates', () => {
       .spyOn(console, 'error')
       .mockImplementation(() => {});
 
-    const certificatePEM =
-      '-----BEGIN CERTIFICATE-----\nInvalidCert\n-----END CERTIFICATE-----';
-    const base64Cert = Buffer.from(certificatePEM).toString('base64');
+    const base64Cert = Buffer.from(MOCK_PEM_INVALID).toString('base64');
 
     mockUseK8sSecretQueries.mockReturnValue({
       status: 'success',
@@ -728,7 +727,7 @@ describe('useParseSecretCertificates', () => {
 
     mockExtractPemParts.mockReturnValue([
       {
-        pem: certificatePEM,
+        pem: MOCK_PEM_INVALID,
         base64Cert: 'InvalidCert',
       },
     ]);
@@ -755,8 +754,7 @@ describe('useParseSecretCertificates', () => {
   it('should filter out bundles without secretName', async () => {
     const extraCACerts: ZenkoCRCertificateBundle[] = [
       {
-        'ca.crt':
-          '-----BEGIN CERTIFICATE-----\nMockCert1\n-----END CERTIFICATE-----',
+        'ca.crt': MOCK_PEM_CERT_1,
         // No secretName - should be filtered out
       },
       {
@@ -765,9 +763,7 @@ describe('useParseSecretCertificates', () => {
       },
     ];
 
-    const certificatePEM =
-      '-----BEGIN CERTIFICATE-----\nMockCert1\n-----END CERTIFICATE-----';
-    const base64Cert = Buffer.from(certificatePEM).toString('base64');
+    const base64Cert = Buffer.from(MOCK_PEM_CERT_1).toString('base64');
 
     mockUseK8sSecretQueries.mockReturnValue({
       status: 'success',
@@ -794,7 +790,7 @@ describe('useParseSecretCertificates', () => {
 
     mockExtractPemParts.mockReturnValue([
       {
-        pem: certificatePEM,
+        pem: MOCK_PEM_CERT_1,
         base64Cert: 'MockCert1',
       },
     ]);
@@ -806,7 +802,7 @@ describe('useParseSecretCertificates', () => {
 
     await waitFor(() => {
       expect(result.current.parsedSecretCertificates).toEqual([
-        [mockCertificate1],
+        [{ ...mockCertificate1, originalPEM: MOCK_PEM_CERT_1 }],
       ]);
     });
 
@@ -817,8 +813,7 @@ describe('useParseSecretCertificates', () => {
   it('should handle mixed bundle and secret certificates', async () => {
     const extraCACerts: ZenkoCRCertificateBundle[] = [
       {
-        'ca.crt':
-          '-----BEGIN CERTIFICATE-----\nBundleCert\n-----END CERTIFICATE-----',
+        'ca.crt': MOCK_PEM_BUNDLE_CERT,
         // This is a bundle certificate, not a secret
       },
       {
@@ -831,12 +826,8 @@ describe('useParseSecretCertificates', () => {
       },
     ];
 
-    const certificatePEM1 =
-      '-----BEGIN CERTIFICATE-----\nMockCert1\n-----END CERTIFICATE-----';
-    const certificatePEM2 =
-      '-----BEGIN CERTIFICATE-----\nMockCert2\n-----END CERTIFICATE-----';
-    const base64Cert1 = Buffer.from(certificatePEM1).toString('base64');
-    const base64Cert2 = Buffer.from(certificatePEM2).toString('base64');
+    const base64Cert1 = Buffer.from(MOCK_PEM_CERT_1).toString('base64');
+    const base64Cert2 = Buffer.from(MOCK_PEM_CERT_2).toString('base64');
 
     mockUseK8sSecretQueries.mockReturnValue({
       status: 'success',
@@ -869,13 +860,13 @@ describe('useParseSecretCertificates', () => {
     mockExtractPemParts
       .mockReturnValueOnce([
         {
-          pem: certificatePEM1,
+          pem: MOCK_PEM_CERT_1,
           base64Cert: 'MockCert1',
         },
       ])
       .mockReturnValueOnce([
         {
-          pem: certificatePEM2,
+          pem: MOCK_PEM_CERT_2,
           base64Cert: 'MockCert2',
         },
       ]);
@@ -890,8 +881,8 @@ describe('useParseSecretCertificates', () => {
 
     await waitFor(() => {
       expect(result.current.parsedSecretCertificates).toEqual([
-        [mockCertificate1],
-        [mockCertificate2],
+        [{ ...mockCertificate1, originalPEM: MOCK_PEM_CERT_1 }],
+        [{ ...mockCertificate2, originalPEM: MOCK_PEM_CERT_2 }],
       ]);
     });
 

--- a/src/react/truststore/hooks.ts
+++ b/src/react/truststore/hooks.ts
@@ -16,6 +16,10 @@ export type SecretCertificate = {
   secretAttributes: string;
 };
 
+export type CertificateWithPEM = ParsedCertificate & {
+  originalPEM: string;
+};
+
 const extractCertificateBundles = (
   certificateBundles: ZenkoCRCertificateBundle[],
 ) => {
@@ -41,12 +45,16 @@ const extractSecretCertificates = (
 
 const parseCertificateBundles = async (
   extractedCertificateBundles: { pem: string }[][],
-) => {
+): Promise<CertificateWithPEM[][]> => {
   return await Promise.all(
     extractedCertificateBundles.map(async (extractedCertificateBundle) => {
       return await Promise.all(
         extractedCertificateBundle.map(async (pemPart) => {
-          return await parseCertificateFromPEM(pemPart.pem);
+          const parsed = await parseCertificateFromPEM(pemPart.pem);
+          return {
+            ...parsed,
+            originalPEM: pemPart.pem,
+          };
         }),
       );
     }),
@@ -56,7 +64,7 @@ const parseCertificateBundles = async (
 export const useParseBundleCertificates = (
   certificateBundles: ZenkoCRCertificateBundle[],
 ) => {
-  const [data, setData] = useState<ParsedCertificate[][]>([]);
+  const [data, setData] = useState<CertificateWithPEM[][]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
@@ -88,9 +96,9 @@ export const useParseBundleCertificates = (
 
 export const useParseSecretCertificates = (
   extraCACerts: ZenkoCRCertificateBundle[],
-): { parsedSecretCertificates: ParsedCertificate[][]; isLoading: boolean } => {
+): { parsedSecretCertificates: CertificateWithPEM[][]; isLoading: boolean } => {
   const [parsedSecretCertificates, setParsedCertificates] = useState<
-    ParsedCertificate[][]
+    CertificateWithPEM[][]
   >([]);
 
   const extractedSecretCertificates = useMemo(
@@ -144,7 +152,13 @@ export const useParseSecretCertificates = (
             // Extract PEM parts to handle certificate bundles
             const pemParts = extractPemParts(certificatePEM);
             return await Promise.all(
-              pemParts.map((pemPart) => parseCertificateFromPEM(pemPart.pem)),
+              pemParts.map(async (pemPart) => {
+                const parsed = await parseCertificateFromPEM(pemPart.pem);
+                return {
+                  ...parsed,
+                  originalPEM: pemPart.pem,
+                };
+              }),
             );
           }),
         );

--- a/src/react/truststore/utils.ts
+++ b/src/react/truststore/utils.ts
@@ -1,4 +1,5 @@
 import { getDateDaysDiff } from '@scality/core-ui';
+import { ParsedCertificate } from '@scality/certchain';
 
 export function formatExpiryDate(expiresOn: Date): {
   shortFormat: string;
@@ -59,4 +60,29 @@ export function formatExpiryDate(expiresOn: Date): {
     longFormatWithPrefix: `${prefix}${longFormat}`,
     status,
   };
+}
+
+export function downloadCertificate(
+  certificate: ParsedCertificate & { originalPEM?: string },
+): void {
+  if (!certificate.originalPEM) {
+    console.error('Original PEM not available for download');
+    return;
+  }
+
+  const filename = `${
+    certificate.commonName || certificate.name || 'certificate'
+  }.pem`;
+  const blob = new Blob([certificate.originalPEM], {
+    type: 'application/x-pem-file',
+  });
+  const url = URL.createObjectURL(blob);
+
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = filename;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
 }


### PR DESCRIPTION
Add download functionality for certificates in CertificateDetails component

- Introduced a download button for each certificate, allowing users to download the certificate in PEM format.
- Updated the CertificateDetails component to include the new button and associated download logic.
- Modified hooks and types to support the new functionality, ensuring the original PEM is accessible.
- Adjusted tests to verify the presence of the download button in the CertificateDetails modal.

<img width="1134" height="738" alt="image" src="https://github.com/user-attachments/assets/be58090b-4a5c-4b36-8cd5-e7e08a015862" />
