### PR TITLE
Bugfix/artesca 16455 tls toggling

### DIFF
--- a/src/js/mutations.test.ts
+++ b/src/js/mutations.test.ts
@@ -861,6 +861,51 @@ describe('mutations', () => {
     let mockFetch;
     let originalFetch;
 
+    // Helper to create mock responses for the deployment lifecycle
+    const createDeploymentLifecycleMocks = (generation: number = 1) => {
+      const now = new Date().toISOString();
+      return {
+        patchSuccess: {
+          ok: true,
+          json: () => Promise.resolve({ status: 'Success' }),
+        },
+        deploymentInProgress: {
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              metadata: { generation },
+              status: {
+                observedGeneration: generation,
+                conditions: [
+                  { type: 'Available', status: 'False' },
+                  {
+                    type: 'DeploymentInProgress',
+                    status: 'True',
+                    lastTransitionTime: now,
+                  },
+                  { type: 'DeploymentFailure', status: 'False' },
+                ],
+              },
+            }),
+        },
+        deploymentComplete: {
+          ok: true,
+          json: () =>
+            Promise.resolve({
+              metadata: { generation },
+              status: {
+                observedGeneration: generation,
+                conditions: [
+                  { type: 'Available', status: 'True' },
+                  { type: 'DeploymentInProgress', status: 'False' },
+                  { type: 'DeploymentFailure', status: 'False' },
+                ],
+              },
+            }),
+        },
+      };
+    };
+
     beforeEach(() => {
       originalFetch = global.fetch;
       mockFetch = jest.fn();
@@ -897,25 +942,13 @@ describe('mutations', () => {
     });
 
     it('should successfully patch Zenko configuration with polling', async () => {
+      jest.useFakeTimers();
+
+      const mocks = createDeploymentLifecycleMocks(5);
       mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ status: 'Success' }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              metadata: { generation: 5 },
-              status: {
-                observedGeneration: 5,
-                conditions: [
-                  { type: 'Available', status: 'True' },
-                  { type: 'DeploymentInProgress', status: 'False' },
-                ],
-              },
-            }),
-        });
+        .mockResolvedValueOnce(mocks.patchSuccess)
+        .mockResolvedValueOnce(mocks.deploymentInProgress)
+        .mockResolvedValue(mocks.deploymentComplete);
 
       const { result } = renderHook(
         () =>
@@ -939,11 +972,21 @@ describe('mutations', () => {
         mutationPromise = result.current.mutateAsync({ testValue: 'test' });
       });
 
+      // Advance timers to allow polling iterations to complete
+      // Each iteration has a 1000ms setTimeout
+      for (let i = 0; i < 5; i++) {
+        await act(async () => {
+          jest.advanceTimersByTime(1000);
+        });
+      }
+
       await mutationPromise;
+
+      jest.useRealTimers();
 
       expect(result.current.isSuccess).toBe(true);
       expect(result.current.isError).toBe(false);
-      expect(mockFetch).toHaveBeenCalledTimes(2);
+      expect(mockFetch).toHaveBeenCalledTimes(3);
 
       const [url, options] = mockFetch.mock.calls[0];
       expect(url).toContain('artesca-data');
@@ -1035,194 +1078,30 @@ describe('mutations', () => {
 
       global.setTimeout = originalSetTimeout;
     });
-    it('should generate correct patch for enabling SOS API', async () => {
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ status: 'Success' }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              metadata: { generation: 1 },
-              status: {
-                observedGeneration: 1,
-                conditions: [
-                  { type: 'Available', status: 'True' },
-                  { type: 'DeploymentInProgress', status: 'False' },
-                ],
-              },
-            }),
-        });
-
-      const { result } = renderHook(() => useEnableSOSAPIMutation(), {
-        wrapper: NewWrapper(),
-      });
-
-      await act(async () => {
-        await result.current.mutateAsync(undefined);
-      });
-
-      // Verify it calls usePatchZenkoConfigurationMutation with correct patch
-      const [, options] = mockFetch.mock.calls[0];
-      expect(JSON.parse(options.body)).toEqual([
-        {
-          op: 'replace',
-          path: '/spec/veeamSosApi',
-          value: { enable: true },
-        },
-      ]);
-    });
-
-    it('should generate append patch when hasExtraCACerts is true', async () => {
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ status: 'Success' }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              metadata: { generation: 1 },
-              status: {
-                observedGeneration: 1,
-                conditions: [
-                  { type: 'Available', status: 'True' },
-                  { type: 'DeploymentInProgress', status: 'False' },
-                ],
-              },
-            }),
-        });
-
-      const { result } = renderHook(
-        () =>
-          useAddCertificateToZenkoConfigurationMutation({
-            hasEgress: true,
-            hasExtraCACerts: true,
-          }),
-        {
-          wrapper: NewWrapper(),
-        },
-      );
-
-      await act(async () => {
-        await result.current.mutateAsync({ certificate: 'test-cert-content' });
-      });
-
-      // Verify it calls usePatchZenkoConfigurationMutation with append patch
-      const [, options] = mockFetch.mock.calls[0];
-      expect(JSON.parse(options.body)).toEqual([
-        {
-          op: 'add',
-          path: '/spec/egress/extraCACerts/-',
-          value: { 'ca.crt': 'test-cert-content' },
-        },
-      ]);
-    });
-
-    it('should generate initialize patch when hasExtraCACerts is false', async () => {
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ status: 'Success' }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              metadata: { generation: 1 },
-              status: {
-                observedGeneration: 1,
-                conditions: [
-                  { type: 'Available', status: 'True' },
-                  { type: 'DeploymentInProgress', status: 'False' },
-                ],
-              },
-            }),
-        });
-
-      const { result } = renderHook(
-        () =>
-          useAddCertificateToZenkoConfigurationMutation({
-            hasEgress: true,
-            hasExtraCACerts: false,
-          }),
-        {
-          wrapper: NewWrapper(),
-        },
-      );
-
-      await act(async () => {
-        await result.current.mutateAsync({ certificate: 'test-cert-content' });
-      });
-
-      // Verify it calls usePatchZenkoConfigurationMutation with initialize patch
-      const [, options] = mockFetch.mock.calls[0];
-      expect(JSON.parse(options.body)).toEqual([
-        {
-          op: 'add',
-          path: '/spec/egress/extraCACerts',
-          value: [{ 'ca.crt': 'test-cert-content' }],
-        },
-      ]);
-    });
-
-    it('should generate add patch when hasEgress is false', async () => {
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ status: 'Success' }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              metadata: { generation: 1 },
-              status: {
-                observedGeneration: 1,
-                conditions: [
-                  { type: 'Available', status: 'True' },
-                  { type: 'DeploymentInProgress', status: 'False' },
-                ],
-              },
-            }),
-        });
-      const { result } = renderHook(
-        () =>
-          useAddCertificateToZenkoConfigurationMutation({
-            hasEgress: false,
-            hasExtraCACerts: false,
-          }),
-        {
-          wrapper: NewWrapper(),
-        },
-      );
-
-      await act(async () => {
-        await result.current.mutateAsync({ certificate: 'test-cert-content' });
-      });
-
-      // Verify it calls usePatchZenkoConfigurationMutation with add patch
-      const [, options] = mockFetch.mock.calls[0];
-      expect(JSON.parse(options.body)).toEqual([
-        {
-          op: 'add',
-          path: '/spec/egress',
-          value: { extraCACerts: [{ 'ca.crt': 'test-cert-content' }] },
-        },
-      ]);
-    });
   });
 
-  describe('useToggleTLSVerificationMutation', () => {
-    let mockFetch;
-    let originalFetch;
+  // ==========================================================================
+  // Tests for hooks that use usePatchZenkoConfigurationMutation
+  // These tests focus only on verifying the correct patch is generated,
+  // not the polling behavior (which is tested in usePatchZenkoConfigurationMutation)
+  // ==========================================================================
+
+  describe('Patch generation for derived mutation hooks', () => {
+    let mockFetch: jest.Mock;
+    let originalFetch: typeof global.fetch;
+    let capturedPatchBody: string | null = null;
 
     beforeEach(() => {
       originalFetch = global.fetch;
-      mockFetch = jest.fn();
+      // Mock fetch to capture the PATCH body and return immediate success
+      mockFetch = jest.fn().mockImplementation((url, options) => {
+        if (options?.method === 'PATCH') {
+          capturedPatchBody = options.body;
+        }
+        // Return a rejected promise to stop the mutation early
+        // We only care about capturing the patch body
+        return Promise.reject(new Error('Test: stopping after patch capture'));
+      });
       global.fetch = mockFetch;
 
       jest
@@ -1252,93 +1131,169 @@ describe('mutations', () => {
 
     afterEach(() => {
       global.fetch = originalFetch;
+      capturedPatchBody = null;
       jest.restoreAllMocks();
     });
 
-    it('should generate replace patch when hasEgress is true', async () => {
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ status: 'Success' }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              metadata: { generation: 1 },
-              status: {
-                observedGeneration: 1,
-                conditions: [
-                  { type: 'Available', status: 'True' },
-                  { type: 'DeploymentInProgress', status: 'False' },
-                ],
-              },
-            }),
+    describe('useEnableSOSAPIMutation', () => {
+      it('should generate correct patch for enabling SOS API', async () => {
+        const { result } = renderHook(() => useEnableSOSAPIMutation(), {
+          wrapper: NewWrapper(),
         });
 
-      const { result } = renderHook(
-        () => useToggleTLSVerificationMutation(true),
-        {
-          wrapper: NewWrapper(),
-        },
-      );
+        await act(async () => {
+          try {
+            await result.current.mutateAsync(undefined);
+          } catch {
+            // Expected - we reject to stop early
+          }
+        });
 
-      await act(async () => {
-        await result.current.mutateAsync({ skipTLSVerify: true });
+        expect(JSON.parse(capturedPatchBody!)).toEqual([
+          {
+            op: 'replace',
+            path: '/spec/veeamSosApi',
+            value: { enable: true },
+          },
+        ]);
       });
-
-      // Verify it calls usePatchZenkoConfigurationMutation with replace patch
-      const [, options] = mockFetch.mock.calls[0];
-      expect(JSON.parse(options.body)).toEqual([
-        {
-          op: 'replace',
-          path: '/spec/egress/skipTLSVerify',
-          value: true,
-        },
-      ]);
     });
 
-    it('should generate add patch when hasEgress is false', async () => {
-      mockFetch
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () => Promise.resolve({ status: 'Success' }),
-        })
-        .mockResolvedValueOnce({
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              metadata: { generation: 1 },
-              status: {
-                observedGeneration: 1,
-                conditions: [
-                  { type: 'Available', status: 'True' },
-                  { type: 'DeploymentInProgress', status: 'False' },
-                ],
-              },
+    describe('useAddCertificateToZenkoConfigurationMutation', () => {
+      it('should generate append patch when hasEgress=true and hasExtraCACerts=true', async () => {
+        const { result } = renderHook(
+          () =>
+            useAddCertificateToZenkoConfigurationMutation({
+              hasEgress: true,
+              hasExtraCACerts: true,
             }),
+          { wrapper: NewWrapper() },
+        );
+
+        await act(async () => {
+          try {
+            await result.current.mutateAsync({
+              certificate: 'test-cert-content',
+            });
+          } catch {
+            // Expected
+          }
         });
 
-      const { result } = renderHook(
-        () => useToggleTLSVerificationMutation(false),
-        {
-          wrapper: NewWrapper(),
-        },
-      );
-
-      await act(async () => {
-        await result.current.mutateAsync({ skipTLSVerify: false });
+        expect(JSON.parse(capturedPatchBody!)).toEqual([
+          {
+            op: 'add',
+            path: '/spec/egress/extraCACerts/-',
+            value: { 'ca.crt': 'test-cert-content' },
+          },
+        ]);
       });
 
-      // Verify it calls usePatchZenkoConfigurationMutation with add patch to create egress
-      const [, options] = mockFetch.mock.calls[0];
-      expect(JSON.parse(options.body)).toEqual([
-        {
-          op: 'add',
-          path: '/spec/egress',
-          value: { skipTLSVerify: false },
-        },
-      ]);
+      it('should generate initialize patch when hasEgress=true and hasExtraCACerts=false', async () => {
+        const { result } = renderHook(
+          () =>
+            useAddCertificateToZenkoConfigurationMutation({
+              hasEgress: true,
+              hasExtraCACerts: false,
+            }),
+          { wrapper: NewWrapper() },
+        );
+
+        await act(async () => {
+          try {
+            await result.current.mutateAsync({
+              certificate: 'test-cert-content',
+            });
+          } catch {
+            // Expected
+          }
+        });
+
+        expect(JSON.parse(capturedPatchBody!)).toEqual([
+          {
+            op: 'add',
+            path: '/spec/egress/extraCACerts',
+            value: [{ 'ca.crt': 'test-cert-content' }],
+          },
+        ]);
+      });
+
+      it('should generate add egress patch when hasEgress=false', async () => {
+        const { result } = renderHook(
+          () =>
+            useAddCertificateToZenkoConfigurationMutation({
+              hasEgress: false,
+              hasExtraCACerts: false,
+            }),
+          { wrapper: NewWrapper() },
+        );
+
+        await act(async () => {
+          try {
+            await result.current.mutateAsync({
+              certificate: 'test-cert-content',
+            });
+          } catch {
+            // Expected
+          }
+        });
+
+        expect(JSON.parse(capturedPatchBody!)).toEqual([
+          {
+            op: 'add',
+            path: '/spec/egress',
+            value: { extraCACerts: [{ 'ca.crt': 'test-cert-content' }] },
+          },
+        ]);
+      });
+    });
+
+    describe('useToggleTLSVerificationMutation', () => {
+      it('should generate replace patch when hasEgress=true', async () => {
+        const { result } = renderHook(
+          () => useToggleTLSVerificationMutation(true),
+          { wrapper: NewWrapper() },
+        );
+
+        await act(async () => {
+          try {
+            await result.current.mutateAsync({ skipTLSVerify: true });
+          } catch {
+            // Expected
+          }
+        });
+
+        expect(JSON.parse(capturedPatchBody!)).toEqual([
+          {
+            op: 'replace',
+            path: '/spec/egress/skipTLSVerify',
+            value: true,
+          },
+        ]);
+      });
+
+      it('should generate add egress patch when hasEgress=false', async () => {
+        const { result } = renderHook(
+          () => useToggleTLSVerificationMutation(false),
+          { wrapper: NewWrapper() },
+        );
+
+        await act(async () => {
+          try {
+            await result.current.mutateAsync({ skipTLSVerify: false });
+          } catch {
+            // Expected
+          }
+        });
+
+        expect(JSON.parse(capturedPatchBody!)).toEqual([
+          {
+            op: 'add',
+            path: '/spec/egress',
+            value: { skipTLSVerify: false },
+          },
+        ]);
+      });
     });
   });
 

--- a/src/js/mutations.ts
+++ b/src/js/mutations.ts
@@ -407,8 +407,9 @@ const usePatchZenkoConfigurationMutation = <T>(
       let resourceSynchronized = false;
       let isReady = false;
       let pollAttempts = 0;
-      const MAX_POLL_ATTEMPTS = 60;
-
+      const MAX_POLL_ATTEMPTS = 90;
+      let deploymentStarted = false;
+      const patchTimestamp = new Date().getTime();
       do {
         await new Promise((resolve) => setTimeout(resolve, 1000));
         const r = await fetch(getURL(instances), {
@@ -425,21 +426,46 @@ const usePatchZenkoConfigurationMutation = <T>(
           resourceSynchronized = true;
         }
 
-        isReady = false;
-        if (response.status.conditions) {
-          const availableCondition = response.status.conditions.find(
-            (cond) => cond.type === 'Available',
-          );
-          const deploymentCondition = response.status.conditions.find(
-            (cond) => cond.type === 'DeploymentInProgress',
-          );
-          if (
-            availableCondition.status === 'True' &&
-            deploymentCondition.status === 'False'
-          ) {
-            isReady = true;
+        // Phase 1: Wait for deployment to START
+        if (resourceSynchronized && !deploymentStarted) {
+          if (response.status.conditions) {
+            const deploymentCondition = response.status.conditions.find(
+              (cond) => cond.type === 'DeploymentInProgress',
+            );
+            if (
+              deploymentCondition &&
+              deploymentCondition.status === 'True' &&
+              new Date(deploymentCondition.lastTransitionTime).getTime() >=
+                patchTimestamp
+            ) {
+              deploymentStarted = true;
+            }
           }
         }
+
+        // Phase 2: Wait for deployment to COMPLETE
+        if (deploymentStarted) {
+          isReady = false;
+          if (response.status.conditions) {
+            const availableCondition = response.status.conditions.find(
+              (cond) => cond.type === 'Available',
+            );
+            const deploymentCondition = response.status.conditions.find(
+              (cond) => cond.type === 'DeploymentInProgress',
+            );
+            const failureCondition = response.status.conditions.find(
+              (cond) => cond.type === 'DeploymentFailure',
+            );
+            if (
+              availableCondition?.status === 'True' &&
+              deploymentCondition?.status === 'False' &&
+              failureCondition?.status === 'False'
+            ) {
+              isReady = true;
+            }
+          }
+        }
+
         pollAttempts++;
       } while (
         !(resourceSynchronized && isReady) &&

--- a/src/react/queries.ts
+++ b/src/react/queries.ts
@@ -1,3 +1,4 @@
+import { useShellHooks } from '@scality/module-federation';
 import { AWSError, S3 } from 'aws-sdk';
 import {
   AccessKeyMetadata,
@@ -14,21 +15,21 @@ import {
   User,
 } from 'aws-sdk/clients/iam';
 import { ListObjectVersionsOutput } from 'aws-sdk/clients/s3';
-import { InfiniteData, useQueries, useQuery } from 'react-query';
+import { useMemo } from 'react';
+import { InfiniteData, QueryOptions, useQuery } from 'react-query';
 import IAMClient from '../js/IAMClient';
+import { UiFacingApiWrapper } from '../js/managementClient';
 import { getAccountSeeds } from '../js/vault';
 import { notFalsyTypeGuard } from '../types/typeGuards';
 import { APIWorkflows, Workflow, Workflows } from '../types/workflow';
+import { useDeployedMetalk8sInstances } from './next-architecture/ui/ConfigProvider';
+import { ZenkoCR } from './truststore/Truststore';
 import { AWS_PAGINATED_QUERY } from './utils/IAMhooks';
 import {
   generateExpirationName,
   generateStreamName,
   generateTransitionName,
 } from './workflow/utils';
-import { UiFacingApiWrapper } from '../js/managementClient';
-import { useShellHooks } from '@scality/module-federation';
-import { useDeployedMetalk8sInstances } from './next-architecture/ui/ConfigProvider';
-import { useMemo } from 'react';
 
 // Copy paste form legacy redux workflow
 export const makeWorkflows = (apiWorkflows: APIWorkflows): Workflows => {
@@ -311,7 +312,7 @@ export const getObjectQuery = ({
   refetchOnWindowFocus: false,
 });
 
-export const getZenkoCRQuery = () => {
+export const getZenkoCRQuery = (): QueryOptions<ZenkoCR> => {
   const { useAuth } = useShellHooks();
   const { getToken } = useAuth();
   const { useConfigRetriever } = useShellHooks();

--- a/src/react/truststore/TLSVerificationModal.tsx
+++ b/src/react/truststore/TLSVerificationModal.tsx
@@ -1,0 +1,137 @@
+import {
+  Banner,
+  Checkbox,
+  Icon,
+  Modal,
+  Stack,
+  Text,
+  useToast,
+} from '@scality/core-ui';
+import { Box } from '@scality/core-ui/dist/components/box/Box';
+import { Button } from '@scality/core-ui/dist/next';
+import { MutationOptions, useQueryClient } from 'react-query';
+import { useToggleTLSVerificationMutation } from '../../js/mutations';
+import { ApiError } from '../../types/actions';
+import { useState } from 'react';
+
+type TLSVerificationModalProps = {
+  isOpen: boolean;
+  setIsOpen: (isOpen: boolean) => void;
+  isTLSVerificationActive: boolean;
+  hasEgress: boolean;
+};
+
+const TLSVerificationModal = ({
+  isOpen,
+  setIsOpen,
+  isTLSVerificationActive,
+  hasEgress,
+}: TLSVerificationModalProps) => {
+  const [isConfirmed, setIsConfirmed] = useState(false);
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
+
+  const toggleTLSVerificationMutationOptions: MutationOptions<
+    { skipTLSVerify: boolean },
+    ApiError,
+    { skipTLSVerify: boolean }
+  > = {
+    onSuccess: () => {
+      queryClient.refetchQueries({ queryKey: ['zenkoCR'] });
+      showToast({
+        message: 'TLS verification updated successfully',
+        status: 'success',
+        open: true,
+      });
+      setIsOpen(false);
+    },
+    onError: () => {
+      showToast({
+        message: 'An error occurred while updating TLS verification',
+        status: 'error',
+        open: true,
+      });
+      setIsOpen(false);
+    },
+  };
+  const {
+    mutate: toggleTLSVerificationMutation,
+    isLoading: isUpdatingTLSVerification,
+  } = useToggleTLSVerificationMutation(
+    hasEgress,
+    toggleTLSVerificationMutationOptions,
+  );
+  return (
+    <Modal
+      close={() => setIsOpen(false)}
+      isOpen={isOpen}
+      title={`${
+        isTLSVerificationActive ? 'Skip' : 'Activate'
+      } TLS Verification?`}
+      footer={
+        <Box style={{ display: 'flex', justifyContent: 'flex-end' }}>
+          <Stack>
+            <Button
+              variant="outline"
+              onClick={() => setIsOpen(false)}
+              label="Cancel"
+              disabled={isUpdatingTLSVerification}
+            />
+            <Button
+              variant="primary"
+              disabled={!isConfirmed && !isTLSVerificationActive}
+              onClick={() =>
+                toggleTLSVerificationMutation({
+                  skipTLSVerify: isTLSVerificationActive,
+                })
+              }
+              label={isUpdatingTLSVerification ? 'Updating...' : 'Confirm'}
+              isLoading={isUpdatingTLSVerification}
+            />
+          </Stack>
+        </Box>
+      }
+    >
+      <Stack
+        direction="vertical"
+        gap="r16"
+        style={{
+          maxWidth: '35rem',
+        }}
+      >
+        <Text>
+          Expect some delay (about 1 minute) - updating Data Management
+          configuration takes time.
+        </Text>
+
+        <Banner
+          variant="warning"
+          icon={<Icon color="statusWarning" name="Exclamation-circle" />}
+        >
+          {isTLSVerificationActive ? (
+            <Text>
+              Skipping TLS Verification will allow ARTESCA to access external
+              locations without verifying their TLS certificates. This is not
+              recommended as it may expose ARTESCA to security risks.
+            </Text>
+          ) : (
+            <Text>
+              Make sure to import the certificates of the external locations
+              before activating TLS Verification. This will prevent service
+              interruption.
+            </Text>
+          )}
+        </Banner>
+        {!isTLSVerificationActive && (
+          <Checkbox
+            label="I understand the consequences of activating TLS Verification"
+            onChange={() => setIsConfirmed(!isConfirmed)}
+            checked={isConfirmed}
+          />
+        )}
+      </Stack>
+    </Modal>
+  );
+};
+
+export default TLSVerificationModal;

--- a/src/react/truststore/TLSVerificationModal.tsx
+++ b/src/react/truststore/TLSVerificationModal.tsx
@@ -31,6 +31,11 @@ const TLSVerificationModal = ({
   const queryClient = useQueryClient();
   const { showToast } = useToast();
 
+  const handleCloseModal = () => {
+    setIsOpen(false);
+    setIsConfirmed(false);
+  };
+
   const toggleTLSVerificationMutationOptions: MutationOptions<
     { skipTLSVerify: boolean },
     ApiError,
@@ -43,7 +48,7 @@ const TLSVerificationModal = ({
         status: 'success',
         open: true,
       });
-      setIsOpen(false);
+      handleCloseModal();
     },
     onError: () => {
       showToast({
@@ -51,7 +56,7 @@ const TLSVerificationModal = ({
         status: 'error',
         open: true,
       });
-      setIsOpen(false);
+      handleCloseModal();
     },
   };
   const {
@@ -63,7 +68,7 @@ const TLSVerificationModal = ({
   );
   return (
     <Modal
-      close={() => setIsOpen(false)}
+      close={handleCloseModal}
       isOpen={isOpen}
       title={`${
         isTLSVerificationActive ? 'Skip' : 'Activate'
@@ -73,7 +78,7 @@ const TLSVerificationModal = ({
           <Stack>
             <Button
               variant="outline"
-              onClick={() => setIsOpen(false)}
+              onClick={handleCloseModal}
               label="Cancel"
               disabled={isUpdatingTLSVerification}
             />

--- a/src/react/truststore/TLSVerificationUpdater.tsx
+++ b/src/react/truststore/TLSVerificationUpdater.tsx
@@ -1,18 +1,7 @@
-import {
-  Banner,
-  Icon,
-  IconHelp,
-  Modal,
-  spacing,
-  Stack,
-  Text,
-  useToast,
-} from '@scality/core-ui';
-import { Box, Button } from '@scality/core-ui/dist/next';
+import { Icon, IconHelp, spacing, Stack, Text } from '@scality/core-ui';
+import { Button } from '@scality/core-ui/dist/next';
 import { useMemo, useState } from 'react';
-import { MutationOptions, useQueryClient } from 'react-query';
-import { useToggleTLSVerificationMutation } from '../../js/mutations';
-import { ApiError } from '../../types/actions';
+import TLSVerificationModal from './TLSVerificationModal';
 import { ZenkoCR } from './Truststore';
 
 const skipTLSVerificationTooltipMessage = (
@@ -46,53 +35,13 @@ const TLSVerificationUpdater = ({
   zenkoCR: ZenkoCR;
   isLoadingZenkoCR: boolean;
 }) => {
-  const queryClient = useQueryClient();
-  const { showToast } = useToast();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const isTLSVerificationActive = useMemo(() => {
     return !zenkoCR?.spec?.egress?.skipTLSVerify;
   }, [zenkoCR]);
-
   const hasEgress = useMemo(() => {
     return !!zenkoCR?.spec?.egress;
   }, [zenkoCR]);
-
-  const toggleTLSVerificationMutationOptions: MutationOptions<
-    { skipTLSVerify: boolean },
-    ApiError,
-    { skipTLSVerify: boolean }
-  > = {
-    onSuccess: () => {
-      queryClient.refetchQueries({ queryKey: ['zenkoCR'] });
-      showToast({
-        message: 'TLS verification updated successfully',
-        status: 'success',
-        open: true,
-      });
-      setIsModalOpen(false);
-    },
-    onError: () => {
-      showToast({
-        message: 'An error occurred while updating TLS verification',
-        status: 'error',
-        open: true,
-      });
-      setIsModalOpen(false);
-    },
-  };
-  const {
-    mutate: toggleTLSVerificationMutation,
-    isLoading: isUpdatingTLSVerification,
-  } = useToggleTLSVerificationMutation(
-    hasEgress,
-    toggleTLSVerificationMutationOptions,
-  );
-  const handleConfirm = () => {
-    toggleTLSVerificationMutation({ skipTLSVerify: isTLSVerificationActive });
-  };
-  const handleCancel = () => {
-    setIsModalOpen(false);
-  };
   return (
     <Stack direction="vertical" gap="r8">
       <Stack
@@ -105,8 +54,8 @@ const TLSVerificationUpdater = ({
       </Stack>
       <Stack>
         <Text>
-          {isUpdatingTLSVerification || isLoadingZenkoCR
-            ? 'Updating...'
+          {isLoadingZenkoCR
+            ? 'Loading...'
             : isTLSVerificationActive
             ? 'Active'
             : 'Skipped'}
@@ -116,77 +65,21 @@ const TLSVerificationUpdater = ({
           color="textSecondary"
           icon={<Icon name="Pencil" />}
           variant="outline"
-          isLoading={isUpdatingTLSVerification || isLoadingZenkoCR}
+          isLoading={isLoadingZenkoCR}
           tooltip={{
             overlay: `${
               isTLSVerificationActive ? 'Skip' : 'Activate'
             } TLS Verification`,
           }}
-          onClick={() => setIsModalOpen(!isModalOpen)}
+          onClick={() => setIsModalOpen(true)}
         />
       </Stack>
-      <Modal
-        close={() => setIsModalOpen(false)}
+      <TLSVerificationModal
         isOpen={isModalOpen}
-        title={`${
-          isTLSVerificationActive ? 'Skip' : 'Activate'
-        } TLS Verification?`}
-        footer={
-          <Box style={{ display: 'flex', justifyContent: 'flex-end' }}>
-            <Stack>
-              <Button
-                variant="outline"
-                onClick={handleCancel}
-                label="Cancel"
-                disabled={isUpdatingTLSVerification}
-              />
-              <Button
-                variant="primary"
-                onClick={handleConfirm}
-                label={isUpdatingTLSVerification ? 'Updating...' : 'Confirm'}
-                isLoading={isUpdatingTLSVerification}
-              />
-            </Stack>
-          </Box>
-        }
-      >
-        <Stack
-          direction="vertical"
-          gap="r16"
-          style={{
-            maxWidth: '35rem',
-          }}
-        >
-          <Banner
-            variant="warning"
-            icon={<Icon color="statusWarning" name="Exclamation-circle" />}
-          >
-            <Text>
-              Expect some delay (about 1 minute) - updating Data Management
-              configuration takes time.
-            </Text>
-          </Banner>
-
-          <Banner
-            variant="warning"
-            icon={<Icon color="statusWarning" name="Exclamation-circle" />}
-          >
-            {isTLSVerificationActive ? (
-              <Text>
-                Skipping TLS Verification will allow ARTESCA to access external
-                locations without verifying their TLS certificates. This is not
-                recommended as it may expose ARTESCA to security risks.
-              </Text>
-            ) : (
-              <Text>
-                Make sure to import the certificates of the external locations
-                before activating TLS Verification. This will prevent service
-                interruption.
-              </Text>
-            )}
-          </Banner>
-        </Stack>
-      </Modal>
+        setIsOpen={setIsModalOpen}
+        isTLSVerificationActive={isTLSVerificationActive}
+        hasEgress={hasEgress}
+      />
     </Stack>
   );
 };

--- a/src/react/truststore/TLSVerificationUpdater.tsx
+++ b/src/react/truststore/TLSVerificationUpdater.tsx
@@ -1,0 +1,194 @@
+import {
+  Banner,
+  Icon,
+  IconHelp,
+  Modal,
+  spacing,
+  Stack,
+  Text,
+  useToast,
+} from '@scality/core-ui';
+import { Box, Button } from '@scality/core-ui/dist/next';
+import { useMemo, useState } from 'react';
+import { MutationOptions, useQueryClient } from 'react-query';
+import { useToggleTLSVerificationMutation } from '../../js/mutations';
+import { ApiError } from '../../types/actions';
+import { ZenkoCR } from './Truststore';
+
+const skipTLSVerificationTooltipMessage = (
+  <Stack direction="vertical" gap="r8">
+    <Text variant="Small">
+      Skipping TLS Verification will allow you to access external locations
+      without verifying their TLS certificates.
+    </Text>
+    <Text variant="Small">
+      Without TLS verification, you lose the ability to:
+      <ul style={{ marginLeft: spacing.r16 }}>
+        <li style={{ marginBottom: spacing.r4 }}>
+          verify the external location's identity
+        </li>
+        <li style={{ marginBottom: spacing.r4 }}>ensure non-repudiation</li>
+      </ul>
+      Your data remains encrypted, but the secure channel verification is
+      bypassed.
+    </Text>
+    <Text variant="Small">
+      Toggling this setting will update the Data Management Component
+      configuration. This action will take some time to complete.
+    </Text>
+  </Stack>
+);
+
+const TLSVerificationUpdater = ({
+  zenkoCR,
+  isLoadingZenkoCR,
+}: {
+  zenkoCR: ZenkoCR;
+  isLoadingZenkoCR: boolean;
+}) => {
+  const queryClient = useQueryClient();
+  const { showToast } = useToast();
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const isTLSVerificationActive = useMemo(() => {
+    return !zenkoCR?.spec?.egress?.skipTLSVerify;
+  }, [zenkoCR]);
+
+  const hasEgress = useMemo(() => {
+    return !!zenkoCR?.spec?.egress;
+  }, [zenkoCR]);
+
+  const toggleTLSVerificationMutationOptions: MutationOptions<
+    { skipTLSVerify: boolean },
+    ApiError,
+    { skipTLSVerify: boolean }
+  > = {
+    onSuccess: () => {
+      queryClient.refetchQueries({ queryKey: ['zenkoCR'] });
+      showToast({
+        message: 'TLS verification updated successfully',
+        status: 'success',
+        open: true,
+      });
+      setIsModalOpen(false);
+    },
+    onError: () => {
+      showToast({
+        message: 'An error occurred while updating TLS verification',
+        status: 'error',
+        open: true,
+      });
+      setIsModalOpen(false);
+    },
+  };
+  const {
+    mutate: toggleTLSVerificationMutation,
+    isLoading: isUpdatingTLSVerification,
+  } = useToggleTLSVerificationMutation(
+    hasEgress,
+    toggleTLSVerificationMutationOptions,
+  );
+  const handleConfirm = () => {
+    toggleTLSVerificationMutation({ skipTLSVerify: isTLSVerificationActive });
+  };
+  const handleCancel = () => {
+    setIsModalOpen(false);
+  };
+  return (
+    <Stack direction="vertical" gap="r8">
+      <Stack
+        direction="horizontal"
+        gap="r4"
+        style={{ marginRight: spacing.r16 }}
+      >
+        <Text>TLS Verification</Text>
+        <IconHelp tooltipMessage={skipTLSVerificationTooltipMessage} />
+      </Stack>
+      <Stack>
+        <Text>
+          {isUpdatingTLSVerification || isLoadingZenkoCR
+            ? 'Updating...'
+            : isTLSVerificationActive
+            ? 'Active'
+            : 'Skipped'}
+        </Text>
+        <Button
+          aria-label="Open Modal"
+          color="textSecondary"
+          icon={<Icon name="Pencil" />}
+          variant="outline"
+          isLoading={isUpdatingTLSVerification || isLoadingZenkoCR}
+          tooltip={{
+            overlay: `${
+              isTLSVerificationActive ? 'Skip' : 'Activate'
+            } TLS Verification`,
+          }}
+          onClick={() => setIsModalOpen(!isModalOpen)}
+        />
+      </Stack>
+      <Modal
+        close={() => setIsModalOpen(false)}
+        isOpen={isModalOpen}
+        title={`${
+          isTLSVerificationActive ? 'Skip' : 'Activate'
+        } TLS Verification?`}
+        footer={
+          <Box style={{ display: 'flex', justifyContent: 'flex-end' }}>
+            <Stack>
+              <Button
+                variant="outline"
+                onClick={handleCancel}
+                label="Cancel"
+                disabled={isUpdatingTLSVerification}
+              />
+              <Button
+                variant="primary"
+                onClick={handleConfirm}
+                label={isUpdatingTLSVerification ? 'Updating...' : 'Confirm'}
+                isLoading={isUpdatingTLSVerification}
+              />
+            </Stack>
+          </Box>
+        }
+      >
+        <Stack
+          direction="vertical"
+          gap="r16"
+          style={{
+            maxWidth: '35rem',
+          }}
+        >
+          <Banner
+            variant="warning"
+            icon={<Icon color="statusWarning" name="Exclamation-circle" />}
+          >
+            <Text>
+              Expect some delay (about 1 minute) - updating Data Management
+              configuration takes time.
+            </Text>
+          </Banner>
+
+          <Banner
+            variant="warning"
+            icon={<Icon color="statusWarning" name="Exclamation-circle" />}
+          >
+            {isTLSVerificationActive ? (
+              <Text>
+                Skipping TLS Verification will allow ARTESCA to access external
+                locations without verifying their TLS certificates. This is not
+                recommended as it may expose ARTESCA to security risks.
+              </Text>
+            ) : (
+              <Text>
+                Make sure to import the certificates of the external locations
+                before activating TLS Verification. This will prevent service
+                interruption.
+              </Text>
+            )}
+          </Banner>
+        </Stack>
+      </Modal>
+    </Stack>
+  );
+};
+
+export default TLSVerificationUpdater;

--- a/src/react/truststore/TLSVerificationUpdater.tsx
+++ b/src/react/truststore/TLSVerificationUpdater.tsx
@@ -1,6 +1,6 @@
 import { Icon, IconHelp, spacing, Stack, Text } from '@scality/core-ui';
 import { Button } from '@scality/core-ui/dist/next';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import TLSVerificationModal from './TLSVerificationModal';
 import { ZenkoCR } from './Truststore';
 
@@ -36,12 +36,18 @@ const TLSVerificationUpdater = ({
   isLoadingZenkoCR: boolean;
 }) => {
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const isTLSVerificationActiveRef = useRef<boolean>(false);
   const isTLSVerificationActive = useMemo(() => {
     return !zenkoCR?.spec?.egress?.skipTLSVerify;
   }, [zenkoCR]);
   const hasEgress = useMemo(() => {
     return !!zenkoCR?.spec?.egress;
   }, [zenkoCR]);
+
+  const handleOpenModal = () => {
+    isTLSVerificationActiveRef.current = isTLSVerificationActive;
+    setIsModalOpen(true);
+  };
   return (
     <Stack direction="vertical" gap="r8">
       <Stack
@@ -71,13 +77,13 @@ const TLSVerificationUpdater = ({
               isTLSVerificationActive ? 'Skip' : 'Activate'
             } TLS Verification`,
           }}
-          onClick={() => setIsModalOpen(true)}
+          onClick={handleOpenModal}
         />
       </Stack>
       <TLSVerificationModal
         isOpen={isModalOpen}
         setIsOpen={setIsModalOpen}
-        isTLSVerificationActive={isTLSVerificationActive}
+        isTLSVerificationActive={isTLSVerificationActiveRef.current}
         hasEgress={hasEgress}
       />
     </Stack>

--- a/src/react/truststore/Truststore.tsx
+++ b/src/react/truststore/Truststore.tsx
@@ -1,14 +1,12 @@
+import { ParsedCertificate } from '@scality/certchain';
 import {
   AppContainer,
   Banner,
   ConstrainedText,
   Icon,
-  IconHelp,
-  Loader,
   spacing,
   Stack,
   Text,
-  Toggle,
   useToast,
   Wrap,
 } from '@scality/core-ui';
@@ -19,10 +17,7 @@ import { useBasenameRelativeNavigate } from '@scality/module-federation';
 import { useMemo, useState } from 'react';
 import { MutationOptions, useQuery, useQueryClient } from 'react-query';
 import { CoreUIColumn, Row } from 'react-table';
-import {
-  useDeleteCertificateFromZenkoConfigurationMutation,
-  useToggleTLSVerificationMutation,
-} from '../../js/mutations';
+import { useDeleteCertificateFromZenkoConfigurationMutation } from '../../js/mutations';
 import { ApiError } from '../../types/actions';
 import { getZenkoCRQuery } from '../queries';
 import DeleteConfirmation from '../ui-elements/DeleteConfirmation';
@@ -31,11 +26,21 @@ import CertificateDetails from './CertificateDetails';
 import {
   useParseBundleCertificates,
   useParseSecretCertificates,
-  ZenkoCRCertificateBundle,
   ZenkoCRCertificateBundleWithIndex,
+  ZenkoCRCertificateBundle,
 } from './hooks';
+import TLSVerificationUpdater from './TLSVerificationUpdater';
 import { formatExpiryDate } from './utils';
-import { ParsedCertificate } from '@scality/certchain';
+
+export type ZenkoCREgress = {
+  skipTLSVerify?: boolean;
+  extraCACerts?: ZenkoCRCertificateBundle[];
+};
+export type ZenkoCR = {
+  spec?: {
+    egress?: ZenkoCREgress;
+  } & Record<string, unknown>;
+} & Record<string, unknown>;
 
 export type CertificateWithPEM = ParsedCertificate & {
   originalPEM: string;
@@ -78,30 +83,6 @@ type CertificateData = {
   certificates: CertificateWithPEM[];
 };
 
-const skipTLSVerificationTooltipMessage = (
-  <Stack direction="vertical" gap="r8">
-    <Text variant="Small">
-      Skip TLS Verification will allow you to access external locations without
-      verifying their TLS certificates.
-    </Text>
-    <Text variant="Small">
-      Without TLS verification, you lose the ability to:
-      <ul style={{ marginLeft: spacing.r16 }}>
-        <li style={{ marginBottom: spacing.r4 }}>
-          verify the external location's identity
-        </li>
-        <li style={{ marginBottom: spacing.r4 }}>ensure non-repudiation</li>
-      </ul>
-      Your data remains encrypted, but the secure channel verification is
-      bypassed.
-    </Text>
-    <Text variant="Small">
-      Toggling this setting will update the Data Management Component
-      configuration. This action will take some time to complete.
-    </Text>
-  </Stack>
-);
-
 const Truststore = () => {
   const queryClient = useQueryClient();
   const { showToast } = useToast();
@@ -123,40 +104,6 @@ const Truststore = () => {
     isLoading: isLoadingZenkoCR,
     isError: isErrorZenkoCR,
   } = useQuery(getZenkoCRQuery());
-
-  const hasEgress = useMemo(() => {
-    return !!zenkoCR?.spec?.egress;
-  }, [zenkoCR]);
-
-  const toggleTLSVerificationMutationOptions: MutationOptions<
-    { skipTLSVerify: boolean },
-    ApiError,
-    { skipTLSVerify: boolean }
-  > = {
-    onSuccess: () => {
-      queryClient.refetchQueries({ queryKey: ['zenkoCR'] });
-      showToast({
-        message: 'TLS verification updated successfully',
-        status: 'success',
-        open: true,
-      });
-    },
-    onError: () => {
-      showToast({
-        message: 'Failed to update TLS verification',
-        status: 'error',
-        open: true,
-      });
-    },
-  };
-
-  const {
-    mutate: toggleTLSVerificationMutation,
-    isLoading: isLoadingToggleTLSVerification,
-  } = useToggleTLSVerificationMutation(
-    hasEgress,
-    toggleTLSVerificationMutationOptions,
-  );
 
   const deleteCertificateMutationOptions: MutationOptions<
     { certificateIndex: number },
@@ -196,10 +143,7 @@ const Truststore = () => {
   const extraCACerts = useMemo(() => {
     // Add index to the extraCACerts to track the order of the ca/secret certificates
     const extraCACertsWithIndex = zenkoCR?.spec?.egress?.extraCACerts?.map(
-      (
-        cert: ZenkoCRCertificateBundle,
-        index: number,
-      ): ZenkoCRCertificateBundleWithIndex => ({
+      (cert, index: number): ZenkoCRCertificateBundleWithIndex => ({
         ...cert,
         index,
       }),
@@ -219,10 +163,6 @@ const Truststore = () => {
     const list = [...parsedExtraCACerts, ...parsedSecretCertificates];
     return list.length > 0 ? formatCertificateDataForTable(list) : [];
   }, [parsedExtraCACerts, parsedSecretCertificates]);
-
-  const toggleTLSVerification = (skipTLSVerify: boolean) => {
-    toggleTLSVerificationMutation({ skipTLSVerify });
-  };
 
   const handleDeleteClick = (certificateData: CertificateData) => {
     setCertificateToDelete({
@@ -366,33 +306,10 @@ const Truststore = () => {
             <Icon name="ID-card" size="2x" withWrapper />
             <Text variant="Larger">Truststore</Text>
           </Stack>
-          <Stack direction="vertical" gap="r8">
-            <Stack
-              direction="horizontal"
-              gap="r4"
-              style={{ marginRight: spacing.r16 }}
-            >
-              <Text>TLS Verification</Text>
-              <IconHelp tooltipMessage={skipTLSVerificationTooltipMessage} />
-            </Stack>
-            <Stack gap="r8">
-              <Toggle
-                label={
-                  isLoadingToggleTLSVerification
-                    ? 'Updating...'
-                    : isTLSVerificationActive
-                    ? 'Active'
-                    : 'Skipped'
-                }
-                toggle={isTLSVerificationActive}
-                onChange={(e) => {
-                  toggleTLSVerification(!e.currentTarget.checked);
-                }}
-                disabled={isLoadingZenkoCR || isLoadingToggleTLSVerification}
-              />
-              {isLoadingToggleTLSVerification && <Loader size="base" />}
-            </Stack>
-          </Stack>
+          <TLSVerificationUpdater
+            zenkoCR={zenkoCR}
+            isLoadingZenkoCR={isLoadingZenkoCR}
+          />
         </Wrap>
       </AppContainer.OverallSummary>
       <AppContainer.MainContent hasPadding>

--- a/src/react/truststore/__tests__/ImportCertificate.test.tsx
+++ b/src/react/truststore/__tests__/ImportCertificate.test.tsx
@@ -20,6 +20,39 @@ jest.mock('../../next-architecture/ui/ConfigProvider', () => ({
   useDeployedMetalk8sInstances: jest.fn(() => [{ name: 'test-instance' }]),
 }));
 
+// Mock the mutation hook
+const mockMutate = jest.fn();
+const mockMutationResult = {
+  mutate: mockMutate,
+  isLoading: false,
+  isIdle: true,
+  isSuccess: false,
+  isError: false,
+  data: undefined,
+  error: null,
+  reset: jest.fn(),
+  mutateAsync: jest.fn(),
+  status: 'idle' as const,
+  variables: undefined,
+  context: undefined,
+  failureCount: 0,
+  failureReason: null,
+  isPaused: false,
+};
+
+jest.mock('../../../js/mutations', () => ({
+  ...jest.requireActual('../../../js/mutations'),
+  useAddCertificateToZenkoConfigurationMutation: jest.fn(
+    () => mockMutationResult,
+  ),
+}));
+
+import { useAddCertificateToZenkoConfigurationMutation } from '../../../js/mutations';
+const mockUseAddCertificateMutation =
+  useAddCertificateToZenkoConfigurationMutation as jest.MockedFunction<
+    typeof useAddCertificateToZenkoConfigurationMutation
+  >;
+
 // Mock certificate validation
 jest.mock('@scality/certchain', () => ({
   isValidTrustedCACertificate: jest.fn((pemBundle: string) => {
@@ -48,6 +81,8 @@ INVALID CERTIFICATE
 describe('ImportCertificate', () => {
   const selectors = {
     importButton: () => screen.getByRole('button', { name: /Import/i }),
+    importingButton: () =>
+      screen.queryByRole('button', { name: /Importing certificate.../i }),
     cancelButton: () => screen.getByRole('button', { name: /Cancel/i }),
     formTitle: () => screen.getByText(/Import a new Certificate/i),
     dragAndDropLabel: () => screen.getByText(/Drag and drop file here/i),
@@ -91,34 +126,10 @@ describe('ImportCertificate', () => {
     },
   };
 
-  let patchCount = 0;
-
   const server = setupServer(
-    // GET Zenko CR - handles both query and polling
+    // GET Zenko CR - only for useQuery to fetch initial state
     rest.get(ZENKO_CR_URL, (req, res, ctx) => {
-      // After PATCH, return CR with synchronized status for polling
-      if (patchCount > 0) {
-        return res(
-          ctx.json({
-            ...mockZenkoCRWithoutCerts,
-            metadata: { generation: 2 },
-            status: {
-              observedGeneration: 2,
-              conditions: [
-                { type: 'Available', status: 'True' },
-                { type: 'DeploymentInProgress', status: 'False' },
-              ],
-            },
-          }),
-        );
-      }
-      // Before PATCH, return initial CR
       return res(ctx.json(mockZenkoCRWithoutCerts));
-    }),
-    // PATCH Zenko CR success
-    rest.patch(ZENKO_CR_URL, (req, res, ctx) => {
-      patchCount++;
-      return res(ctx.json({ status: 'Success' }));
     }),
   );
 
@@ -140,7 +151,11 @@ describe('ImportCertificate', () => {
 
   afterEach(() => {
     server.resetHandlers();
-    patchCount = 0;
+    jest.clearAllMocks();
+    mockMutate.mockReset();
+    (mockUseAddCertificateMutation as jest.Mock).mockReturnValue(
+      mockMutationResult,
+    );
   });
 
   afterAll(() => {
@@ -181,6 +196,14 @@ describe('ImportCertificate', () => {
     expect(screen.getByText(/Truststore/i)).toBeInTheDocument();
   });
   it('should navigate to truststore page if import is successful and show success toast', async () => {
+    // Mock mutation to trigger success callback
+    (mockUseAddCertificateMutation as jest.Mock).mockImplementation(() => ({
+      ...mockMutationResult,
+      mutate: (args: any, options: any) => {
+        setTimeout(() => options?.onSuccess?.(), 0);
+      },
+    }));
+
     renderWithCustomRoute(
       <Routes>
         <Route path="/truststore" element={<div>Truststore</div>} />
@@ -195,9 +218,6 @@ describe('ImportCertificate', () => {
     await userEvent.type(selectors.certificateInput(), mockedValidCertificate);
     expect(selectors.importButton()).toBeEnabled();
     await userEvent.click(selectors.importButton());
-    expect(
-      screen.getByRole('button', { name: /Importing certificate.../i }),
-    ).toBeInTheDocument();
 
     await waitFor(() => {
       expect(
@@ -208,12 +228,13 @@ describe('ImportCertificate', () => {
   });
 
   it('should show error toast if import fails', async () => {
-    // Mock failed PATCH request
-    server.use(
-      rest.patch(ZENKO_CR_URL, (req, res, ctx) => {
-        return res(ctx.status(500));
-      }),
-    );
+    // Mock mutation to trigger error callback
+    (mockUseAddCertificateMutation as jest.Mock).mockImplementation(() => ({
+      ...mockMutationResult,
+      mutate: (args: any, options: any) => {
+        setTimeout(() => options?.onError?.(), 0);
+      },
+    }));
 
     renderWithCustomRoute(
       <Routes>
@@ -230,48 +251,79 @@ describe('ImportCertificate', () => {
     expect(selectors.importButton()).toBeEnabled();
     await userEvent.click(selectors.importButton());
 
-    await waitFor(
-      () => {
-        expect(
-          screen.getByText(/Failed to import certificate/i),
-        ).toBeInTheDocument();
-      },
-      {
-        timeout: 10000,
-      },
-    );
+    await waitFor(() => {
+      expect(
+        screen.getByText(/Failed to import certificate/i),
+      ).toBeInTheDocument();
+    });
   });
 
-  it('should send correct patch to append when Zenko CR has existing certs', async () => {
-    let patchBody: any;
-    let localPatchCount = 0;
+  it('should call mutation with correct certificate when importing', async () => {
+    let capturedArgs: any;
+    let capturedHookArgs: any;
+
+    // Mock mutation to capture args
+    (mockUseAddCertificateMutation as jest.Mock).mockImplementation(
+      (hookArgs: any) => {
+        capturedHookArgs = hookArgs;
+        return {
+          ...mockMutationResult,
+          mutate: (args: any, options: any) => {
+            capturedArgs = args;
+            setTimeout(() => options?.onSuccess?.(), 0);
+          },
+        };
+      },
+    );
+
+    renderWithCustomRoute(
+      <Routes>
+        <Route path="/truststore" element={<div>Truststore</div>} />
+        <Route
+          path="/truststore/import-certificate"
+          element={<ImportCertificate />}
+        />
+      </Routes>,
+      '/truststore/import-certificate',
+    );
+
+    await userEvent.type(selectors.certificateInput(), mockedValidCertificate);
+    await userEvent.click(selectors.importButton());
+
+    await waitFor(() => {
+      expect(screen.getByText(/Truststore/i)).toBeInTheDocument();
+    });
+
+    // Verify mutation was called with correct certificate
+    expect(capturedArgs).toEqual({ certificate: mockedValidCertificate });
+    // Verify hook was called with correct hasEgress/hasExtraCACerts flags
+    expect(capturedHookArgs).toEqual({
+      hasEgress: true, // mockZenkoCRWithoutCerts has egress: {}
+      hasExtraCACerts: false, // mockZenkoCRWithoutCerts has no extraCACerts
+    });
+  });
+
+  it('should pass hasExtraCACerts=true when Zenko CR has existing certs', async () => {
+    let capturedHookArgs: any;
 
     // Mock GET to return CR with existing certs
     server.use(
       rest.get(ZENKO_CR_URL, (req, res, ctx) => {
-        // After PATCH, return synchronized CR for polling
-        if (localPatchCount > 0) {
-          return res(
-            ctx.json({
-              ...mockZenkoCRWithCerts,
-              metadata: { generation: 2 },
-              status: {
-                observedGeneration: 2,
-                conditions: [
-                  { type: 'Available', status: 'True' },
-                  { type: 'DeploymentInProgress', status: 'False' },
-                ],
-              },
-            }),
-          );
-        }
         return res(ctx.json(mockZenkoCRWithCerts));
       }),
-      rest.patch(ZENKO_CR_URL, (req, res, ctx) => {
-        patchBody = req.body;
-        localPatchCount++;
-        return res(ctx.status(200));
-      }),
+    );
+
+    // Mock mutation to capture hook args
+    (mockUseAddCertificateMutation as jest.Mock).mockImplementation(
+      (hookArgs: any) => {
+        capturedHookArgs = hookArgs;
+        return {
+          ...mockMutationResult,
+          mutate: (args: any, options: any) => {
+            setTimeout(() => options?.onSuccess?.(), 0);
+          },
+        };
+      },
     );
 
     renderWithCustomRoute(
@@ -292,74 +344,11 @@ describe('ImportCertificate', () => {
       expect(screen.getByText(/Truststore/i)).toBeInTheDocument();
     });
 
-    // Verify patch uses append operation (/-) for existing array
-    expect(patchBody).toEqual([
-      {
-        op: 'add',
-        path: '/spec/egress/extraCACerts/-',
-        value: { 'ca.crt': mockedValidCertificate },
-      },
-    ]);
-  });
-
-  it('should send correct patch to initialize when Zenko CR has no certs', async () => {
-    let patchBody: any;
-    let localPatchCount = 0;
-
-    // Override handlers to capture patch body and handle polling
-    server.use(
-      rest.get(ZENKO_CR_URL, (req, res, ctx) => {
-        // After PATCH, return synchronized CR for polling
-        if (localPatchCount > 0) {
-          return res(
-            ctx.json({
-              ...mockZenkoCRWithoutCerts,
-              metadata: { generation: 2 },
-              status: {
-                observedGeneration: 2,
-                conditions: [
-                  { type: 'Available', status: 'True' },
-                  { type: 'DeploymentInProgress', status: 'False' },
-                ],
-              },
-            }),
-          );
-        }
-        return res(ctx.json(mockZenkoCRWithoutCerts));
-      }),
-      rest.patch(ZENKO_CR_URL, (req, res, ctx) => {
-        patchBody = req.body;
-        localPatchCount++;
-        return res(ctx.json({ status: 'Success' }));
-      }),
-    );
-
-    renderWithCustomRoute(
-      <Routes>
-        <Route path="/truststore" element={<div>Truststore</div>} />
-        <Route
-          path="/truststore/import-certificate"
-          element={<ImportCertificate />}
-        />
-      </Routes>,
-      '/truststore/import-certificate',
-    );
-
-    await userEvent.type(selectors.certificateInput(), mockedValidCertificate);
-    await userEvent.click(selectors.importButton());
-
-    await waitFor(() => {
-      expect(screen.getByText(/Truststore/i)).toBeInTheDocument();
+    // Verify hook was called with correct flags
+    expect(capturedHookArgs).toEqual({
+      hasEgress: true,
+      hasExtraCACerts: true, // mockZenkoCRWithCerts has extraCACerts
     });
-
-    // Verify patch initializes new array
-    expect(patchBody).toEqual([
-      {
-        op: 'add',
-        path: '/spec/egress/extraCACerts',
-        value: [{ 'ca.crt': mockedValidCertificate }],
-      },
-    ]);
   });
   it('should show error message and disable import button if certificate is empty', async () => {
     render(<ImportCertificate />, { wrapper: NewWrapper() });

--- a/src/react/truststore/__tests__/TLSVerificationModal.test.tsx
+++ b/src/react/truststore/__tests__/TLSVerificationModal.test.tsx
@@ -102,17 +102,16 @@ describe('TLSVerificationModal', () => {
     jest.clearAllMocks();
     mockMutate.mockReset();
     mockSetIsOpen.mockReset();
-    //@ts-expect-error - mock return value
-    mockUseToggleTLSVerificationMutation.mockReturnValue(mockMutationResult);
+
+    (mockUseToggleTLSVerificationMutation as jest.Mock).mockReturnValue(
+      mockMutationResult,
+    );
   });
 
   afterAll(() => {
     server.close();
   });
 
-  // ============================================
-  // Basic Modal render
-  // ============================================
   describe('Basic Modal render', () => {
     it('should render Skip modal when TLS verification is active', () => {
       render(
@@ -170,9 +169,7 @@ describe('TLSVerificationModal', () => {
       expect(mockSetIsOpen).toHaveBeenCalledWith(false);
     });
   });
-  // ============================================
-  // Mutation calls
-  // ============================================
+
   describe('Mutation', () => {
     it('should call mutation with skipTLSVerify=true when confirming from active state', async () => {
       let capturedMutateArgs: any;
@@ -238,9 +235,7 @@ describe('TLSVerificationModal', () => {
       });
     });
   });
-  // ============================================
-  // State rendering
-  // ============================================
+
   describe('State rendering', () => {
     it('should close modal and display success toast when mutation succeeds', async () => {
       (mockUseToggleTLSVerificationMutation as jest.Mock).mockImplementation(

--- a/src/react/truststore/__tests__/TLSVerificationModal.test.tsx
+++ b/src/react/truststore/__tests__/TLSVerificationModal.test.tsx
@@ -1,0 +1,340 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import TLSVerificationModal from '../TLSVerificationModal';
+import {
+  NewWrapper,
+  mockOffsetSize,
+  mockShellHooks,
+} from '../../utils/testUtil';
+
+// Mock Zenko CR endpoint URL
+const TEST_URL = 'https://test-url';
+const ZENKO_CR_URL = `${TEST_URL}/apis/zenko.io/v1alpha2/namespaces/zenko/zenkos/artesca-data`;
+
+// Mock useDeployedMetalk8sInstances
+jest.mock('../../next-architecture/ui/ConfigProvider', () => ({
+  ...jest.requireActual('../../next-architecture/ui/ConfigProvider'),
+  useDeployedMetalk8sInstances: jest.fn(() => [{ name: 'test-instance' }]),
+}));
+
+// Mock the mutation hook
+const mockMutate = jest.fn();
+const mockMutationResult = {
+  mutate: mockMutate,
+  isLoading: false,
+  isIdle: true,
+  isSuccess: false,
+  isError: false,
+  data: undefined,
+  error: null,
+  reset: jest.fn(),
+  mutateAsync: jest.fn(),
+  status: 'idle' as const,
+  variables: undefined,
+  context: undefined,
+  failureCount: 0,
+  failureReason: null,
+  isPaused: false,
+};
+
+jest.mock('../../../js/mutations', () => ({
+  ...jest.requireActual('../../../js/mutations'),
+  useToggleTLSVerificationMutation: jest.fn(() => mockMutationResult),
+}));
+
+import { useToggleTLSVerificationMutation } from '../../../js/mutations';
+const mockUseToggleTLSVerificationMutation =
+  useToggleTLSVerificationMutation as jest.MockedFunction<
+    typeof useToggleTLSVerificationMutation
+  >;
+
+describe('TLSVerificationModal', () => {
+  const selectors = {
+    modalTitle: (action: 'Skip' | 'Activate') =>
+      screen.getByText(`${action} TLS Verification?`),
+    cancelButton: () => screen.getByRole('button', { name: /Cancel/i }),
+    confirmButton: () => screen.getByRole('button', { name: /Confirm/i }),
+    confirmingButton: () =>
+      screen.queryByRole('button', { name: /Updating\.\.\./i }),
+    delayBanner: () =>
+      screen.queryByText(/Expect some delay \(about 1 minute\)/i),
+    skipWarningBanner: () =>
+      screen.queryByText(/Skipping TLS Verification will allow ARTESCA/i),
+    activateWarningBanner: () =>
+      screen.getByText(/Make sure to import the certificates/i),
+    checkbox: () =>
+      screen.queryByRole('checkbox', {
+        name: /I understand the consequences of activating TLS Verification/i,
+      }),
+  };
+
+  const server = setupServer(
+    rest.get(ZENKO_CR_URL, (req, res, ctx) => {
+      return res(ctx.json({}));
+    }),
+    rest.patch(ZENKO_CR_URL, (req, res, ctx) => {
+      return res(ctx.json({ status: 'Success' }));
+    }),
+  );
+
+  const mockSetIsOpen = jest.fn();
+
+  beforeAll(() => {
+    mockShellHooks.useConfigRetriever.mockReturnValue({
+      retrieveConfiguration: jest.fn(() => ({
+        spec: {
+          remoteEntryPath: '/remoteEntry.js',
+          selfConfiguration: {
+            url: TEST_URL,
+          },
+        },
+      })),
+    });
+
+    server.listen({ onUnhandledRequest: 'warn' });
+    mockOffsetSize(200, 800);
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+    jest.clearAllMocks();
+    mockMutate.mockReset();
+    mockSetIsOpen.mockReset();
+    //@ts-expect-error - mock return value
+    mockUseToggleTLSVerificationMutation.mockReturnValue(mockMutationResult);
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  // ============================================
+  // Basic Modal render
+  // ============================================
+  describe('Basic Modal render', () => {
+    it('should render Skip modal when TLS verification is active', () => {
+      render(
+        <TLSVerificationModal
+          isOpen={true}
+          setIsOpen={mockSetIsOpen}
+          isTLSVerificationActive={true}
+          hasEgress={true}
+        />,
+        { wrapper: NewWrapper() },
+      );
+
+      expect(selectors.modalTitle('Skip')).toBeInTheDocument();
+      expect(selectors.delayBanner()).toBeInTheDocument();
+      expect(selectors.skipWarningBanner()).toBeInTheDocument();
+      expect(selectors.cancelButton()).toBeEnabled();
+      expect(selectors.confirmButton()).toBeEnabled();
+      expect(selectors.checkbox()).not.toBeInTheDocument();
+    });
+
+    it('should render Activate modal when TLS verification is skipped', () => {
+      render(
+        <TLSVerificationModal
+          isOpen={true}
+          setIsOpen={mockSetIsOpen}
+          isTLSVerificationActive={false}
+          hasEgress={true}
+        />,
+        { wrapper: NewWrapper() },
+      );
+
+      expect(selectors.modalTitle('Activate')).toBeInTheDocument();
+      expect(selectors.delayBanner()).toBeInTheDocument();
+      expect(selectors.activateWarningBanner()).toBeInTheDocument();
+      expect(selectors.cancelButton()).toBeEnabled();
+      expect(selectors.confirmButton()).toBeDisabled();
+      expect(selectors.checkbox()).toBeInTheDocument();
+    });
+
+    it('should call setIsOpen(false) when clicking on cancel', async () => {
+      render(
+        <TLSVerificationModal
+          isOpen={true}
+          setIsOpen={mockSetIsOpen}
+          isTLSVerificationActive={true}
+          hasEgress={true}
+        />,
+        { wrapper: NewWrapper() },
+      );
+
+      expect(selectors.modalTitle('Skip')).toBeInTheDocument();
+
+      await userEvent.click(selectors.cancelButton());
+
+      expect(mockSetIsOpen).toHaveBeenCalledWith(false);
+    });
+  });
+  // ============================================
+  // Mutation calls
+  // ============================================
+  describe('Mutation', () => {
+    it('should call mutation with skipTLSVerify=true when confirming from active state', async () => {
+      let capturedMutateArgs: any;
+      let capturedHasEgress: boolean;
+      (mockUseToggleTLSVerificationMutation as jest.Mock).mockImplementation(
+        (hasEgress: boolean, options: any) => ({
+          ...mockMutationResult,
+          mutate: (args: any) => {
+            capturedMutateArgs = args;
+            capturedHasEgress = hasEgress;
+            setTimeout(() => options?.onSuccess?.(), 0);
+          },
+        }),
+      );
+
+      render(
+        <TLSVerificationModal
+          isOpen={true}
+          setIsOpen={mockSetIsOpen}
+          isTLSVerificationActive={true}
+          hasEgress={true}
+        />,
+        { wrapper: NewWrapper() },
+      );
+
+      await userEvent.click(selectors.confirmButton());
+
+      await waitFor(() => {
+        expect(capturedMutateArgs).toEqual({ skipTLSVerify: true });
+        expect(capturedHasEgress).toBe(true);
+      });
+    });
+
+    it('should call mutation with skipTLSVerify=false when confirming from skipped state', async () => {
+      let capturedMutateArgs: any;
+
+      (mockUseToggleTLSVerificationMutation as jest.Mock).mockImplementation(
+        (hasEgress: boolean, options: any) => ({
+          ...mockMutationResult,
+          mutate: (args: any) => {
+            capturedMutateArgs = args;
+            setTimeout(() => options?.onSuccess?.(), 0);
+          },
+        }),
+      );
+
+      render(
+        <TLSVerificationModal
+          isOpen={true}
+          setIsOpen={mockSetIsOpen}
+          isTLSVerificationActive={false}
+          hasEgress={true}
+        />,
+        { wrapper: NewWrapper() },
+      );
+
+      await userEvent.click(selectors.checkbox());
+
+      await userEvent.click(selectors.confirmButton());
+
+      await waitFor(() => {
+        expect(capturedMutateArgs).toEqual({ skipTLSVerify: false });
+      });
+    });
+  });
+  // ============================================
+  // State rendering
+  // ============================================
+  describe('State rendering', () => {
+    it('should close modal and display success toast when mutation succeeds', async () => {
+      (mockUseToggleTLSVerificationMutation as jest.Mock).mockImplementation(
+        (hasEgress: boolean, options: any) => ({
+          ...mockMutationResult,
+          mutate: () => {
+            setTimeout(() => options?.onSuccess?.(), 0);
+          },
+        }),
+      );
+
+      render(
+        <TLSVerificationModal
+          isOpen={true}
+          setIsOpen={mockSetIsOpen}
+          isTLSVerificationActive={true}
+          hasEgress={true}
+        />,
+        { wrapper: NewWrapper() },
+      );
+
+      await userEvent.click(selectors.confirmButton());
+
+      // setIsOpen(false) should be called
+      await waitFor(() => {
+        expect(mockSetIsOpen).toHaveBeenCalledWith(false);
+      });
+
+      // Success toast should appear
+      await waitFor(() => {
+        expect(
+          screen.getByText(/TLS verification updated successfully/i),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('should close modal and display error toast when mutation fails', async () => {
+      (mockUseToggleTLSVerificationMutation as jest.Mock).mockImplementation(
+        (hasEgress: boolean, options: any) => ({
+          ...mockMutationResult,
+          mutate: () => {
+            setTimeout(() => options?.onError?.(), 0);
+          },
+        }),
+      );
+
+      render(
+        <TLSVerificationModal
+          isOpen={true}
+          setIsOpen={mockSetIsOpen}
+          isTLSVerificationActive={true}
+          hasEgress={true}
+        />,
+        { wrapper: NewWrapper() },
+      );
+
+      await userEvent.click(selectors.confirmButton());
+
+      // setIsOpen(false) should be called
+      await waitFor(() => {
+        expect(mockSetIsOpen).toHaveBeenCalledWith(false);
+      });
+
+      // Error toast should appear
+      await waitFor(() => {
+        expect(
+          screen.getByText(
+            /An error occurred while updating TLS verification/i,
+          ),
+        ).toBeInTheDocument();
+      });
+    });
+
+    it('should display updating state during mutation: disabled buttons + updating label', () => {
+      // Mock mutation to be in loading state
+      (mockUseToggleTLSVerificationMutation as jest.Mock).mockReturnValue({
+        ...mockMutationResult,
+        isLoading: true,
+      });
+
+      render(
+        <TLSVerificationModal
+          isOpen={true}
+          setIsOpen={mockSetIsOpen}
+          isTLSVerificationActive={true}
+          hasEgress={true}
+        />,
+        { wrapper: NewWrapper() },
+      );
+
+      // Should show "Updating..." button instead of "Confirm"
+      expect(selectors.confirmingButton()).toBeInTheDocument();
+      // Cancel button should be disabled
+      expect(selectors.cancelButton()).toBeDisabled();
+    });
+  });
+});

--- a/src/react/truststore/__tests__/TLSVerificationUpdater.test.tsx
+++ b/src/react/truststore/__tests__/TLSVerificationUpdater.test.tsx
@@ -1,0 +1,175 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import TLSVerificationUpdater from '../TLSVerificationUpdater';
+import { ZenkoCR } from '../Truststore';
+import {
+  NewWrapper,
+  mockOffsetSize,
+  mockShellHooks,
+} from '../../utils/testUtil';
+
+// Mock useDeployedMetalk8sInstances
+jest.mock('../../next-architecture/ui/ConfigProvider', () => ({
+  ...jest.requireActual('../../next-architecture/ui/ConfigProvider'),
+  useDeployedMetalk8sInstances: jest.fn(() => [{ name: 'test-instance' }]),
+}));
+
+// Mock the mutation hook (needed for modal)
+jest.mock('../../../js/mutations', () => ({
+  ...jest.requireActual('../../../js/mutations'),
+  useToggleTLSVerificationMutation: jest.fn(() => ({
+    mutate: jest.fn(),
+    isLoading: false,
+  })),
+}));
+
+describe('TLSVerificationUpdater', () => {
+  const selectors = {
+    tlsVerificationLabel: () => screen.getByText('TLS Verification'),
+    activeStatus: () => screen.getByText(/^Active$/i),
+    skippedStatus: () => screen.getByText(/^Skipped$/i),
+    loadingStatus: () => screen.getByText(/^Loading\.\.\.$/i),
+    editButton: () => screen.getByRole('button', { name: /Open Modal/i }),
+    modalTitle: (action: 'Skip' | 'Activate') =>
+      screen.getByText(`${action} TLS Verification?`),
+  };
+
+  // Mock Zenko CR data with TLS verification active (has egress)
+  const mockZenkoCRWithTLSActive: ZenkoCR = {
+    metadata: { generation: 1 },
+    spec: {
+      egress: {
+        skipTLSVerify: false,
+        extraCACerts: [],
+      },
+    },
+    status: {
+      observedGeneration: 1,
+      conditions: [
+        { type: 'Available', status: 'True' },
+        { type: 'DeploymentInProgress', status: 'False' },
+        { type: 'DeploymentFailure', status: 'False' },
+      ],
+    },
+  };
+
+  // Mock Zenko CR data with TLS verification skipped
+  const mockZenkoCRWithTLSSkipped: ZenkoCR = {
+    metadata: { generation: 1 },
+    spec: {
+      egress: {
+        skipTLSVerify: true,
+        extraCACerts: [],
+      },
+    },
+    status: {
+      observedGeneration: 1,
+      conditions: [
+        { type: 'Available', status: 'True' },
+        { type: 'DeploymentInProgress', status: 'False' },
+      ],
+    },
+  };
+
+  beforeAll(() => {
+    mockShellHooks.useConfigRetriever.mockReturnValue({
+      retrieveConfiguration: jest.fn(() => ({
+        spec: {
+          remoteEntryPath: '/remoteEntry.js',
+          selfConfiguration: {
+            url: 'https://test-url',
+          },
+        },
+      })),
+    });
+    mockOffsetSize(200, 800);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ============================================
+  // Basic render
+  // ============================================
+  describe('Basic render', () => {
+    it('should render when active: Active label + button enabled', () => {
+      render(
+        <TLSVerificationUpdater
+          zenkoCR={mockZenkoCRWithTLSActive}
+          isLoadingZenkoCR={false}
+        />,
+        { wrapper: NewWrapper() },
+      );
+
+      expect(selectors.tlsVerificationLabel()).toBeInTheDocument();
+      expect(selectors.activeStatus()).toBeInTheDocument();
+      expect(selectors.editButton()).toBeEnabled();
+    });
+
+    it('should render when skipped: Skipped label + button enabled', () => {
+      render(
+        <TLSVerificationUpdater
+          zenkoCR={mockZenkoCRWithTLSSkipped}
+          isLoadingZenkoCR={false}
+        />,
+        { wrapper: NewWrapper() },
+      );
+
+      expect(selectors.tlsVerificationLabel()).toBeInTheDocument();
+      expect(selectors.skippedStatus()).toBeInTheDocument();
+      expect(selectors.editButton()).toBeEnabled();
+    });
+
+    it('should render when loading ZenkoCR: Loading label + button disabled', () => {
+      render(
+        <TLSVerificationUpdater
+          zenkoCR={mockZenkoCRWithTLSActive}
+          isLoadingZenkoCR={true}
+        />,
+        { wrapper: NewWrapper() },
+      );
+
+      expect(selectors.tlsVerificationLabel()).toBeInTheDocument();
+      expect(selectors.loadingStatus()).toBeInTheDocument();
+      expect(selectors.editButton()).toBeDisabled();
+    });
+  });
+
+  // ============================================
+  // Modal opening
+  // ============================================
+  describe('Modal opening', () => {
+    it('should open Skip modal when clicking edit button and TLS is active', async () => {
+      render(
+        <TLSVerificationUpdater
+          zenkoCR={mockZenkoCRWithTLSActive}
+          isLoadingZenkoCR={false}
+        />,
+        { wrapper: NewWrapper() },
+      );
+
+      await userEvent.click(selectors.editButton());
+
+      await waitFor(() => {
+        expect(selectors.modalTitle('Skip')).toBeInTheDocument();
+      });
+    });
+
+    it('should open Activate modal when clicking edit button and TLS is skipped', async () => {
+      render(
+        <TLSVerificationUpdater
+          zenkoCR={mockZenkoCRWithTLSSkipped}
+          isLoadingZenkoCR={false}
+        />,
+        { wrapper: NewWrapper() },
+      );
+
+      await userEvent.click(selectors.editButton());
+
+      await waitFor(() => {
+        expect(selectors.modalTitle('Activate')).toBeInTheDocument();
+      });
+    });
+  });
+});

--- a/src/react/truststore/__tests__/TLSVerificationUpdater.test.tsx
+++ b/src/react/truststore/__tests__/TLSVerificationUpdater.test.tsx
@@ -89,9 +89,6 @@ describe('TLSVerificationUpdater', () => {
     jest.clearAllMocks();
   });
 
-  // ============================================
-  // Basic render
-  // ============================================
   describe('Basic render', () => {
     it('should render when active: Active label + button enabled', () => {
       render(
@@ -136,9 +133,6 @@ describe('TLSVerificationUpdater', () => {
     });
   });
 
-  // ============================================
-  // Modal opening
-  // ============================================
   describe('Modal opening', () => {
     it('should open Skip modal when clicking edit button and TLS is active', async () => {
       render(

--- a/src/react/truststore/__tests__/Truststore.test.tsx
+++ b/src/react/truststore/__tests__/Truststore.test.tsx
@@ -12,7 +12,6 @@ import {
   useParseBundleCertificates,
   useParseSecretCertificates,
 } from '../hooks';
-import { debug } from 'jest-preview';
 
 // Mock Zenko CR endpoint URL
 const TEST_URL = 'https://test-url';
@@ -40,10 +39,42 @@ const mockUseParseSecretCertificates =
     typeof useParseSecretCertificates
   >;
 
+// Mock the delete mutation hook
+const mockDeleteMutate = jest.fn();
+const mockDeleteMutationResult = {
+  mutate: mockDeleteMutate,
+  isLoading: false,
+  isIdle: true,
+  isSuccess: false,
+  isError: false,
+  data: undefined,
+  error: null,
+  reset: jest.fn(),
+  mutateAsync: jest.fn(),
+  status: 'idle' as const,
+  variables: undefined,
+  context: undefined,
+  failureCount: 0,
+  failureReason: null,
+  isPaused: false,
+};
+
+jest.mock('../../../js/mutations', () => ({
+  ...jest.requireActual('../../../js/mutations'),
+  useDeleteCertificateFromZenkoConfigurationMutation: jest.fn(
+    () => mockDeleteMutationResult,
+  ),
+}));
+
+import { useDeleteCertificateFromZenkoConfigurationMutation } from '../../../js/mutations';
+const mockUseDeleteMutation =
+  useDeleteCertificateFromZenkoConfigurationMutation as jest.MockedFunction<
+    typeof useDeleteCertificateFromZenkoConfigurationMutation
+  >;
+
 describe('Truststore', () => {
   const selectors = {
     pageTitle: () => screen.getByText('Truststore'),
-    toggle: () => screen.getByRole('checkbox'),
     importButton: () =>
       screen.getByRole('button', { name: /Import Certificate/i }),
     nameColumn: () => screen.getByText('Name'),
@@ -116,9 +147,6 @@ describe('Truststore', () => {
     rest.get(ZENKO_CR_URL, (req, res, ctx) => {
       return res(ctx.json(mockZenkoCRWithCerts));
     }),
-    rest.patch(ZENKO_CR_URL, (req, res, ctx) => {
-      return res(ctx.json({ status: 'Success' }));
-    }),
   );
 
   beforeAll(() => {
@@ -140,6 +168,10 @@ describe('Truststore', () => {
   afterEach(() => {
     server.resetHandlers();
     jest.clearAllMocks();
+    mockDeleteMutate.mockReset();
+    (mockUseDeleteMutation as jest.Mock).mockReturnValue(
+      mockDeleteMutationResult,
+    );
   });
 
   afterAll(() => {
@@ -159,10 +191,9 @@ describe('Truststore', () => {
     //E
     render(<Truststore />, { wrapper: NewWrapper() });
     //V
-    /********** Page title and toggle: ************/
+    /********** Page title and TLS Verification: ************/
     expect(selectors.pageTitle()).toBeInTheDocument();
     expect(screen.getByText('TLS Verification')).toBeInTheDocument();
-    expect(selectors.toggle()).toBeInTheDocument();
 
     /********** Action button: ************/
     expect(selectors.importButton()).toBeInTheDocument();
@@ -172,7 +203,7 @@ describe('Truststore', () => {
     expect(selectors.expireOnColumn()).toBeInTheDocument();
   });
 
-  it('should display "Skipped" toggle label and banner when TLS verification is skipped', async () => {
+  it('should display banner when TLS verification is skipped', async () => {
     //S
     mockUseParseBundleCertificates.mockReturnValue({
       parsedCertificates: [],
@@ -201,134 +232,11 @@ describe('Truststore', () => {
     //E
     render(<Truststore />, { wrapper: NewWrapper() });
     //V
-
     await waitFor(() => {
-      expect(screen.getByText(/^Skipped$/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/Imported certificates listed below are ignored/i),
+      ).toBeInTheDocument();
     });
-    expect(
-      screen.getByText(/Imported certificates listed below are ignored/i),
-    ).toBeInTheDocument();
-  });
-  it('should display "Active" toggle label when TLS verification is active', async () => {
-    //S
-    mockUseParseBundleCertificates.mockReturnValue({
-      parsedCertificates: [],
-      isLoading: false,
-    });
-    mockUseParseSecretCertificates.mockReturnValue({
-      parsedSecretCertificates: [],
-      isLoading: false,
-    });
-
-    //E
-    render(<Truststore />, { wrapper: NewWrapper() });
-    //V
-    expect(screen.getByText(/Active/i)).toBeInTheDocument();
-  });
-  it('should render "Updating..." toggle label during TLS verification mutation', async () => {
-    //S
-    mockUseParseBundleCertificates.mockReturnValue({
-      parsedCertificates: [],
-      isLoading: false,
-    });
-    mockUseParseSecretCertificates.mockReturnValue({
-      parsedSecretCertificates: [],
-      isLoading: false,
-    });
-
-    // Mock server to delay response to capture loading state
-    server.use(
-      rest.patch(ZENKO_CR_URL, async (req, res, ctx) => {
-        await new Promise((resolve) => setTimeout(resolve, 100));
-        return res(ctx.json({ status: 'Success' }));
-      }),
-    );
-    //E
-    render(<Truststore />, { wrapper: NewWrapper() });
-
-    // Wait for initial render
-    await waitFor(() => {
-      expect(screen.getByText('TLS Verification')).toBeInTheDocument();
-    });
-    //V
-    /********** Initial state: ************/
-
-    expect(selectors.toggle()).toBeInTheDocument();
-    expect(screen.getByText(/Active/i)).toBeInTheDocument();
-
-    /********** Click toggle: ************/
-    await userEvent.click(selectors.toggle());
-
-    /********** Loading state during mutation: ************/
-    await waitFor(() => {
-      expect(screen.getByText(/Updating.../i)).toBeInTheDocument();
-    });
-  });
-
-  it('should handle TLS verification toggle when no egress entry exists', async () => {
-    // Mock Zenko CR data without egress entry
-    const mockZenkoCRWithoutEgress = {
-      metadata: {
-        generation: 1,
-      },
-      spec: {
-        // No egress entry
-      },
-      status: {
-        observedGeneration: 1,
-        conditions: [
-          { type: 'Available', status: 'True' },
-          { type: 'DeploymentInProgress', status: 'False' },
-        ],
-      },
-    };
-
-    let patchBody: any;
-    server.use(
-      rest.get(ZENKO_CR_URL, (req, res, ctx) => {
-        return res(ctx.json(mockZenkoCRWithoutEgress));
-      }),
-      rest.patch(ZENKO_CR_URL, (req, res, ctx) => {
-        patchBody = req.body;
-        return res(ctx.json({ status: 'Success' }));
-      }),
-    );
-
-    mockUseParseBundleCertificates.mockReturnValue({
-      parsedCertificates: [],
-      isLoading: false,
-    });
-    mockUseParseSecretCertificates.mockReturnValue({
-      parsedSecretCertificates: [],
-      isLoading: false,
-    });
-
-    render(<Truststore />, { wrapper: NewWrapper() });
-
-    // Wait for initial render
-    await waitFor(() => {
-      expect(screen.getByText('TLS Verification')).toBeInTheDocument();
-    });
-
-    // Toggle should show "Active" initially (no egress means skipTLSVerify is undefined, so TLS verification is active by default)
-    expect(selectors.toggle()).toBeInTheDocument();
-    expect(screen.getByText('Active')).toBeInTheDocument();
-
-    // Click toggle to disable TLS verification (which will set skipTLSVerify to true)
-    await userEvent.click(selectors.toggle());
-
-    await waitFor(() => {
-      expect(patchBody).toBeDefined();
-    });
-
-    // Verify patch creates egress entry with skipTLSVerify
-    expect(patchBody).toEqual([
-      {
-        op: 'add',
-        path: '/spec/egress',
-        value: { skipTLSVerify: true },
-      },
-    ]);
   });
 
   it('should open certificate details modal when View Details is clicked', async () => {
@@ -491,7 +399,6 @@ describe('Truststore', () => {
       //V
       // Component should render with table in loading state
       expect(selectors.pageTitle()).toBeInTheDocument();
-      expect(selectors.toggle()).toBeInTheDocument();
       expect(selectors.importButton()).toBeInTheDocument();
       expect(screen.getByText(/Loading certificates/i)).toBeInTheDocument();
     });
@@ -512,7 +419,6 @@ describe('Truststore', () => {
       //V
       // Component should render with table in loading state
       expect(selectors.pageTitle()).toBeInTheDocument();
-      expect(selectors.toggle()).toBeInTheDocument();
       expect(selectors.importButton()).toBeInTheDocument();
       expect(screen.getByText(/Loading certificates/i)).toBeInTheDocument();
     });
@@ -626,14 +532,18 @@ describe('Truststore', () => {
         isLoading: false,
       });
 
-      // Track the PATCH request
-      let patchRequestBody: any = null;
-      server.use(
-        rest.patch(ZENKO_CR_URL, async (req, res, ctx) => {
-          patchRequestBody = req.body;
-          return res(ctx.json({ status: 'Success' }));
+      // Mock the mutation to capture args and trigger success callback
+      let capturedMutateArgs: any;
+      (mockUseDeleteMutation as jest.Mock).mockImplementation(
+        (options: any) => ({
+          ...mockDeleteMutationResult,
+          mutate: (args: any) => {
+            capturedMutateArgs = args;
+            setTimeout(() => options?.onSuccess?.(), 0);
+          },
         }),
       );
+
       //E
       render(<Truststore />, { wrapper: NewWrapper() });
 
@@ -649,12 +559,6 @@ describe('Truststore', () => {
 
       await userEvent.click(selectors.deleteConfirmationDeleteButton());
 
-      // The delete button should be disabled during deletion and replaced by `deleting...`
-      await waitFor(() => {
-        expect(selectors.deletingButton()).toBeInTheDocument();
-        expect(selectors.deletingButton()).toBeDisabled();
-      });
-
       //V
       // Modal should close
       await waitFor(() => {
@@ -668,13 +572,8 @@ describe('Truststore', () => {
         ).toBeInTheDocument();
       });
 
-      // Verify the correct PATCH request was made
-      expect(patchRequestBody).toEqual([
-        {
-          op: 'remove',
-          path: '/spec/egress/extraCACerts/0',
-        },
-      ]);
+      // Verify the mutation was called with correct args
+      expect(capturedMutateArgs).toEqual({ certificateIndex: 0 });
     });
 
     it('should display error toast when delete fails', async () => {
@@ -690,12 +589,16 @@ describe('Truststore', () => {
         isLoading: false,
       });
 
-      // Mock server to return error
-      server.use(
-        rest.patch(ZENKO_CR_URL, (req, res, ctx) => {
-          return res(ctx.status(500));
+      // Mock the mutation to trigger error callback
+      (mockUseDeleteMutation as jest.Mock).mockImplementation(
+        (options: any) => ({
+          ...mockDeleteMutationResult,
+          mutate: () => {
+            setTimeout(() => options?.onError?.(), 0);
+          },
         }),
       );
+
       //E
       render(<Truststore />, { wrapper: NewWrapper() });
 
@@ -713,11 +616,6 @@ describe('Truststore', () => {
       await userEvent.click(selectors.deleteConfirmationDeleteButton());
 
       //V
-      // Modal should close
-      await waitFor(() => {
-        expect(selectors.deleteConfirmationQuery()).not.toBeInTheDocument();
-      });
-
       // Error toast should appear
       await waitFor(() => {
         expect(


### PR DESCRIPTION
The purpose of this PR is to improve the UX for the TLS Verification toggle:
- Make sure the user knows the consequences of updating the SkipTLS value and that this action takes times (more or less 60s!)
- Make sure to have the correct status in UI (eg: if TLS verification is skipped, the communication with a location should be possible). The updating was succeeding too early leading to a mismatch between the UI status and the deployment status

Fix:
- Change toggle for button with confirmation modal (same model as Serve the Root CA from Certificates)
- In Zenko CR mutation, the polling checks are improved with a 'deployment started' check and  'deployment failure' check

<img width="1166" height="100" alt="image" src="https://github.com/user-attachments/assets/ab465cc9-5d13-4f31-bd05-be6920aff639" />

<img width="753" height="459" alt="image" src="https://github.com/user-attachments/assets/55a46cc9-8ab9-489c-bee3-0e66553bc86f" />
<img width="737" height="439" alt="image" src="https://github.com/user-attachments/assets/e7fd942e-df93-4964-8253-8496763fa86a" />


<img width="1710" height="217" alt="image" src="https://github.com/user-attachments/assets/0a324b86-7b68-49fa-b046-82108e9e5e58" />

<img width="1165" height="95" alt="image" src="https://github.com/user-attachments/assets/cb4c0c74-565b-47a1-8517-3a9499841a87" />

