### PR TITLE
change import certificate form width

### DIFF
--- a/src/react/truststore/ImportCertificate.tsx
+++ b/src/react/truststore/ImportCertificate.tsx
@@ -40,7 +40,7 @@ const ImportCertificate = () => {
     register,
     formState: { isValid, errors },
   } = formMethods;
-
+  const certificateValue = formMethods.watch('certificate');
   const { data: zenkoCR, isLoading: isLoadingZenkoCR } = useQuery(
     getZenkoCRQuery(),
   );
@@ -127,7 +127,7 @@ const ImportCertificate = () => {
           </Stack>
         }
       >
-        <Stack direction="vertical" gap="r16">
+        <Stack direction="vertical" gap="r16" style={{ width: 'min-content' }}>
           <Stack direction="vertical" gap="r8">
             <Text>
               Choose a file or paste the Certificate chain bundle in order to
@@ -192,7 +192,10 @@ const ImportCertificate = () => {
               })}
               id="Certificate"
               placeholder={CertificatePlaceholder}
-              rows={15}
+              variant="code"
+              width={'68ch'}
+              autoGrow={true}
+              value={certificateValue}
             />
             <Text isEmphazed variant="Smaller" color="statusCritical">
               {errors.certificate?.message}

--- a/src/react/truststore/__tests__/ImportCertificate.test.tsx
+++ b/src/react/truststore/__tests__/ImportCertificate.test.tsx
@@ -382,7 +382,11 @@ describe('ImportCertificate', () => {
 
     await waitFor(() => {
       expect(selectors.importButton()).toBeDisabled();
-      expect(screen.getByText(/Invalid certificate./i)).toBeInTheDocument();
+      expect(
+        screen.getByText(
+          /Invalid certificate. The certificate should be a valid PEM x509 file/i,
+        ),
+      ).toBeInTheDocument();
     });
   });
 });


### PR DESCRIPTION
Change textArea to be close to 64 characters (pem files format) + padding.
Change textarea variant to have consistent character width and add min content width to container to force dropzone + text to take textarea width