### PR TITLE
Replace data browser by using data-browser-library

### DIFF
--- a/__mocks__/@scality/data-browser-library.tsx
+++ b/__mocks__/@scality/data-browser-library.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+/**
+ * Mock for @scality/data-browser-library
+ *
+ * This mock is necessary because:
+ * 1. The library uses ESM modules which Jest 27 has limited support for
+ * 2. The library uses @tanstack/react-query v5 while this project uses react-query v3
+ * 3. Following unit testing best practices: mock external dependencies to isolate tests
+ *
+ * We only mock the DataBrowserProvider to avoid initialization issues in tests.
+ * Other components can be added as needed.
+ */
+
+export const DataBrowserProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  return <>{children}</>;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "@monaco-editor/react": "^4.4.5",
         "@scality/certchain": "1.4.0",
         "@scality/core-ui": "0.185.0",
+        "@scality/data-browser-library": "1.0.0-preview.15",
         "@scality/module-federation": "^1.4.1",
         "@types/react-table": "^7.7.10",
         "@types/react-virtualized": "^9.21.20",
@@ -118,6 +119,1079 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-5.2.0.tgz",
+      "integrity": "sha512-nLbCWqQNgUiwwtFsen1AdzAtvuLRsQS8rYgMuxCrdKf9kOssamGLuPwyTY9wyYblNr9+1XM8v6zoDTPPSIeANg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/crc32c": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
+      "integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha1-browser/-/sha1-browser-5.2.0.tgz",
+      "integrity": "sha512-OH6lveCFfcDjX4dbAvCFSYUjJZjDr/3XJ3xHtjn3Oj5b9RjojQo8npoLeA/bNwkOkrSQ0wgrHzXk4tDRxGKJeg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha1-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-5.2.0.tgz",
+      "integrity": "sha512-AXfN/lGotSQwu6HNcEsIASo7kWXZ5HYWvfOmSNKDsEqC4OashTp8alTmaz+F7TC2L083SFv5RdB+qU3Vs1kZqw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
+        "@aws-crypto/supports-web-crypto": "^5.2.0",
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-locate-window": "^3.0.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-browser/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/supports-web-crypto": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-5.2.0.tgz",
+      "integrity": "sha512-iAvUotm021kM33eCdNfwIN//F77/IADDSs58i+MDaOqFrVjZo9bAal0NK7HurRuWLLpF1iLX7gbWrjHjeo+YFg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/is-array-buffer": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.2.0.tgz",
+      "integrity": "sha512-GGP3O9QFD24uGeAXYUjwSTXARoqpZykHadOmA8G5vfJPK0/DC67qa//0qvqrJzL1xc8WQWX7/yc7fwudjPHPhA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-buffer-from": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.2.0.tgz",
+      "integrity": "sha512-IJdWBbTcMQ6DA0gdNhh/BwrLkDR+ADW5Kr1aZmd4k3DIF6ezMV4R2NIAmT08wQJ3yUK82thHWmC/TnK/wpMMIA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util/node_modules/@smithy/util-utf8": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.3.0.tgz",
+      "integrity": "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-cognito-identity": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.943.0.tgz",
+      "integrity": "sha512-XkuokRF2IQ+VLBn0AwrwfFOkZ2c1IXACwQdn3CDnpBZpT1s2hgH3MX0DoH9+41w4ar2QCSI09uAJiv9PX4DLoQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/credential-provider-node": "3.943.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.943.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.943.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-s3": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.943.0.tgz",
+      "integrity": "sha512-UOX8/1mmNaRmEkxoIVP2+gxd5joPJqz+fygRqlIXON1cETLGoctinMwQs7qU8g8hghm76TU2G6ZV6sLH8cySMw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha1-browser": "5.2.0",
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/credential-provider-node": "3.943.0",
+        "@aws-sdk/middleware-bucket-endpoint": "3.936.0",
+        "@aws-sdk/middleware-expect-continue": "3.936.0",
+        "@aws-sdk/middleware-flexible-checksums": "3.943.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-location-constraint": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-sdk-s3": "3.943.0",
+        "@aws-sdk/middleware-ssec": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.943.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/signature-v4-multi-region": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.943.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/eventstream-serde-browser": "^4.2.5",
+        "@smithy/eventstream-serde-config-resolver": "^4.3.5",
+        "@smithy/eventstream-serde-node": "^4.2.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-blob-browser": "^4.2.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/hash-stream-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/md5-js": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/util-waiter": "^4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.943.0.tgz",
+      "integrity": "sha512-kOTO2B8Ks2qX73CyKY8PAajtf5n39aMe2spoiOF5EkgSzGV7hZ/HONRDyADlyxwfsX39Q2F2SpPUaXzon32IGw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.943.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.943.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/core": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.943.0.tgz",
+      "integrity": "sha512-8CBy2hI9ABF7RBVQuY1bgf/ue+WPmM/hl0adrXFlhnhkaQP0tFY5zhiy1Y+n7V+5f3/ORoHBmCCQmcHDDYJqJQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/xml-builder": "3.930.0",
+        "@smithy/core": "^3.18.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-cognito-identity": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.943.0.tgz",
+      "integrity": "sha512-jZJ0uHjNlhfjx2ZX7YVYnh1wfSkLAvQmecGCSl9C6LJRNXy4uWFPbGjPqcA0tWp0WWIsUYhqjasgvCOMZIY8nw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-env": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.943.0.tgz",
+      "integrity": "sha512-WnS5w9fK9CTuoZRVSIHLOMcI63oODg9qd1vXMYb7QGLGlfwUm4aG3hdu7i9XvYrpkQfE3dzwWLtXF4ZBuL1Tew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-http": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.943.0.tgz",
+      "integrity": "sha512-SA8bUcYDEACdhnhLpZNnWusBpdmj4Vl67Vxp3Zke7SvoWSYbuxa+tiDiC+c92Z4Yq6xNOuLPW912ZPb9/NsSkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-stream": "^4.5.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-ini": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.943.0.tgz",
+      "integrity": "sha512-BcLDb8l4oVW+NkuqXMlO7TnM6lBOWW318ylf4FRED/ply5eaGxkQYqdGvHSqGSN5Rb3vr5Ek0xpzSjeYD7C8Kw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/credential-provider-env": "3.943.0",
+        "@aws-sdk/credential-provider-http": "3.943.0",
+        "@aws-sdk/credential-provider-login": "3.943.0",
+        "@aws-sdk/credential-provider-process": "3.943.0",
+        "@aws-sdk/credential-provider-sso": "3.943.0",
+        "@aws-sdk/credential-provider-web-identity": "3.943.0",
+        "@aws-sdk/nested-clients": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-login": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.943.0.tgz",
+      "integrity": "sha512-9iCOVkiRW+evxiJE94RqosCwRrzptAVPhRhGWv4osfYDhjNAvUMyrnZl3T1bjqCoKNcETRKEZIU3dqYHnUkcwQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/nested-clients": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-node": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.943.0.tgz",
+      "integrity": "sha512-14eddaH/gjCWoLSAELVrFOQNyswUYwWphIt+PdsJ/FqVfP4ay2HsiZVEIYbQtmrKHaoLJhiZKwBQRjcqJDZG0w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/credential-provider-env": "3.943.0",
+        "@aws-sdk/credential-provider-http": "3.943.0",
+        "@aws-sdk/credential-provider-ini": "3.943.0",
+        "@aws-sdk/credential-provider-process": "3.943.0",
+        "@aws-sdk/credential-provider-sso": "3.943.0",
+        "@aws-sdk/credential-provider-web-identity": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-process": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.943.0.tgz",
+      "integrity": "sha512-GIY/vUkthL33AdjOJ8r9vOosKf/3X+X7LIiACzGxvZZrtoOiRq0LADppdiKIB48vTL63VvW+eRIOFAxE6UDekw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-sso": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.943.0.tgz",
+      "integrity": "sha512-1c5G11syUrru3D9OO6Uk+ul5e2lX1adb+7zQNyluNaLPXP6Dina6Sy6DFGRLu7tM8+M7luYmbS3w63rpYpaL+A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-sso": "3.943.0",
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/token-providers": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-provider-web-identity": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.943.0.tgz",
+      "integrity": "sha512-VtyGKHxICSb4kKGuaqotxso8JVM8RjCS3UYdIMOxUt9TaFE/CZIfZKtjTr+IJ7M0P7t36wuSUb/jRLyNmGzUUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/nested-clients": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.943.0.tgz",
+      "integrity": "sha512-uZurSNsS01ehhrSwEPwcKdqp9lmd/x9q++BYO351bXyjSj1LzA/2lfUIxI2tCz/wAjJWOdnnlUdJj6P9I1uNvw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-cognito-identity": "3.943.0",
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/credential-provider-cognito-identity": "3.943.0",
+        "@aws-sdk/credential-provider-env": "3.943.0",
+        "@aws-sdk/credential-provider-http": "3.943.0",
+        "@aws-sdk/credential-provider-ini": "3.943.0",
+        "@aws-sdk/credential-provider-login": "3.943.0",
+        "@aws-sdk/credential-provider-node": "3.943.0",
+        "@aws-sdk/credential-provider-process": "3.943.0",
+        "@aws-sdk/credential-provider-sso": "3.943.0",
+        "@aws-sdk/credential-provider-web-identity": "3.943.0",
+        "@aws-sdk/nested-clients": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-bucket-endpoint": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.936.0.tgz",
+      "integrity": "sha512-XLSVVfAorUxZh6dzF+HTOp4R1B5EQcdpGcPliWr0KUj2jukgjZEcqbBmjyMF/p9bmyQsONX80iURF1HLAlW0qg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-arn-parser": "3.893.0",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-expect-continue": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.936.0.tgz",
+      "integrity": "sha512-Eb4ELAC23bEQLJmUMYnPWcjD3FZIsmz2svDiXEcxRkQU9r7NRID7pM7C5NPH94wOfiCk0b2Y8rVyFXW0lGQwbA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-flexible-checksums": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.943.0.tgz",
+      "integrity": "sha512-J2oYbAQXTFEezs5m2Vij6H3w71K1hZfCtb85AsR/2Ovp/FjABMnK+Es1g1edRx6KuMTc9HkL/iGU4e+ek+qCZw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@aws-crypto/crc32c": "5.2.0",
+        "@aws-crypto/util": "5.2.0",
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-host-header": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.936.0.tgz",
+      "integrity": "sha512-tAaObaAnsP1XnLGndfkGWFuzrJYuk9W0b/nLvol66t8FZExIAf/WdkT2NNAWOYxljVs++oHnyHBCxIlaHrzSiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-location-constraint": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.936.0.tgz",
+      "integrity": "sha512-SCMPenDtQMd9o5da9JzkHz838w3327iqXk3cbNnXWqnNRx6unyW8FL0DZ84gIY12kAyVHz5WEqlWuekc15ehfw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-logger": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.936.0.tgz",
+      "integrity": "sha512-aPSJ12d3a3Ea5nyEnLbijCaaYJT2QjQ9iW+zGh5QcZYXmOGWbKVyPSxmVOboZQG+c1M8t6d2O7tqrwzIq8L8qw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-recursion-detection": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.936.0.tgz",
+      "integrity": "sha512-l4aGbHpXM45YNgXggIux1HgsCVAvvBoqHPkqLnqMl9QVapfuSTjJHfDYDsx1Xxct6/m7qSMUzanBALhiaGO2fA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@aws/lambda-invoke-store": "^0.2.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-sdk-s3": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.943.0.tgz",
+      "integrity": "sha512-kd2mALfthU+RS9NsPS+qvznFcPnVgVx9mgmStWCPn5Qc5BTnx4UAtm+HPA+XZs+zxOopp+zmAfE4qxDHRVONBA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-arn-parser": "3.893.0",
+        "@smithy/core": "^3.18.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-ssec": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.936.0.tgz",
+      "integrity": "sha512-/GLC9lZdVp05ozRik5KsuODR/N7j+W+2TbfdFL3iS+7un+gnP6hC8RDOZd6WhpZp7drXQ9guKiTAxkZQwzS8DA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/middleware-user-agent": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.943.0.tgz",
+      "integrity": "sha512-956n4kVEwFNXndXfhSAN5wO+KRgqiWEEY+ECwLvxmmO8uQ0NWOa8l6l65nTtyuiWzMX81c9BvlyNR5EgUeeUvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@smithy/core": "^3.18.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.943.0.tgz",
+      "integrity": "sha512-anFtB0p2FPuyUnbOULwGmKYqYKSq1M73c9uZ08jR/NCq6Trjq9cuF5TFTeHwjJyPRb4wMf2Qk859oiVfFqnQiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/middleware-host-header": "3.936.0",
+        "@aws-sdk/middleware-logger": "3.936.0",
+        "@aws-sdk/middleware-recursion-detection": "3.936.0",
+        "@aws-sdk/middleware-user-agent": "3.943.0",
+        "@aws-sdk/region-config-resolver": "3.936.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-endpoints": "3.936.0",
+        "@aws-sdk/util-user-agent-browser": "3.936.0",
+        "@aws-sdk/util-user-agent-node": "3.943.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/core": "^3.18.5",
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/hash-node": "^4.2.5",
+        "@smithy/invalid-dependency": "^4.2.5",
+        "@smithy/middleware-content-length": "^4.2.5",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/middleware-retry": "^4.4.12",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.11",
+        "@smithy/util-defaults-mode-node": "^4.2.14",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http": {
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.370.0.tgz",
+      "integrity": "sha512-MfZCgSsVmir+4kJps7xT0awOPNi+swBpcVp9ZtAP7POduUVV6zVLurMNLXsppKsErggssD5E9HUgQFs5w06U4Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.370.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http/node_modules/@aws-sdk/types": {
+      "version": "3.370.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.370.0.tgz",
+      "integrity": "sha512-8PGMKklSkRKjunFhzM2y5Jm0H2TBu7YRNISdYzXLUHKSP9zlMEYagseKVdmox0zKHf1LXVNuSlUV2b6SRrieCQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^1.1.0",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/protocol-http/node_modules/@smithy/types": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-1.2.0.tgz",
+      "integrity": "sha512-z1r00TvBqF3dh4aHhya7nz1HhvCg4TRmw51fjMrh5do3h+ngSstt/yKlNbHeb9QxJmFbmN8KEVSWgb1bRvfEoA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/region-config-resolver": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.936.0.tgz",
+      "integrity": "sha512-wOKhzzWsshXGduxO4pqSiNyL9oUtk4BEvjWm9aaq6Hmfdoydq6v6t0rAGHWPjFwy9z2haovGRi3C8IxdMB4muw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-presigned-post": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-presigned-post/-/s3-presigned-post-3.943.0.tgz",
+      "integrity": "sha512-7XesqSmTwkP2cgySy+qdvdxs2nWLywBZU+Agjgq/zeFVfoG1kZqqYhl+plGg/CSfBbeUysDqeBCxs/Sj6m9evA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-s3": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-format-url": "3.936.0",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/s3-request-presigner": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.943.0.tgz",
+      "integrity": "sha512-r79MlUb7jeydV0caSz/emoyttzDdxgSkS/8ZU3lawkoTTnWCt+1nB4VA2xzOAPzP2dSdwNVpuAdY7uD1t2f0wA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/signature-v4-multi-region": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@aws-sdk/util-format-url": "3.936.0",
+        "@smithy/middleware-endpoint": "^4.3.12",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/smithy-client": "^4.9.8",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/signature-v4-multi-region": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.943.0.tgz",
+      "integrity": "sha512-KKvmxNQ/FZbM6ml6nKd8ltDulsUojsXnMJNgf1VHTcJEbADC/6mVWOq0+e9D0WP1qixUBEuMjlS2HqD5KoqwEg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-sdk-s3": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/signature-v4": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/token-providers": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.943.0.tgz",
+      "integrity": "sha512-cRKyIzwfkS+XztXIFPoWORuaxlIswP+a83BJzelX4S1gUZ7FcXB4+lj9Jxjn8SbQhR4TPU3Owbpu+S7pd6IRbQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/core": "3.943.0",
+        "@aws-sdk/nested-clients": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.936.0.tgz",
+      "integrity": "sha512-uz0/VlMd2pP5MepdrHizd+T+OKfyK4r3OA9JI+L/lPKg0YFQosdJNCKisr6o70E3dh8iMpFYxF1UN/4uZsyARg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-arn-parser": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.893.0.tgz",
+      "integrity": "sha512-u8H4f2Zsi19DGnwj5FSZzDMhytYF/bCh37vAtBsn3cNDL3YG578X5oc+wSX54pM3tOxS+NY7tvOAo52SW7koUA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.936.0.tgz",
+      "integrity": "sha512-0Zx3Ntdpu+z9Wlm7JKUBOzS9EunwKAb4KdGUQQxDqh5Lc3ta5uBoub+FgmVuzwnmBu9U1Os8UuwVTH0Lgu+P5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-endpoints": "^3.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-format-url": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-format-url/-/util-format-url-3.936.0.tgz",
+      "integrity": "sha512-MS5eSEtDUFIAMHrJaMERiHAvDPdfxc/T869ZjDNFAIiZhyc037REw0aoTNeimNXDNy2txRNZJaAUn/kE4RwN+g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/querystring-builder": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-locate-window": {
+      "version": "3.893.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.893.0.tgz",
+      "integrity": "sha512-T89pFfgat6c8nMmpI8eKjBcDcgJq36+m9oiXbcUzeU55MP9ZuGgBomGjGnHaEyF36jenW9gmg3NfZDm0AO2XPg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-browser": {
+      "version": "3.936.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.936.0.tgz",
+      "integrity": "sha512-eZ/XF6NxMtu+iCma58GRNRxSq4lHo6zHQLOZRIeL/ghqYJirqHdenMOwrzPettj60KWlv827RVebP9oNVrwZbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/types": "^4.9.0",
+        "bowser": "^2.11.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/util-user-agent-node": {
+      "version": "3.943.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.943.0.tgz",
+      "integrity": "sha512-gn+ILprVRrgAgTIBk2TDsJLRClzIOdStQFeFTcN0qpL8Z4GBCqMFhw7O7X+MM55Stt5s4jAauQ/VvoqmCADnQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/middleware-user-agent": "3.943.0",
+        "@aws-sdk/types": "3.936.0",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "peerDependencies": {
+        "aws-crt": ">=1.0.0"
+      },
+      "peerDependenciesMeta": {
+        "aws-crt": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@aws-sdk/xml-builder": {
+      "version": "3.930.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.930.0.tgz",
+      "integrity": "sha512-YIfkD17GocxdmlUVc3ia52QhcWuRIUJonbF8A2CYfcWNV3HzvAqpcPeC0bYUhkK+8e8YO1ARnLKZQE0TlwzorA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "fast-xml-parser": "5.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@aws/lambda-invoke-store": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.2.1.tgz",
+      "integrity": "sha512-sIyFcoPZkTtNu9xFeEoynMef3bPJIAbOfUh+ueYcfhVl6xm2VRtMcMclSxmZCMnHHd4hlYKJeq/aggmBEWynww==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -2369,6 +3443,15 @@
       "resolved": "https://registry.npmjs.org/@hapi/pinpoint/-/pinpoint-2.0.1.tgz",
       "integrity": "sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q=="
     },
+    "node_modules/@hapi/tlds": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@hapi/tlds/-/tlds-1.1.4.tgz",
+      "integrity": "sha512-Fq+20dxsxLaUn5jSSWrdtSRcIUba2JquuorF9UW1wIJS5cSUwxIsO2GIhaWynPRflvxSzFN+gxKte2HEW1OuoA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/@hapi/topo": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
@@ -3168,27 +4251,26 @@
       }
     },
     "node_modules/@monaco-editor/loader": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.4.0.tgz",
-      "integrity": "sha512-00ioBig0x642hytVspPl7DbQyaSWRaolYie/UFNjoTdvoKPzo6xrXLhTk9ixgIKcLH5b5vDOjVNiGyY+uDCUlg==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/loader/-/loader-1.7.0.tgz",
+      "integrity": "sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==",
+      "license": "MIT",
       "dependencies": {
         "state-local": "^1.0.6"
-      },
-      "peerDependencies": {
-        "monaco-editor": ">= 0.21.0 < 1"
       }
     },
     "node_modules/@monaco-editor/react": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.6.0.tgz",
-      "integrity": "sha512-RFkU9/i7cN2bsq/iTkurMWOEErmYcY6JiQI3Jn+WeR/FGISH8JbHERjpS9oRuSOPvDMJI0Z8nJeKkbOs9sBYQw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@monaco-editor/react/-/react-4.7.0.tgz",
+      "integrity": "sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==",
+      "license": "MIT",
       "dependencies": {
-        "@monaco-editor/loader": "^1.4.0"
+        "@monaco-editor/loader": "^1.5.0"
       },
       "peerDependencies": {
         "monaco-editor": ">= 0.25.0 < 1",
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0",
-        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/@mswjs/cookies": {
@@ -4058,6 +5140,75 @@
         "node": ">=10"
       }
     },
+    "node_modules/@scality/data-browser-library": {
+      "version": "1.0.0-preview.15",
+      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.0.0-preview.15.tgz",
+      "integrity": "sha512-gHh4Nn3mObJU+hmwbGXoF/PcBznLZyZn4ysGFGd/8BLDk+zzGf/8PLhcMhcG381NiJXCoNLlMxxgebDKlv+L7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.478.0",
+        "@aws-sdk/protocol-http": "^3.370.0",
+        "@aws-sdk/s3-presigned-post": "^3.888.0",
+        "@aws-sdk/s3-request-presigner": "^3.478.0",
+        "@hookform/resolvers": "^5.2.2",
+        "@monaco-editor/react": "^4.7.0",
+        "@scality/zenkoclient": "^2.0.0-preview.1",
+        "@tanstack/react-query": "^5.8.0",
+        "@tanstack/react-query-devtools": "^5.8.0",
+        "@testing-library/user-event": "^14.6.1",
+        "joi": "^18.0.1",
+        "react-dropzone": "^14.2.0",
+        "react-hook-form": "^7.48.0"
+      },
+      "peerDependencies": {
+        "@scality/core-ui": "0.185.0",
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0",
+        "react-router-dom": ">=6.0.0",
+        "styled-components": "^5.0.0"
+      }
+    },
+    "node_modules/@scality/data-browser-library/node_modules/@hookform/resolvers": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
+      "peerDependencies": {
+        "react-hook-form": "^7.55.0"
+      }
+    },
+    "node_modules/@scality/data-browser-library/node_modules/file-selector": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
+      "integrity": "sha512-QgXo+mXTe8ljeqUFaX3QVHc5osSItJ/Km+xpocx0aSqWGMSCf6qYs/VnzZgS864Pjn5iceMRFigeAV7AfTlaig==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.7.0"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/@scality/data-browser-library/node_modules/react-dropzone": {
+      "version": "14.3.8",
+      "resolved": "https://registry.npmjs.org/react-dropzone/-/react-dropzone-14.3.8.tgz",
+      "integrity": "sha512-sBgODnq+lcA4P296DY4wacOZz3JFpD99fp+hb//iBO2HHnyeZU3FwWyXJ6salNpqQdsZrgMrotuko/BdJMV8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "attr-accept": "^2.2.4",
+        "file-selector": "^2.1.0",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">= 10.13"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8 || 18.0.0"
+      }
+    },
     "node_modules/@scality/module-federation": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/@scality/module-federation/-/module-federation-1.4.1.tgz",
@@ -4068,6 +5219,23 @@
       "peerDependencies": {
         "react": "^18.3.1",
         "react-dom": "^18.3.1"
+      }
+    },
+    "node_modules/@scality/zenkoclient": {
+      "version": "2.0.0-preview.1",
+      "resolved": "https://registry.npmjs.org/@scality/zenkoclient/-/zenkoclient-2.0.0-preview.1.tgz",
+      "integrity": "sha512-hScltXLyqJk6X2HyAu2mRj2xqAz8WfZYqgi2wUrB13e5B+z/J221E7pVRErxiDchoKkZQbSIIcGLFBdvfaK+Sg==",
+      "license": "ISC",
+      "dependencies": {
+        "@aws-sdk/client-s3": "^3.478.0",
+        "@aws-sdk/credential-providers": "^3.0.0",
+        "@aws-sdk/protocol-http": "^3.0.0",
+        "@aws-sdk/s3-presigned-post": "^3.0.0",
+        "@aws-sdk/s3-request-presigner": "^3.0.0",
+        "@aws-sdk/types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@sindresorhus/is": {
@@ -4104,6 +5272,738 @@
       "dev": true,
       "dependencies": {
         "@sinonjs/commons": "^1.7.0"
+      }
+    },
+    "node_modules/@smithy/abort-controller": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/abort-controller/-/abort-controller-4.2.5.tgz",
+      "integrity": "sha512-j7HwVkBw68YW8UmFRcjZOmssE77Rvk0GWAIN1oFBhsaovQmZWYCIcGa9/pwRB0ExI8Sk9MWNALTjftjHZea7VA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader/-/chunked-blob-reader-5.2.0.tgz",
+      "integrity": "sha512-WmU0TnhEAJLWvfSeMxBNe5xtbselEO8+4wG0NtZeL8oR21WgH1xiO37El+/Y+H/Ie4SCwBy3MxYWmOYaGgZueA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/chunked-blob-reader-native": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/chunked-blob-reader-native/-/chunked-blob-reader-native-4.2.1.tgz",
+      "integrity": "sha512-lX9Ay+6LisTfpLid2zZtIhSEjHMZoAR5hHCR4H7tBz/Zkfr5ea8RcQ7Tk4mi0P76p4cN+Btz16Ffno7YHpKXnQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-base64": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/config-resolver": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.3.tgz",
+      "integrity": "sha512-ezHLe1tKLUxDJo2LHtDuEDyWXolw8WGOR92qb4bQdWq/zKenO5BvctZGrVJBK08zjezSk7bmbKFOXIVyChvDLw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-config-provider": "^4.2.0",
+        "@smithy/util-endpoints": "^3.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/core": {
+      "version": "3.18.6",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.18.6.tgz",
+      "integrity": "sha512-8Q/ugWqfDUEU1Exw71+DoOzlONJ2Cn9QA8VeeDzLLjzO/qruh9UKFzbszy4jXcIYgGofxYiT0t1TT6+CT/GupQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-stream": "^4.5.6",
+        "@smithy/util-utf8": "^4.2.0",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/credential-provider-imds": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.5.tgz",
+      "integrity": "sha512-BZwotjoZWn9+36nimwm/OLIcVe+KYRwzMjfhd4QT7QxPm9WY0HiOV8t/Wlh+HVUif0SBVV7ksq8//hPaBC/okQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-4.2.5.tgz",
+      "integrity": "sha512-Ogt4Zi9hEbIP17oQMd68qYOHUzmH47UkK7q7Gl55iIm9oKt27MUGrC5JfpMroeHjdkOliOA4Qt3NQ1xMq/nrlA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/crc32": "5.2.0",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-browser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.2.5.tgz",
+      "integrity": "sha512-HohfmCQZjppVnKX2PnXlf47CW3j92Ki6T/vkAT2DhBR47e89pen3s4fIa7otGTtrVxmj7q+IhH0RnC5kpR8wtw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-config-resolver": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.3.5.tgz",
+      "integrity": "sha512-ibjQjM7wEXtECiT6my1xfiMH9IcEczMOS6xiCQXoUIYSj5b1CpBbJ3VYbdwDy8Vcg5JHN7eFpOCGk8nyZAltNQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-node": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.2.5.tgz",
+      "integrity": "sha512-+elOuaYx6F2H6x1/5BQP5ugv12nfJl66GhxON8+dWVUEDJ9jah/A0tayVdkLRP0AeSac0inYkDz5qBFKfVp2Gg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-serde-universal": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/eventstream-serde-universal": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-universal/-/eventstream-serde-universal-4.2.5.tgz",
+      "integrity": "sha512-G9WSqbST45bmIFaeNuP/EnC19Rhp54CcVdX9PDL1zyEB514WsDVXhlyihKlGXnRycmHNmVv88Bvvt4EYxWef/Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/fetch-http-handler": {
+      "version": "5.3.6",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.6.tgz",
+      "integrity": "sha512-3+RG3EA6BBJ/ofZUeTFJA7mHfSYrZtQIrDP9dI8Lf7X6Jbos2jptuLrAAteDiFVrmbEmLSuRG/bUKzfAXk7dhg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/querystring-builder": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-blob-browser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.2.6.tgz",
+      "integrity": "sha512-8P//tA8DVPk+3XURk2rwcKgYwFvwGwmJH/wJqQiSKwXZtf/LiZK+hbUZmPj/9KzM+OVSwe4o85KTp5x9DUZTjw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/chunked-blob-reader": "^5.2.0",
+        "@smithy/chunked-blob-reader-native": "^4.2.1",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-node": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.5.tgz",
+      "integrity": "sha512-DpYX914YOfA3UDT9CN1BM787PcHfWRBB43fFGCYrZFUH0Jv+5t8yYl+Pd5PW4+QzoGEDvn5d5QIO4j2HyYZQSA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/hash-stream-node": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.2.5.tgz",
+      "integrity": "sha512-6+do24VnEyvWcGdHXomlpd0m8bfZePpUKBy7m311n+JuRwug8J4dCanJdTymx//8mi0nlkflZBvJe+dEO/O12Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/invalid-dependency": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.5.tgz",
+      "integrity": "sha512-2L2erASEro1WC5nV+plwIMxrTXpvpfzl4e+Nre6vBVRR2HKeGGcvpJyyL3/PpiSg+cJG2KpTmZmq934Olb6e5A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.0.tgz",
+      "integrity": "sha512-DZZZBvC7sjcYh4MazJSGiWMI2L7E0oCiRHREDzIxi/M2LY79/21iXt6aPLHge82wi5LsuRF5A06Ds3+0mlh6CQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/md5-js": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.2.5.tgz",
+      "integrity": "sha512-Bt6jpSTMWfjCtC0s79gZ/WZ1w90grfmopVOWqkI2ovhjpD5Q2XRXuecIPB9689L2+cCySMbaXDhBPU56FKNDNg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-content-length": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.5.tgz",
+      "integrity": "sha512-Y/RabVa5vbl5FuHYV2vUCwvh/dqzrEY/K2yWPSqvhFUwIY0atLqO4TienjBXakoy4zrKAMCZwg+YEqmH7jaN7A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-endpoint": {
+      "version": "4.3.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.3.13.tgz",
+      "integrity": "sha512-X4za1qCdyx1hEVVXuAWlZuK6wzLDv1uw1OY9VtaYy1lULl661+frY7FeuHdYdl7qAARUxH2yvNExU2/SmRFfcg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.18.6",
+        "@smithy/middleware-serde": "^4.2.6",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "@smithy/url-parser": "^4.2.5",
+        "@smithy/util-middleware": "^4.2.5",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-retry": {
+      "version": "4.4.13",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.13.tgz",
+      "integrity": "sha512-RzIDF9OrSviXX7MQeKOm8r/372KTyY8Jmp6HNKOOYlrguHADuM3ED/f4aCyNhZZFLG55lv5beBin7nL0Nzy1Dw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/service-error-classification": "^4.2.5",
+        "@smithy/smithy-client": "^4.9.9",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-retry": "^4.2.5",
+        "@smithy/uuid": "^1.1.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-serde": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.6.tgz",
+      "integrity": "sha512-VkLoE/z7e2g8pirwisLz8XJWedUSY8my/qrp81VmAdyrhi94T+riBfwP+AOEEFR9rFTSonC/5D2eWNmFabHyGQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/middleware-stack": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.5.tgz",
+      "integrity": "sha512-bYrutc+neOyWxtZdbB2USbQttZN0mXaOyYLIsaTbJhFsfpXyGWUxJpEuO1rJ8IIJm2qH4+xJT0mxUSsEDTYwdQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-config-provider": {
+      "version": "4.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.5.tgz",
+      "integrity": "sha512-UTurh1C4qkVCtqggI36DGbLB2Kv8UlcFdMXDcWMbqVY2uRg0XmT9Pb4Vj6oSQ34eizO1fvR0RnFV4Axw4IrrAg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/shared-ini-file-loader": "^4.4.0",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/node-http-handler": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.5.tgz",
+      "integrity": "sha512-CMnzM9R2WqlqXQGtIlsHMEZfXKJVTIrqCNoSd/QpAyp+Dw0a1Vps13l6ma1fH8g7zSPNsA59B/kWgeylFuA/lw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/querystring-builder": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/property-provider": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.5.tgz",
+      "integrity": "sha512-8iLN1XSE1rl4MuxvQ+5OSk/Zb5El7NJZ1td6Tn+8dQQHIjp59Lwl6bd0+nzw6SKm2wSSriH2v/I9LPzUic7EOg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/protocol-http": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.5.tgz",
+      "integrity": "sha512-RlaL+sA0LNMp03bf7XPbFmT5gN+w3besXSWMkA8rcmxLSVfiEXElQi4O2IWwPfxzcHkxqrwBFMbngB8yx/RvaQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-builder": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.5.tgz",
+      "integrity": "sha512-y98otMI1saoajeik2kLfGyRp11e5U/iJYH/wLCh3aTV/XutbGT9nziKGkgCaMD1ghK7p6htHMm6b6scl9JRUWg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/querystring-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.5.tgz",
+      "integrity": "sha512-031WCTdPYgiQRYNPXznHXof2YM0GwL6SeaSyTH/P72M1Vz73TvCNH2Nq8Iu2IEPq9QP2yx0/nrw5YmSeAi/AjQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/service-error-classification": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.5.tgz",
+      "integrity": "sha512-8fEvK+WPE3wUAcDvqDQG1Vk3ANLR8Px979te96m84CbKAjBVf25rPYSzb4xU4hlTyho7VhOGnh5i62D/JVF0JQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/shared-ini-file-loader": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.0.tgz",
+      "integrity": "sha512-5WmZ5+kJgJDjwXXIzr1vDTG+RhF9wzSODQBfkrQ2VVkYALKGvZX1lgVSxEkgicSAFnFhPj5rudJV0zoinqS0bA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "5.3.5",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.5.tgz",
+      "integrity": "sha512-xSUfMu1FT7ccfSXkoLl/QRQBi2rOvi3tiBZU2Tdy3I6cgvZ6SEi9QNey+lqps/sJRnogIS+lq+B1gxxbra2a/w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-middleware": "^4.2.5",
+        "@smithy/util-uri-escape": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/smithy-client": {
+      "version": "4.9.9",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.9.9.tgz",
+      "integrity": "sha512-SUnZJMMo5yCmgjopJbiNeo1vlr8KvdnEfIHV9rlD77QuOGdRotIVBcOrBuMr+sI9zrnhtDtLP054bZVbpZpiQA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/core": "^3.18.6",
+        "@smithy/middleware-endpoint": "^4.3.13",
+        "@smithy/middleware-stack": "^4.2.5",
+        "@smithy/protocol-http": "^5.3.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-stream": "^4.5.6",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.9.0.tgz",
+      "integrity": "sha512-MvUbdnXDTwykR8cB1WZvNNwqoWVaTRA0RLlLmf/cIFNMM2cKWz01X4Ly6SMC4Kks30r8tT3Cty0jmeWfiuyHTA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/url-parser": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.5.tgz",
+      "integrity": "sha512-VaxMGsilqFnK1CeBX+LXnSuaMx4sTL/6znSZh2829txWieazdVxr54HmiyTsIbpOTLcf5nYpq9lpzmwRdxj6rQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/querystring-parser": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-base64": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.0.tgz",
+      "integrity": "sha512-GkXZ59JfyxsIwNTWFnjmFEI8kZpRNIBfxKjv09+nkAWPt/4aGaEWMM04m4sxgNVWkbt2MdSvE3KF/PfX4nFedQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-browser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.0.tgz",
+      "integrity": "sha512-Fkoh/I76szMKJnBXWPdFkQJl2r9SjPt3cMzLdOB6eJ4Pnpas8hVoWPYemX/peO0yrrvldgCUVJqOAjUrOLjbxg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-body-length-node": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.1.tgz",
+      "integrity": "sha512-h53dz/pISVrVrfxV1iqXlx5pRg3V2YWFcSQyPyXZRrZoZj4R4DeWRDo1a7dd3CPTcFi3kE+98tuNyD2axyZReA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.0.tgz",
+      "integrity": "sha512-kAY9hTKulTNevM2nlRtxAG2FQ3B2OR6QIrPY3zE5LqJy1oxzmgBGsHLWTcNhWXKchgA0WHW+mZkQrng/pgcCew==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-config-provider": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.0.tgz",
+      "integrity": "sha512-YEjpl6XJ36FTKmD+kRJJWYvrHeUvm5ykaUS5xK+6oXffQPHeEM4/nXlZPe+Wu0lsgRUcNZiliYNh/y7q9c2y6Q==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-browser": {
+      "version": "4.3.12",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.12.tgz",
+      "integrity": "sha512-TKc6FnOxFULKxLgTNHYjcFqdOYzXVPFFVm5JhI30F3RdhT7nYOtOsjgaOwfDRmA/3U66O9KaBQ3UHoXwayRhAg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/smithy-client": "^4.9.9",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-defaults-mode-node": {
+      "version": "4.2.15",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.15.tgz",
+      "integrity": "sha512-94NqfQVo+vGc5gsQ9SROZqOvBkGNMQu6pjXbnn8aQvBUhc31kx49gxlkBEqgmaZQHUUfdRUin5gK/HlHKmbAwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/config-resolver": "^4.4.3",
+        "@smithy/credential-provider-imds": "^4.2.5",
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/property-provider": "^4.2.5",
+        "@smithy/smithy-client": "^4.9.9",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-endpoints": {
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.2.5.tgz",
+      "integrity": "sha512-3O63AAWu2cSNQZp+ayl9I3NapW1p1rR5mlVHcF6hAB1dPZUQFfRPYtplWX/3xrzWthPGj5FqB12taJJCfH6s8A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/node-config-provider": "^4.3.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.0.tgz",
+      "integrity": "sha512-CCQBwJIvXMLKxVbO88IukazJD9a4kQ9ZN7/UMGBjBcJYvatpWk+9g870El4cB8/EJxfe+k+y0GmR9CAzkF+Nbw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.5.tgz",
+      "integrity": "sha512-6Y3+rvBF7+PZOc40ybeZMcGln6xJGVeY60E7jy9Mv5iKpMJpHgRE6dKy9ScsVxvfAYuEX4Q9a65DQX90KaQ3bA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-retry": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.5.tgz",
+      "integrity": "sha512-GBj3+EZBbN4NAqJ/7pAhsXdfzdlznOh8PydUijy6FpNIMnHPSMO2/rP4HKu+UFeikJxShERk528oy7GT79YiJg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/service-error-classification": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-stream": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.6.tgz",
+      "integrity": "sha512-qWw/UM59TiaFrPevefOZ8CNBKbYEP6wBAIlLqxn3VAIo9rgnTNc4ASbVrqDmhuwI87usnjhdQrxodzAGFFzbRQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/fetch-http-handler": "^5.3.6",
+        "@smithy/node-http-handler": "^4.4.5",
+        "@smithy/types": "^4.9.0",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-buffer-from": "^4.2.0",
+        "@smithy/util-hex-encoding": "^4.2.0",
+        "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.0.tgz",
+      "integrity": "sha512-igZpCKV9+E/Mzrpq6YacdTQ0qTiLm85gD6N/IrmyDvQFA4UnU3d5g3m8tMT/6zG/vVkWSU+VxeUyGonL62DuxA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.0.tgz",
+      "integrity": "sha512-zBPfuzoI8xyBtR2P6WQj63Rz8i3AmfAaJLuNG8dWsfvPe8lO4aCPYLn879mEgHndZH1zQ2oXmG8O1GGzzaoZiw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/util-waiter": {
+      "version": "4.2.5",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.2.5.tgz",
+      "integrity": "sha512-Dbun99A3InifQdIrsXZ+QLcC0PGBPAdrl4cj1mTgJvyc9N2zf7QSxg8TBkzsCmGJdE3TLbO9ycwpY0EkWahQ/g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@smithy/abort-controller": "^4.2.5",
+        "@smithy/types": "^4.9.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@smithy/uuid": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.0.tgz",
+      "integrity": "sha512-4aUIteuyxtBUhVdiQqcDhKFitwfd9hqoSDYY2KRXiWtgoWJ9Bmise+KfEPDiVHWeJepvF8xJO9/9+WDIciMFFw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@socket.io/component-emitter": {
@@ -4475,6 +6375,59 @@
         "node": ">=6"
       }
     },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.90.11",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.90.11.tgz",
+      "integrity": "sha512-f9z/nXhCgWDF4lHqgIE30jxLe4sYv15QodfdPDKYAk7nAEjNcndy4dHz3ezhdUaR23BpWa4I2EH4/DZ0//Uf8A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.91.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.91.1.tgz",
+      "integrity": "sha512-l8bxjk6BMsCaVQH6NzQEE/bEgFy1hAs5qbgXl0xhzezlaQbPk6Mgz9BqEg2vTLPOHD8N4k+w/gdgCbEzecGyNg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.90.11",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.11.tgz",
+      "integrity": "sha512-3uyzz01D1fkTLXuxF3JfoJoHQMU2fxsfJwE+6N5hHy0dVNoZOvwKP8Z2k7k1KDeD54N20apcJnG75TBAStIrBA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.90.11"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.91.1",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.91.1.tgz",
+      "integrity": "sha512-tRnJYwEbH0kAOuToy8Ew7bJw1lX3AjkkgSlf/vzb+NpnqmHPdWM+lA2DSdGQSLi1SU0PDRrrCI1vnZnci96CsQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.91.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.90.10",
+        "react": "^18 || ^19"
+      }
+    },
     "node_modules/@testing-library/dom": {
       "version": "10.4.0",
       "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.0.tgz",
@@ -4595,19 +6548,20 @@
       }
     },
     "node_modules/@testing-library/react/node_modules/@types/react-dom": {
-      "version": "18.3.5",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.5.tgz",
-      "integrity": "sha512-P4t6saawp+b/dFrUr2cvkVsfvPguwsxtH6dNIYRllMsefqFzkZk5UIjzyDOv5g1dXIPdG4Sp1yCR4Z6RCUsG/Q==",
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
         "@types/react": "^18.0.0"
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "14.5.2",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.5.2.tgz",
-      "integrity": "sha512-YAh82Wh4TIrxYLmfGcixwD18oIjyC1pFQC2Y01F2lzV2HTMiYrI0nze0FD0ocB//CKS/7jIUgae+adPqxK5yCQ==",
-      "dev": true,
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "license": "MIT",
       "engines": {
         "node": ">=12",
         "npm": ">=6"
@@ -5097,20 +7051,22 @@
       "dev": true
     },
     "node_modules/@types/react": {
-      "version": "19.0.6",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.0.6.tgz",
-      "integrity": "sha512-gIlMztcTeDgXCUj0vCBOqEuSEhX//63fW9SZtCJ+agxoQTOklwDfiEMlTWn4mR/C/UK5VHlpwsCsOyf7/hc4lw==",
+      "version": "19.2.7",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.7.tgz",
+      "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
+      "license": "MIT",
       "dependencies": {
-        "csstype": "^3.0.2"
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@types/react-dom": {
-      "version": "19.0.3",
-      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.0.3.tgz",
-      "integrity": "sha512-0Knk+HJiMP/qOZgMyNFamlIjw9OFCsyC2ZbigmEEyXXixgre6IQpm/4V+r3qH4GC1JPvRJKInw+on2rV6YZLeA==",
+      "version": "19.2.3",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
+      "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "dev": true,
+      "license": "MIT",
       "peerDependencies": {
-        "@types/react": "^19.0.0"
+        "@types/react": "^19.2.0"
       }
     },
     "node_modules/@types/react-redux": {
@@ -6595,6 +8551,12 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
       "dev": true
     },
+    "node_modules/bowser": {
+      "version": "2.13.1",
+      "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.13.1.tgz",
+      "integrity": "sha512-OHawaAbjwx6rqICCKgSG0SAnT05bzd7ppyKLVUITZpANBaaMFBAsaNkto3LoQ31tyFP5kNujE8Cdx85G9VzOkw==",
+      "license": "MIT"
+    },
     "node_modules/boxen": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-5.1.2.tgz",
@@ -7662,9 +9624,10 @@
       "dev": true
     },
     "node_modules/csstype": {
-      "version": "3.1.3",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
-      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw=="
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
     },
     "node_modules/d3-array": {
       "version": "3.2.4",
@@ -9194,6 +11157,24 @@
           "url": "https://opencollective.com/fastify"
         }
       ]
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.2.5",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
+      "integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^2.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
     },
     "node_modules/fastq": {
       "version": "1.18.0",
@@ -11857,6 +13838,57 @@
       "integrity": "sha512-9FzQjJ7MATs1tSpnco1K6ayiYE3figslrXA72G2HQ/n76RzvYlofyi5QM+iX4YRs/pu3yzxlVQSST23+dMDknw==",
       "engines": {
         "node": ">= 0.6.0"
+      }
+    },
+    "node_modules/joi": {
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.2.tgz",
+      "integrity": "sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/joi/node_modules/@hapi/address": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/joi/node_modules/@hapi/formula": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/joi/node_modules/@hapi/hoek": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/joi/node_modules/@hapi/topo": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
       }
     },
     "node_modules/js-levenshtein": {
@@ -15310,7 +17342,8 @@
     "node_modules/state-local": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/state-local/-/state-local-1.0.7.tgz",
-      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w=="
+      "integrity": "sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==",
+      "license": "MIT"
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -15478,6 +17511,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
+      "integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/styled-components": {
       "version": "5.3.11",

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "@monaco-editor/react": "^4.4.5",
     "@scality/certchain": "1.4.0",
     "@scality/core-ui": "0.185.0",
+    "@scality/data-browser-library": "1.0.0-preview.15",
     "@scality/module-federation": "^1.4.1",
     "@types/react-table": "^7.7.10",
     "@types/react-virtualized": "^9.21.20",

--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -45,6 +45,14 @@ const config: Configuration = {
   module: {
     rules: [
       {
+        test: /\.js$/,
+        include: [/data-browser-library/],
+        resolve: {
+          fullySpecified: false,
+        },
+        type: 'javascript/auto',
+      },
+      {
         test: /\.jsx$/,
         use: {
           loader: 'builtin:swc-loader',

--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -122,9 +122,6 @@ const config: Configuration = {
   resolve: {
     modules: ['node_modules'],
     extensions: ['.js', '.jsx', '.css', '.json', '.ts', '.tsx'],
-    alias: {
-      '@scality/core-ui': path.resolve(__dirname, 'node_modules/@scality/core-ui'),
-    },
   },
   plugins: [
     new ModuleFederationPlugin({

--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -122,6 +122,9 @@ const config: Configuration = {
   resolve: {
     modules: ['node_modules'],
     extensions: ['.js', '.jsx', '.css', '.json', '.ts', '.tsx'],
+    alias: {
+      '@scality/core-ui': path.resolve(__dirname, 'node_modules/@scality/core-ui'),
+    },
   },
   plugins: [
     new ModuleFederationPlugin({

--- a/src/react/ISV/components/ISVApplyActions.tsx
+++ b/src/react/ISV/components/ISVApplyActions.tsx
@@ -172,6 +172,7 @@ const Main = ({
             <Button
               disabled={!isContinue}
               variant="primary"
+              type="button"
               label={'Continue'}
               icon={<Icon name="Arrow-right" />}
               onClick={handleContinue}

--- a/src/react/ISV/components/ISVConfiguration.tsx
+++ b/src/react/ISV/components/ISVConfiguration.tsx
@@ -71,7 +71,8 @@ export const ISVConfiguration = () => {
         },
       ],
     },
-    resolver: joiResolver(platform.validator as any),
+    // @ts-expect-error - Type conflict between @hookform/resolvers versions in zenko-ui and data-browser-library
+    resolver: joiResolver(platform.validator),
     shouldUnregister: false,
   });
 

--- a/src/react/ISV/components/ISVConfiguration.tsx
+++ b/src/react/ISV/components/ISVConfiguration.tsx
@@ -16,7 +16,8 @@ import { FormProvider, useForm, Controller } from 'react-hook-form';
 import { joiResolver } from '@hookform/resolvers/joi';
 import { ISVConfig } from '../types';
 import { useStepper } from '@scality/core-ui/dist/components/steppers/Stepper.component';
-import { ISVStepsIndexes, useISVStepper } from './ISVSteps';
+import { useISVStepper } from './ISVStepperContext';
+import { ISVStepsIndexes } from './ISVSteps';
 import { ISVSkipModal } from './ISVSkipModal';
 import BucketField from './BucketField';
 import { useIAMUser } from '../hooks/useIAMUser';
@@ -70,7 +71,7 @@ export const ISVConfiguration = () => {
         },
       ],
     },
-    resolver: joiResolver(platform.validator),
+    resolver: joiResolver(platform.validator as any),
     shouldUnregister: false,
   });
 

--- a/src/react/ISV/components/ISVStepperContext.tsx
+++ b/src/react/ISV/components/ISVStepperContext.tsx
@@ -1,0 +1,19 @@
+import { createContext, useContext } from 'react';
+import { ISVPlatformConfig } from '../types';
+
+export type ISVStepperContextType = {
+  platform: ISVPlatformConfig;
+};
+
+export const ISVStepperContext = createContext<
+  ISVStepperContextType | undefined
+>(undefined);
+
+export const useISVStepper = () => {
+  const context = useContext(ISVStepperContext);
+  if (!context) {
+    throw new Error('useISVStepper must be used within ISVStepperProvider');
+  }
+  return context;
+};
+

--- a/src/react/ISV/components/ISVSteps.tsx
+++ b/src/react/ISV/components/ISVSteps.tsx
@@ -1,8 +1,6 @@
 import { spacing, Stepper } from '@scality/core-ui';
-import { createContext, useContext, useMemo } from 'react';
+import { useMemo } from 'react';
 import { ISVConfiguration } from './ISVConfiguration';
-
-import { ISVPlatformConfig } from '../types';
 
 import { useTheme } from 'styled-components';
 import { Box } from '@scality/core-ui/dist/next';
@@ -11,6 +9,7 @@ import ISVApplyActions from './ISVApplyActions';
 
 import { useSearchParams } from 'react-router';
 import { isvModules } from '../modules';
+import { ISVStepperContext } from './ISVStepperContext';
 
 
 export enum ISVStepsIndexes {
@@ -18,22 +17,6 @@ export enum ISVStepsIndexes {
   ApplyActions,
   Summary,
 }
-
-export type ISVStepperContextType = {
-  platform: ISVPlatformConfig;
-};
-
-export const ISVStepperContext = createContext<
-  ISVStepperContextType | undefined
->(undefined);
-
-export const useISVStepper = () => {
-  const context = useContext(ISVStepperContext);
-  if (!context) {
-    throw new Error('useISVStepper must be used within ISVStepperProvider');
-  }
-  return context;
-};
 
 export const ISV_STEPS = [
   {

--- a/src/react/ISV/components/ISVSummary.tsx
+++ b/src/react/ISV/components/ISVSummary.tsx
@@ -15,7 +15,7 @@ import { useAuthGroups } from '../../utils/hooks';
 import { useBasenameRelativeNavigate } from '@scality/module-federation';
 import { HideCredential } from '../../ui-elements/Hide';
 import { useGetS3ServicePoint } from '../hooks/useGetS3ServicePoint';
-import { useISVStepper } from './ISVSteps';
+import { useISVStepper } from './ISVStepperContext';
 import { ISVConfig, ISVPlatformConfig } from '../types';
 import { queries } from '../../next-architecture/domain/business/buckets';
 import { useS3Client } from '../../next-architecture/ui/S3ClientProvider';

--- a/src/react/ISV/components/__tests__/ISVConfiguration.test.tsx
+++ b/src/react/ISV/components/__tests__/ISVConfiguration.test.tsx
@@ -1,7 +1,7 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { ISVConfiguration } from '../ISVConfiguration';
-import { ISVStepperContext } from '../ISVSteps';
+import { ISVStepperContext } from '../ISVStepperContext';
 import { useListAccounts } from '../../../next-architecture/domain/business/accounts';
 import { Veeam } from '../../modules/veeam';
 import { Commvault } from '../../modules/commvault';

--- a/src/react/ISV/components/__tests__/ISVSteps.test.tsx
+++ b/src/react/ISV/components/__tests__/ISVSteps.test.tsx
@@ -1,6 +1,6 @@
 import { render, screen } from '@testing-library/react';
 import * as React from 'react';
-import { ISVStepperContext, useISVStepper } from '../ISVSteps';
+import { ISVStepperContext, useISVStepper } from '../ISVStepperContext';
 import { Veeam } from '../../modules/veeam';
 import { Commvault } from '../../modules/commvault';
 import { VeeamVBO } from '../../modules/veeam-vbo';

--- a/src/react/ISV/components/__tests__/ISVSummary.test.tsx
+++ b/src/react/ISV/components/__tests__/ISVSummary.test.tsx
@@ -16,7 +16,7 @@ import {
   renderWithCustomRoute,
   Wrapper,
 } from '../../../utils/testUtil';
-import { ISVStepperContext, ISVStepperContextType } from '../ISVSteps';
+import { ISVStepperContext, ISVStepperContextType } from '../ISVStepperContext';
 import { ISVPlatformConfig } from '../../types';
 import { Route, Routes, useParams } from 'react-router';
 import { Veeam } from '../../modules/veeam';

--- a/src/react/ISV/modules/veeam/components/VeeamCapacityModal.tsx
+++ b/src/react/ISV/modules/veeam/components/VeeamCapacityModal.tsx
@@ -59,6 +59,7 @@ export const VeeamCapacityModalInternal = ({
   const { capacityValue, capacityUnit } = useCapacityUnit(maxCapacity);
   const methods = useForm<VeeamCapacityForm>({
     mode: 'all',
+    // @ts-expect-error - Type conflict between @hookform/resolvers versions in zenko-ui and data-browser-library
     resolver: joiResolver(schema),
     defaultValues: {
       capacity: capacityValue,

--- a/src/react/Routes.tsx
+++ b/src/react/Routes.tsx
@@ -31,13 +31,11 @@ import Endpoints from './endpoint/Endpoints';
 import EndpointCreate from './endpoint/EndpointCreate';
 import AccountCreate from './account/AccountCreate';
 import AccountContent from './account/AccountContent';
-import BucketCreate from './databrowser/buckets/BucketCreate';
 import DataBrowser from './databrowser/DataBrowser';
 import LocationEditor from './locations/LocationEditor';
 import { useBasenameRelativeNavigate } from '@scality/module-federation';
 import Workflows from './workflow/Workflows';
 import CreateWorkflow from './workflow/CreateWorkflow';
-import Objects from './databrowser/objects/Objects';
 import Attachments from './account/iamAttachment/Attachments';
 import AccountUpdateUser from './account/AccountUpdateUser';
 import UpdateAccountPolicy from './account/UpdateAccountPolicy';
@@ -332,22 +330,6 @@ export function PrivateRoutes() {
         }
       />
       <Route
-        path="accounts/:accountName/create-bucket/*"
-        element={
-          <DataServiceRoleProvider>
-            <BucketCreate />
-          </DataServiceRoleProvider>
-        }
-      />
-      <Route
-        path={'accounts/:accountName/buckets/:bucketName/objects'}
-        element={
-          <DataServiceRoleProvider>
-            <Objects />
-          </DataServiceRoleProvider>
-        }
-      />
-      <Route
         path="accounts/:accountName/data/buckets/*"
         element={
           <DataServiceRoleProvider>
@@ -433,7 +415,6 @@ function InternalRoutes() {
     '/locations/:locations/edit',
     '/accounts/:accountName/create-user',
     '/accounts/:accountName/users/:user/update-user',
-    '/accounts/:accountName/create-bucket',
     '/accounts/:accountName/workflows/create-workflow',
     '/accounts/:accountName/create-policy',
     '/isv/configuration',

--- a/src/react/Routes.tsx
+++ b/src/react/Routes.tsx
@@ -96,7 +96,11 @@ const RedirectToAccount = () => {
   }
 };
 
-export function PrivateRoutes() {
+export function PrivateRoutes({
+  hideSideBar = false,
+}: {
+  hideSideBar?: boolean;
+}) {
   const dispatch = useDispatch();
   const isClientsLoaded = useSelector(
     (state: AppState) => state.auth.isClientsLoaded,
@@ -333,7 +337,7 @@ export function PrivateRoutes() {
         path="accounts/:accountName/data/buckets/*"
         element={
           <DataServiceRoleProvider>
-            <DataBrowser />
+            <DataBrowser hideHeader={hideSideBar} />
           </DataServiceRoleProvider>
         }
       />
@@ -341,7 +345,7 @@ export function PrivateRoutes() {
         path="accounts/:accountName/buckets/*"
         element={
           <DataServiceRoleProvider>
-            <DataBrowser />
+            <DataBrowser hideHeader={hideSideBar} />
           </DataServiceRoleProvider>
         }
       />
@@ -419,6 +423,13 @@ function InternalRoutes() {
     '/accounts/:accountName/create-policy',
     '/isv/configuration',
     '/truststore/import-certificate',
+    '/accounts/:accountName/buckets/-/create',
+    '/accounts/:accountName/buckets/:bucketName/lifecycle/create',
+    '/accounts/:accountName/buckets/:bucketName/lifecycle/edit/:ruleId',
+    '/accounts/:accountName/buckets/:bucketName/replication/create',
+    '/accounts/:accountName/buckets/:bucketName/replication/edit/:ruleId',
+    '/accounts/:accountName/buckets/:bucketName/objects/object-lock-settings',
+    '/accounts/:accountName/buckets/:bucketName/notifications/create',
   ];
 
   const hideSideBar = doesRouteMatch(routeWithoutSideBars);
@@ -506,7 +517,7 @@ function InternalRoutes() {
       >
         <RemoveTrailingSlash />
         <ManagementProvider>
-          <PrivateRoutes />
+          <PrivateRoutes hideSideBar={hideSideBar} />
         </ManagementProvider>
       </AppContainer>
     </>

--- a/src/react/account/AccountCreate.tsx
+++ b/src/react/account/AccountCreate.tsx
@@ -48,6 +48,7 @@ function AccountCreate() {
     formState: { errors },
   } = useForm<AccountFormField>({
     mode: 'all',
+    // @ts-expect-error - Type conflict between @hookform/resolvers versions in zenko-ui and data-browser-library
     resolver: joiResolver(schema),
   });
   const navigate = useNavigate();

--- a/src/react/account/AccountCreateUser.tsx
+++ b/src/react/account/AccountCreateUser.tsx
@@ -53,6 +53,7 @@ const AccountCreateUser = () => {
     formState: { errors },
   } = useForm({
     mode: 'all',
+    // @ts-expect-error - Type conflict between @hookform/resolvers versions in zenko-ui and data-browser-library
     resolver: joiResolver(schema),
     defaultValues: { name: '' },
   });

--- a/src/react/account/AccountUpdateUser.tsx
+++ b/src/react/account/AccountUpdateUser.tsx
@@ -49,6 +49,7 @@ const AccountUpdateUser = () => {
 
     formState: { errors },
   } = useForm({
+    // @ts-expect-error - Type conflict between @hookform/resolvers versions in zenko-ui and data-browser-library
     resolver: joiResolver(schema),
     defaultValues: { name: IAMUserName },
   });

--- a/src/react/databrowser/BucketLocationsPrefetch.tsx
+++ b/src/react/databrowser/BucketLocationsPrefetch.tsx
@@ -1,0 +1,37 @@
+import {
+  useBuckets,
+  useGetBucketLocation,
+} from '@scality/data-browser-library';
+import { memo } from 'react';
+
+/**
+ * Single bucket location prefetcher.
+ * Triggers the useGetBucketLocation hook to populate React Query cache.
+ */
+const HiddenLocationFetcher = memo(({ bucketName }: { bucketName: string }) => {
+  useGetBucketLocation({ Bucket: bucketName });
+  return null;
+});
+
+HiddenLocationFetcher.displayName = 'HiddenLocationFetcher';
+
+/**
+ * Prefetch component for bucket locations.
+ */
+export const BucketLocationsPrefetch = () => {
+  const { data: bucketsData } = useBuckets();
+  const buckets = bucketsData?.Buckets || [];
+
+  // Early return for empty state
+  if (buckets.length === 0) {
+    return null;
+  }
+
+  return (
+    <>
+      {buckets.map((bucket) => (
+        <HiddenLocationFetcher key={bucket.Name} bucketName={bucket.Name} />
+      ))}
+    </>
+  );
+};

--- a/src/react/databrowser/DataBrowser.tsx
+++ b/src/react/databrowser/DataBrowser.tsx
@@ -19,6 +19,7 @@ import { LocationSection } from './buckets/LocationSection';
 import { StartISVConnectorButton } from '../ISV/components/StartISVConnectorButton';
 import { useDataBrowserS3Config } from './hooks/useDataBrowserS3Config';
 import { BucketMetricsPrefetch } from './hooks/useBucketMetrics';
+import { BucketLocationsPrefetch } from './BucketLocationsPrefetch';
 
 const EXTRA_BUCKET_OVERVIEW_SECTIONS = [
   {
@@ -112,6 +113,7 @@ export default function DataBrowser({
   return (
     <DataBrowserProvider getS3Config={getS3Config} theme={theme}>
       <BucketMetricsPrefetch />
+      <BucketLocationsPrefetch />
       <DataBrowserUI
         basePath={dataBrowserBasePath}
         header={hideHeader ? undefined : headerComponent}

--- a/src/react/databrowser/DataBrowser.tsx
+++ b/src/react/databrowser/DataBrowser.tsx
@@ -52,9 +52,7 @@ export default function DataBrowser({
   const { basePath } = useConfig();
   const { getS3Config } = useDataBrowserS3Config();
 
-  const dataBrowserBasePath = useMemo(() => {
-    return `${basePath}/accounts/${accountName}`;
-  }, [basePath, accountName]);
+  const dataBrowserBasePath = `${basePath}/accounts/${accountName}`;
 
   const extraBucketListColumns = useMemo(() => {
     const columns: ColumnConfig<Bucket>[] = [
@@ -80,15 +78,12 @@ export default function DataBrowser({
     return columns;
   }, [isStorageManager]);
 
-  const extraBucketListActions = useMemo(
-    () => [
-      {
-        id: 'startISVConnector',
-        render: () => <StartISVConnectorButton />,
-      },
-    ],
-    [],
-  );
+  const extraBucketListActions = [
+    {
+      id: 'startISVConnector',
+      render: () => <StartISVConnectorButton />,
+    },
+  ];
 
   const headerComponent = useMemo(
     () => (

--- a/src/react/databrowser/DataBrowser.tsx
+++ b/src/react/databrowser/DataBrowser.tsx
@@ -64,14 +64,17 @@ export default function DataBrowser({
         width: '280px',
         cellStyle: { textAlign: 'left' },
       },
-      isStorageManager && {
+    ];
+
+    if (isStorageManager) {
+      columns.push({
         id: 'dataUsed',
         header: 'Data Used',
         render: DataUsedColumn,
         width: '150px',
         cellStyle: { textAlign: 'right' },
-      },
-    ];
+      });
+    }
 
     return columns;
   }, [isStorageManager]);
@@ -105,8 +108,8 @@ export default function DataBrowser({
     [pathname, prefixPath, accountName, basePath],
   );
 
+  // TODO: Move DataBrowserProvider to the S3ClientProvider when refactoring the S3ClientProvider
   return (
-    // {/* TODO: Move DataBrowserProvider to the S3ClientProvider when refactoring the S3ClientProvider */}
     <DataBrowserProvider getS3Config={getS3Config} theme={theme}>
       <BucketMetricsPrefetch />
       <DataBrowserUI

--- a/src/react/databrowser/DataBrowser.tsx
+++ b/src/react/databrowser/DataBrowser.tsx
@@ -1,113 +1,122 @@
+import { useMemo } from 'react';
 import { Route, Routes, useLocation, useParams } from 'react-router';
-import { useDispatch, useSelector } from 'react-redux';
-
-import { AppState } from '../../types/state';
+import { useTheme } from 'styled-components';
 import { Breadcrumb, breadcrumbPathsBuckets } from '../ui-elements/Breadcrumb';
-import Buckets from './buckets/Buckets';
-import { EmptyStateContainer } from '../ui-elements/Container';
 import ListLayoutButtons from './HeaderButtons';
-import Objects from './objects/Objects';
-import { Warning } from '../ui-elements/Warning';
-import { clearError } from '../actions';
-import ObjectLockSetting from './buckets/ObjectLockSetting';
-import ObjectLockSettingOnObject from './objects/ObjectLockSetting';
-import { useAccounts, useQueryParams } from '../utils/hooks';
-import { AppContainer, EmptyState, Icon } from '@scality/core-ui';
+import { useAuthGroups, useQueryParams } from '../utils/hooks';
 import { Box } from '@scality/core-ui/dist/next';
-import { useS3Client } from '../next-architecture/ui/S3ClientProvider';
-import Loader from '../ui-elements/Loader';
-import { useBasenameRelativeNavigate } from '@scality/module-federation';
 import { useConfig } from '../next-architecture/ui/ConfigProvider';
+import {
+  Bucket,
+  ColumnConfig,
+  DataBrowserProvider,
+  DataBrowserUI,
+} from '@scality/data-browser-library';
+import { StorageLocationColumn } from './buckets/StorageLocationColumn';
+import { DataUsedColumn } from './buckets/DataUsedColumn';
+import { UseCaseSection } from './buckets/UseCaseSection';
+import { LocationSection } from './buckets/LocationSection';
+import { StartISVConnectorButton } from '../ISV/components/StartISVConnectorButton';
+import { useDataBrowserS3Config } from './hooks/useDataBrowserS3Config';
+import { BucketMetricsPrefetch } from './hooks/useBucketMetrics';
 
-export default function DataBrowser() {
-  const dispatch = useDispatch();
-  const navigate = useBasenameRelativeNavigate();
+const EXTRA_BUCKET_OVERVIEW_SECTIONS = [
+  {
+    id: 'useCase',
+    title: 'Use-case',
+    render: UseCaseSection,
+  },
+];
+
+const EXTRA_BUCKET_OVERVIEW_GENERAL = [
+  {
+    id: 'location',
+    render: LocationSection,
+  },
+];
+
+export default function DataBrowser({
+  hideHeader = false,
+}: {
+  hideHeader?: boolean;
+}) {
   const { accountName } = useParams<{ accountName: string }>();
-  const { accounts } = useAccounts();
-  const hasError = useSelector(
-    (state: AppState) =>
-      !!state.uiErrors.errorMsg && state.uiErrors.errorType === 'byComponent',
-  );
-  const errorMessage = useSelector(
-    (state: AppState) => state.uiErrors.errorMsg,
-  );
+  const { isStorageManager } = useAuthGroups();
+  const theme = useTheme();
+
   const { pathname } = useLocation();
   const query = useQueryParams();
   const prefixPath = query.get('prefix');
 
-  const s3Client = useS3Client();
   const { basePath } = useConfig();
+  const { getS3Config } = useDataBrowserS3Config();
 
-  if (!s3Client.config.credentials?.accessKeyId) {
-    return (
-      <Loader>
-        <>Authenticating...</>
-      </Loader>
-    );
-  }
+  const dataBrowserBasePath = useMemo(() => {
+    return `${basePath}/accounts/${accountName}`;
+  }, [basePath, accountName]);
 
-  // NOTE: create-bucket page has its own way to manage "byComponent" errors.
-  if (hasError) {
-    return (
-      <EmptyStateContainer>
-        <Warning
-          centered={true}
-          icon={<Icon name="Exclamation-triangle" size="5x" />}
-          title={errorMessage || 'An unexpected error has occurred.'}
-          btnTitle="Display buckets"
-          btnAction={() => {
-            dispatch(clearError());
-            navigate('/buckets');
-          }}
+  const extraBucketListColumns = useMemo(() => {
+    const columns: ColumnConfig<Bucket>[] = [
+      {
+        id: 'location',
+        header: 'Storage Location',
+        render: StorageLocationColumn,
+        width: '280px',
+        cellStyle: { textAlign: 'left' },
+      },
+      isStorageManager && {
+        id: 'dataUsed',
+        header: 'Data Used',
+        render: DataUsedColumn,
+        width: '150px',
+        cellStyle: { textAlign: 'right' },
+      },
+    ];
+
+    return columns;
+  }, [isStorageManager]);
+
+  const extraBucketListActions = useMemo(
+    () => [
+      {
+        id: 'startISVConnector',
+        render: () => <StartISVConnectorButton />,
+      },
+    ],
+    [],
+  );
+
+  const headerComponent = useMemo(
+    () => (
+      <Box display="flex" alignItems="center" justifyContent="space-between">
+        <Breadcrumb
+          breadcrumbPaths={breadcrumbPathsBuckets(
+            pathname,
+            prefixPath,
+            accountName,
+            basePath,
+          )}
         />
-      </EmptyStateContainer>
-    );
-  }
-
-  if (accounts.length === 0) {
-    return (
-      <EmptyState
-        icon="Bucket"
-        link={`${basePath}/create-account`}
-        listedResource={{
-          singular: 'Bucket',
-          plural: 'Buckets',
-        }}
-        resourceToCreate="Account"
-      />
-    );
-  }
+        <Routes>
+          <Route path={':bucketName'} element={<ListLayoutButtons />} />
+        </Routes>
+      </Box>
+    ),
+    [pathname, prefixPath, accountName, basePath],
+  );
 
   return (
-    <Box display="flex" flexDirection="column" height="100%">
-      <AppContainer.ContextContainer>
-        <Box display="flex" alignItems="center" justifyContent="space-between">
-          <Breadcrumb
-            breadcrumbPaths={breadcrumbPathsBuckets(
-              pathname,
-              prefixPath,
-              accountName,
-              basePath,
-            )}
-          />
-          <Routes>
-            <Route path={':bucketName'} element={<ListLayoutButtons />} />
-          </Routes>
-        </Box>
-      </AppContainer.ContextContainer>
-
-      <Routes>
-        <Route
-          path={':bucketName/retention-setting'}
-          element={<ObjectLockSetting />}
-        />
-        <Route
-          path={':bucketName/objects-retention-setting'}
-          element={<ObjectLockSettingOnObject />}
-        />
-        <Route path={':bucketName/objects/*'} element={<Objects />} />
-        <Route path={':bucketName?'} element={<Buckets />} />
-      </Routes>
-    </Box>
+    // {/* TODO: Move DataBrowserProvider to the S3ClientProvider when refactoring the S3ClientProvider */}
+    <DataBrowserProvider getS3Config={getS3Config} theme={theme}>
+      <BucketMetricsPrefetch />
+      <DataBrowserUI
+        basePath={dataBrowserBasePath}
+        header={hideHeader ? undefined : headerComponent}
+        extraBucketListColumns={extraBucketListColumns}
+        extraBucketOverviewSections={EXTRA_BUCKET_OVERVIEW_SECTIONS}
+        extraBucketOverviewGeneral={EXTRA_BUCKET_OVERVIEW_GENERAL}
+        extraBucketListActions={extraBucketListActions}
+      />
+    </DataBrowserProvider>
   );
 }

--- a/src/react/databrowser/buckets/BucketCreate.tsx
+++ b/src/react/databrowser/buckets/BucketCreate.tsx
@@ -77,6 +77,7 @@ function BucketCreate() {
 
   const useFormMethods = useForm({
     mode: 'all',
+    // @ts-expect-error - Type conflict between @hookform/resolvers versions in zenko-ui and data-browser-library
     resolver: joiResolver(schema),
     defaultValues: {
       name: '',

--- a/src/react/databrowser/buckets/DataUsedColumn.tsx
+++ b/src/react/databrowser/buckets/DataUsedColumn.tsx
@@ -1,0 +1,16 @@
+import { Bucket } from '@scality/data-browser-library';
+import { useMetricsAdapter } from '../../next-architecture/ui/MetricsAdapterProvider';
+import { UsedCapacityInlinePromiseResult } from '../../next-architecture/ui/metrics/LatestUsedCapacity';
+import { useBucketMetrics } from '../hooks/useBucketMetrics';
+
+export const DataUsedColumn = ({ data }: { data: Bucket }) => {
+  const bucketName = data.Name;
+
+  const metricsAdapter = useMetricsAdapter();
+  const { usedCapacity } = useBucketMetrics({
+    metricsAdapter,
+    bucketName,
+  });
+
+  return <UsedCapacityInlinePromiseResult result={usedCapacity} />;
+};

--- a/src/react/databrowser/buckets/LocationSection.tsx
+++ b/src/react/databrowser/buckets/LocationSection.tsx
@@ -1,0 +1,44 @@
+import { Loader } from '@scality/core-ui';
+import {
+  useGetBucketLocation,
+  useBucketOverviewContext,
+} from '@scality/data-browser-library';
+import { useLocationAndStorageInfos } from '../../next-architecture/domain/business/locations';
+import { useAccountsLocationsEndpointsAdapter } from '../../next-architecture/ui/AccountsLocationsEndpointsAdapterProvider';
+
+export function LocationSection() {
+  const { bucketName } = useBucketOverviewContext();
+
+  const { data: bucketLocation, status } = useGetBucketLocation({
+    Bucket: bucketName,
+  });
+
+  const accountsLocationsEndpointsAdapter =
+    useAccountsLocationsEndpointsAdapter();
+  const locationConstraint = bucketLocation?.LocationConstraint || 'us-east-1';
+  const locationInfos = useLocationAndStorageInfos({
+    accountsLocationsEndpointsAdapter,
+    locationName: locationConstraint,
+  });
+
+  if (status === 'pending') {
+    return <Loader size="small" />;
+  }
+
+  if (status === 'error') {
+    return <>Error</>;
+  }
+
+  if (
+    locationInfos.status === 'loading' ||
+    locationInfos.status === 'unknown'
+  ) {
+    return <Loader size="small" />;
+  }
+
+  if (locationInfos.status === 'error') {
+    return <>{locationConstraint || 'us-east-1'}</>;
+  }
+
+  return <>{locationInfos.value.nameAndShortType}</>;
+}

--- a/src/react/databrowser/buckets/LocationSection.tsx
+++ b/src/react/databrowser/buckets/LocationSection.tsx
@@ -1,44 +1,18 @@
 import { Loader } from '@scality/core-ui';
-import {
-  useGetBucketLocation,
-  useBucketOverviewContext,
-} from '@scality/data-browser-library';
-import { useLocationAndStorageInfos } from '../../next-architecture/domain/business/locations';
-import { useAccountsLocationsEndpointsAdapter } from '../../next-architecture/ui/AccountsLocationsEndpointsAdapterProvider';
+import { useBucketOverviewContext } from '@scality/data-browser-library';
+import { useBucketLocationDisplay } from '../hooks/useBucketLocationDisplay';
 
 export function LocationSection() {
   const { bucketName } = useBucketOverviewContext();
+  const locationResult = useBucketLocationDisplay(bucketName);
 
-  const { data: bucketLocation, status } = useGetBucketLocation({
-    Bucket: bucketName,
-  });
-
-  const accountsLocationsEndpointsAdapter =
-    useAccountsLocationsEndpointsAdapter();
-  const locationConstraint = bucketLocation?.LocationConstraint || 'us-east-1';
-  const locationInfos = useLocationAndStorageInfos({
-    accountsLocationsEndpointsAdapter,
-    locationName: locationConstraint,
-  });
-
-  if (status === 'pending') {
+  if (locationResult.status === 'loading') {
     return <Loader size="small" />;
   }
 
-  if (status === 'error') {
-    return <>Error</>;
+  if (locationResult.status === 'error') {
+    return <>{locationResult.fallback}</>;
   }
 
-  if (
-    locationInfos.status === 'loading' ||
-    locationInfos.status === 'unknown'
-  ) {
-    return <Loader size="small" />;
-  }
-
-  if (locationInfos.status === 'error') {
-    return <>{locationConstraint || 'us-east-1'}</>;
-  }
-
-  return <>{locationInfos.value.nameAndShortType}</>;
+  return <>{locationResult.display}</>;
 }

--- a/src/react/databrowser/buckets/ObjectLockSetting.tsx
+++ b/src/react/databrowser/buckets/ObjectLockSetting.tsx
@@ -38,6 +38,7 @@ export default function ObjectLockSetting() {
   const isObjectLockEnabled = objectLockEnabled === 'Enabled';
   const useFormMethods = useForm({
     mode: 'all',
+    // @ts-expect-error - Type conflict between @hookform/resolvers versions in zenko-ui and data-browser-library
     resolver: joiResolver(schema),
     defaultValues: {
       isObjectLockEnabled: isObjectLockEnabled,

--- a/src/react/databrowser/buckets/StorageLocationColumn.tsx
+++ b/src/react/databrowser/buckets/StorageLocationColumn.tsx
@@ -1,41 +1,18 @@
 import { Loader } from '@scality/core-ui';
-import { Bucket, useGetBucketLocation } from '@scality/data-browser-library';
-import { useLocationAndStorageInfos } from '../../next-architecture/domain/business/locations';
-import { useAccountsLocationsEndpointsAdapter } from '../../next-architecture/ui/AccountsLocationsEndpointsAdapterProvider';
+import { Bucket } from '@scality/data-browser-library';
+import { useBucketLocationDisplay } from '../hooks/useBucketLocationDisplay';
 
 export const StorageLocationColumn = ({ data }: { data: Bucket }) => {
   const bucketName = data.Name;
+  const locationResult = useBucketLocationDisplay(bucketName);
 
-  const { data: bucketLocation, status } = useGetBucketLocation({
-    Bucket: bucketName,
-  });
-
-  const accountsLocationsEndpointsAdapter =
-    useAccountsLocationsEndpointsAdapter();
-  const locationConstraint = bucketLocation?.LocationConstraint || 'us-east-1';
-  const locationInfos = useLocationAndStorageInfos({
-    accountsLocationsEndpointsAdapter,
-    locationName: locationConstraint,
-  });
-
-  if (status === 'pending') {
+  if (locationResult.status === 'loading') {
     return <Loader size="small" />;
   }
 
-  if (status === 'error') {
-    return <>Error loading location</>;
+  if (locationResult.status === 'error') {
+    return <>{locationResult.fallback}</>;
   }
 
-  if (
-    locationInfos.status === 'loading' ||
-    locationInfos.status === 'unknown'
-  ) {
-    return <Loader size="small" />;
-  }
-
-  if (locationInfos.status === 'error') {
-    return <>{locationConstraint || 'us-east-1'}</>;
-  }
-
-  return <>{locationInfos.value.nameAndShortType}</>;
+  return <>{locationResult.display}</>;
 };

--- a/src/react/databrowser/buckets/StorageLocationColumn.tsx
+++ b/src/react/databrowser/buckets/StorageLocationColumn.tsx
@@ -1,0 +1,41 @@
+import { Loader } from '@scality/core-ui';
+import { Bucket, useGetBucketLocation } from '@scality/data-browser-library';
+import { useLocationAndStorageInfos } from '../../next-architecture/domain/business/locations';
+import { useAccountsLocationsEndpointsAdapter } from '../../next-architecture/ui/AccountsLocationsEndpointsAdapterProvider';
+
+export const StorageLocationColumn = ({ data }: { data: Bucket }) => {
+  const bucketName = data.Name;
+
+  const { data: bucketLocation, status } = useGetBucketLocation({
+    Bucket: bucketName,
+  });
+
+  const accountsLocationsEndpointsAdapter =
+    useAccountsLocationsEndpointsAdapter();
+  const locationConstraint = bucketLocation?.LocationConstraint || 'us-east-1';
+  const locationInfos = useLocationAndStorageInfos({
+    accountsLocationsEndpointsAdapter,
+    locationName: locationConstraint,
+  });
+
+  if (status === 'pending') {
+    return <Loader size="small" />;
+  }
+
+  if (status === 'error') {
+    return <>Error loading location</>;
+  }
+
+  if (
+    locationInfos.status === 'loading' ||
+    locationInfos.status === 'unknown'
+  ) {
+    return <Loader size="small" />;
+  }
+
+  if (locationInfos.status === 'error') {
+    return <>{locationConstraint || 'us-east-1'}</>;
+  }
+
+  return <>{locationInfos.value.nameAndShortType}</>;
+};

--- a/src/react/databrowser/buckets/UseCaseSection.tsx
+++ b/src/react/databrowser/buckets/UseCaseSection.tsx
@@ -1,18 +1,16 @@
 import {
-  BUCKET_TAG_APPLICATION,
-  BUCKET_TAG_VEEAM_APPLICATION,
-  COMMVAULT_APPLICATION,
-  VEEAM_BACKUP_REPLICATION,
-} from '../../ISV/constants';
-import { VeeamApplicationType } from '../../ISV/constants';
-import { VEEAM_VBO_APPLICATION } from '../../ISV/modules/veeam-vbo';
-import {
   useGetBucketTagging,
   useBucketOverviewContext,
 } from '@scality/data-browser-library';
 import { VeeamCapacityOverviewRow } from '../../ISV/modules/veeam/components/VeeamCapacityOverviewRow';
 import { Row, Key, Value } from '../../ui-elements/TableKeyValue2';
+import { detectBucketApplication } from '../utils/bucketApplicationDetector';
 
+/**
+ * Displays the ISV application use-case for a bucket.
+ * Shows application type (Veeam, Commvault, or S3 Generic) and
+ * conditionally displays Veeam capacity metrics.
+ */
 export const UseCaseSection = () => {
   const { bucketName } = useBucketOverviewContext();
 
@@ -30,39 +28,16 @@ export const UseCaseSection = () => {
     });
   }
 
-  // Keep this to avoid breaking changes
-  const veeamTagApplication =
-    taggingStatus === 'success' && tags[BUCKET_TAG_VEEAM_APPLICATION];
-  // New tag for ISV application
-  const ISVApplicationTag =
-    taggingStatus === 'success' && tags[BUCKET_TAG_APPLICATION];
-
-  const isVeeamBucket =
-    veeamTagApplication === VeeamApplicationType.VEEAM_BACKUP_REPLICATION ||
-    veeamTagApplication === VeeamApplicationType.VEEAM_OFFICE_365 ||
-    veeamTagApplication === VeeamApplicationType.VEEAM_OFFICE_365_V8;
-  const isISVBucketTagAsVeeam =
-    ISVApplicationTag === VEEAM_BACKUP_REPLICATION ||
-    ISVApplicationTag === VEEAM_VBO_APPLICATION;
-  const isISVCommvault = ISVApplicationTag === COMMVAULT_APPLICATION;
-
-  const applicationValue = isISVCommvault
-    ? COMMVAULT_APPLICATION
-    : isVeeamBucket || isISVBucketTagAsVeeam
-    ? `${veeamTagApplication || ISVApplicationTag || 'S3 Generic'}`
-    : ISVApplicationTag || 'S3 Generic';
-
-  const shouldShowVeeamCapacity =
-    ISVApplicationTag === VEEAM_BACKUP_REPLICATION ||
-    veeamTagApplication === VEEAM_BACKUP_REPLICATION;
+  // Detect application type and determine what to display
+  const application = detectBucketApplication(tags);
 
   return (
     <>
       <Row>
         <Key>Application</Key>
-        <Value>{applicationValue}</Value>
+        <Value>{application.displayName}</Value>
       </Row>
-      {shouldShowVeeamCapacity && (
+      {application.shouldShowVeeamCapacity && (
         <VeeamCapacityOverviewRow bucketName={bucketName} />
       )}
     </>

--- a/src/react/databrowser/buckets/UseCaseSection.tsx
+++ b/src/react/databrowser/buckets/UseCaseSection.tsx
@@ -1,0 +1,70 @@
+import {
+  BUCKET_TAG_APPLICATION,
+  BUCKET_TAG_VEEAM_APPLICATION,
+  COMMVAULT_APPLICATION,
+  VEEAM_BACKUP_REPLICATION,
+} from '../../ISV/constants';
+import { VeeamApplicationType } from '../../ISV/constants';
+import { VEEAM_VBO_APPLICATION } from '../../ISV/modules/veeam-vbo';
+import {
+  useGetBucketTagging,
+  useBucketOverviewContext,
+} from '@scality/data-browser-library';
+import { VeeamCapacityOverviewRow } from '../../ISV/modules/veeam/components/VeeamCapacityOverviewRow';
+import { Row, Key, Value } from '../../ui-elements/TableKeyValue2';
+
+export const UseCaseSection = () => {
+  const { bucketName } = useBucketOverviewContext();
+
+  const { data: taggingData, status: taggingStatus } = useGetBucketTagging({
+    Bucket: bucketName,
+  });
+
+  // Convert TagSet array to key-value object
+  const tags: Record<string, string> = {};
+  if (taggingStatus === 'success' && taggingData?.TagSet) {
+    taggingData.TagSet.forEach((tag) => {
+      if (tag.Key && tag.Value) {
+        tags[tag.Key] = tag.Value;
+      }
+    });
+  }
+
+  // Keep this to avoid breaking changes
+  const veeamTagApplication =
+    taggingStatus === 'success' && tags[BUCKET_TAG_VEEAM_APPLICATION];
+  // New tag for ISV application
+  const ISVApplicationTag =
+    taggingStatus === 'success' && tags[BUCKET_TAG_APPLICATION];
+
+  const isVeeamBucket =
+    veeamTagApplication === VeeamApplicationType.VEEAM_BACKUP_REPLICATION ||
+    veeamTagApplication === VeeamApplicationType.VEEAM_OFFICE_365 ||
+    veeamTagApplication === VeeamApplicationType.VEEAM_OFFICE_365_V8;
+  const isISVBucketTagAsVeeam =
+    ISVApplicationTag === VEEAM_BACKUP_REPLICATION ||
+    ISVApplicationTag === VEEAM_VBO_APPLICATION;
+  const isISVCommvault = ISVApplicationTag === COMMVAULT_APPLICATION;
+
+  const applicationValue = isISVCommvault
+    ? COMMVAULT_APPLICATION
+    : isVeeamBucket || isISVBucketTagAsVeeam
+    ? `${veeamTagApplication || ISVApplicationTag || 'S3 Generic'}`
+    : ISVApplicationTag || 'S3 Generic';
+
+  const shouldShowVeeamCapacity =
+    ISVApplicationTag === VEEAM_BACKUP_REPLICATION ||
+    veeamTagApplication === VEEAM_BACKUP_REPLICATION;
+
+  return (
+    <>
+      <Row>
+        <Key>Application</Key>
+        <Value>{applicationValue}</Value>
+      </Row>
+      {shouldShowVeeamCapacity && (
+        <VeeamCapacityOverviewRow bucketName={bucketName} />
+      )}
+    </>
+  );
+};

--- a/src/react/databrowser/hooks/useBucketLocationDisplay.ts
+++ b/src/react/databrowser/hooks/useBucketLocationDisplay.ts
@@ -1,0 +1,52 @@
+import { useGetBucketLocation } from '@scality/data-browser-library';
+import { useLocationAndStorageInfos } from '../../next-architecture/domain/business/locations';
+import { useAccountsLocationsEndpointsAdapter } from '../../next-architecture/ui/AccountsLocationsEndpointsAdapterProvider';
+
+type LocationDisplayResult =
+  | { status: 'loading' }
+  | { status: 'error'; fallback: string }
+  | { status: 'success'; display: string };
+
+/**
+ * Custom hook to fetch and format bucket location display information.
+ * Consolidates the common pattern of fetching bucket location information
+ *
+ * @param bucketName - Name of the bucket
+ * @returns Location display state with status and display text
+ */
+export const useBucketLocationDisplay = (
+  bucketName: string,
+): LocationDisplayResult => {
+  const { data: bucketLocation, status } = useGetBucketLocation({
+    Bucket: bucketName,
+  });
+
+  const accountsLocationsEndpointsAdapter =
+    useAccountsLocationsEndpointsAdapter();
+  const locationConstraint = bucketLocation?.LocationConstraint || 'us-east-1';
+  const locationInfos = useLocationAndStorageInfos({
+    accountsLocationsEndpointsAdapter,
+    locationName: locationConstraint,
+  });
+
+  if (status === 'pending') {
+    return { status: 'loading' };
+  }
+
+  if (status === 'error') {
+    return { status: 'error', fallback: 'Error loading location' };
+  }
+
+  if (
+    locationInfos.status === 'loading' ||
+    locationInfos.status === 'unknown'
+  ) {
+    return { status: 'loading' };
+  }
+
+  if (locationInfos.status === 'error') {
+    return { status: 'error', fallback: locationConstraint };
+  }
+
+  return { status: 'success', display: locationInfos.value.nameAndShortType };
+};

--- a/src/react/databrowser/hooks/useBucketMetrics.ts
+++ b/src/react/databrowser/hooks/useBucketMetrics.ts
@@ -1,0 +1,120 @@
+import { useBuckets } from '@scality/data-browser-library';
+import { Bucket } from 'aws-sdk/clients/s3';
+import { useQuery, useQueryClient } from 'react-query';
+import { useAuthGroups } from '../../utils/hooks';
+import { IMetricsAdapter } from '../../next-architecture/adapters/metrics/IMetricsAdapter';
+import { LatestUsedCapacity } from '../../next-architecture/domain/entities/metrics';
+import { PromiseResult } from '../../next-architecture/domain/entities/promise';
+import { useMetricsAdapter } from '../../next-architecture/ui/MetricsAdapterProvider';
+
+export type BucketLatestUsedCapacityPromiseResult = {
+  usedCapacity: PromiseResult<LatestUsedCapacity>;
+};
+
+// Query configuration constants
+const BUCKET_METRICS_QUERY_KEY = 'bucketMetrics';
+const noRefetchOptions = {
+  refetchOnWindowFocus: false,
+  refetchOnMount: false,
+  refetchOnReconnect: false,
+};
+
+/**
+ * Creates a React Query configuration for fetching bucket metrics.
+ * Isolated from buckets.ts for data-browser-library usage.
+ */
+export const createBucketMetricsQuery = (
+  metricsAdapter: IMetricsAdapter,
+  buckets: Bucket[],
+  useSpecificCacheKey?: boolean,
+) => ({
+  queryKey: [
+    BUCKET_METRICS_QUERY_KEY,
+    useSpecificCacheKey ? buckets.map((bucket) => bucket.Name).join(',') : '',
+  ],
+  queryFn: () => metricsAdapter.listBucketsLatestUsedCapacity(buckets),
+  enabled: !!buckets.length,
+  ...noRefetchOptions,
+});
+
+/**
+ * Hook to get bucket metrics from the batch prefetch cache.
+ * This hook reads from the batch metrics cache populated by BucketMetricsPrefetch component.
+ * It does NOT trigger individual API requests - it only reads from the shared cache.
+ *
+ * @param metricsAdapter - The metrics adapter instance
+ * @param bucketName - Name of the bucket
+ * @returns Bucket's latest used capacity from cache
+ */
+export const useBucketMetrics = ({
+  metricsAdapter,
+  bucketName,
+}: {
+  metricsAdapter: IMetricsAdapter;
+  bucketName: string;
+}): BucketLatestUsedCapacityPromiseResult => {
+  const queryClient = useQueryClient();
+  const allBucketsMetricsQuery = queryClient.getQueryState<
+    Record<string, LatestUsedCapacity>
+  >(createBucketMetricsQuery(metricsAdapter, []).queryKey);
+
+  if (allBucketsMetricsQuery?.status === 'loading' || !allBucketsMetricsQuery) {
+    return {
+      usedCapacity: {
+        status: 'loading',
+      },
+    };
+  }
+
+  if (allBucketsMetricsQuery?.status === 'error') {
+    return {
+      usedCapacity: {
+        status: 'error',
+        title: 'An error occurred while fetching the latest used capacity',
+        reason: 'Internal Server Error',
+      },
+    };
+  }
+
+  if (
+    allBucketsMetricsQuery?.status === 'success' &&
+    allBucketsMetricsQuery?.data?.[bucketName]
+  ) {
+    return {
+      usedCapacity: {
+        status: 'success',
+        value: allBucketsMetricsQuery.data[bucketName],
+      },
+    };
+  }
+
+  return {
+    usedCapacity: {
+      status: 'success',
+      value: {
+        type: 'noMetrics',
+      },
+    },
+  };
+};
+
+/**
+ * Component to prefetch all bucket metrics in a single batch request.
+ * Must be rendered inside DataBrowserProvider to access the bucket list from library's React Query.
+ * This component doesn't render anything visible - it only triggers data fetching.
+ */
+export const BucketMetricsPrefetch = () => {
+  const { isStorageManager } = useAuthGroups();
+  const metricsAdapter = useMetricsAdapter();
+
+  const { data: bucketsData } = useBuckets();
+
+  const bucketsForMetrics = bucketsData?.Buckets || [];
+
+  useQuery({
+    ...createBucketMetricsQuery(metricsAdapter, bucketsForMetrics),
+    enabled: isStorageManager && bucketsForMetrics.length > 0,
+  });
+
+  return null;
+};

--- a/src/react/databrowser/hooks/useBucketMetrics.ts
+++ b/src/react/databrowser/hooks/useBucketMetrics.ts
@@ -22,16 +22,15 @@ const noRefetchOptions = {
 /**
  * Creates a React Query configuration for fetching bucket metrics.
  * Isolated from buckets.ts for data-browser-library usage.
+ *
+ * All buckets share a single cache entry for optimal performance.
+ * The cache is populated by BucketMetricsPrefetch and consumed by useBucketMetrics.
  */
 export const createBucketMetricsQuery = (
   metricsAdapter: IMetricsAdapter,
   buckets: Bucket[],
-  useSpecificCacheKey?: boolean,
 ) => ({
-  queryKey: [
-    BUCKET_METRICS_QUERY_KEY,
-    useSpecificCacheKey ? buckets.map((bucket) => bucket.Name).join(',') : '',
-  ],
+  queryKey: [BUCKET_METRICS_QUERY_KEY],
   queryFn: () => metricsAdapter.listBucketsLatestUsedCapacity(buckets),
   enabled: !!buckets.length,
   ...noRefetchOptions,

--- a/src/react/databrowser/hooks/useDataBrowserS3Config.ts
+++ b/src/react/databrowser/hooks/useDataBrowserS3Config.ts
@@ -1,0 +1,61 @@
+/**
+ * Hook for creating S3 configuration for DataBrowserProvider
+ *
+ * This hook provides the S3 configuration needed by DataBrowserProvider,
+ * including credentials, endpoint, and development proxy settings.
+ */
+
+import { useMemo } from 'react';
+import { useAssumedRole } from '../../DataServiceRoleProvider';
+import { useConfig } from '../../next-architecture/ui/ConfigProvider';
+import { DEFAULT_REGION } from '../../ISV/components/ISVSummary';
+import { genClientEndpoint } from '../../utils';
+
+export const useDataBrowserS3Config = () => {
+  const assumedRole = useAssumedRole();
+  const { zenkoEndpoint, features, s3InternalFQDN } = useConfig();
+
+  const {
+    AccessKeyId: accessKeyId,
+    SecretAccessKey: secretAccessKey,
+    SessionToken: sessionToken,
+  } = assumedRole?.Credentials || {};
+  const region = DEFAULT_REGION;
+
+  const getS3Config = useMemo(() => {
+    const isDevelopment = process.env.NODE_ENV === 'development';
+    const endpoint = genClientEndpoint(zenkoEndpoint);
+
+    return () => ({
+      endpoint,
+      region,
+      forcePathStyle: true,
+      features,
+      ...(isDevelopment && {
+        useDevProxy: true,
+        realS3Host: s3InternalFQDN,
+        proxyPath: zenkoEndpoint,
+      }),
+      credentials: {
+        accessKeyId,
+        secretAccessKey,
+        sessionToken,
+      },
+    });
+  }, [
+    zenkoEndpoint,
+    region,
+    features,
+    s3InternalFQDN,
+    accessKeyId,
+    secretAccessKey,
+    sessionToken,
+  ]);
+
+  return {
+    getS3Config,
+    accessKeyId,
+    secretAccessKey,
+    sessionToken,
+  };
+};

--- a/src/react/databrowser/utils/bucketApplicationDetector.ts
+++ b/src/react/databrowser/utils/bucketApplicationDetector.ts
@@ -1,0 +1,75 @@
+import {
+  BUCKET_TAG_APPLICATION,
+  BUCKET_TAG_VEEAM_APPLICATION,
+  COMMVAULT_APPLICATION,
+  VEEAM_BACKUP_REPLICATION,
+} from '../../ISV/constants';
+import { VeeamApplicationType } from '../../ISV/constants';
+import { VEEAM_VBO_APPLICATION } from '../../ISV/modules/veeam-vbo';
+
+/**
+ * Bucket application detection result
+ */
+export type BucketApplicationInfo = {
+  /** Display name for the application (e.g., "Veeam", "Commvault", "S3 Generic") */
+  displayName: string;
+  /** Whether to show Veeam capacity metrics */
+  shouldShowVeeamCapacity: boolean;
+};
+
+/**
+ * Detects which ISV application (if any) is associated with a bucket
+ * based on its tags.
+ *
+ * Supports:
+ * - Legacy Veeam tags (veeam:application)
+ * - Modern ISV tags (application)
+ * - Commvault
+ * - Generic S3
+ *
+ * @param tags - Bucket tags as key-value pairs
+ * @returns Application information including display name and feature flags
+ */
+export function detectBucketApplication(
+  tags: Record<string, string>,
+): BucketApplicationInfo {
+  const modernTag = tags[BUCKET_TAG_APPLICATION];
+  const legacyVeeamTag = tags[BUCKET_TAG_VEEAM_APPLICATION];
+
+  // Priority 1: Commvault
+  if (modernTag === COMMVAULT_APPLICATION) {
+    return {
+      displayName: COMMVAULT_APPLICATION,
+      shouldShowVeeamCapacity: false,
+    };
+  }
+
+  // Priority 2: Veeam (check both modern and legacy tags)
+  if (isVeeamApplication(modernTag) || isVeeamApplication(legacyVeeamTag)) {
+    return {
+      displayName: modernTag || legacyVeeamTag,
+      shouldShowVeeamCapacity: modernTag === VEEAM_BACKUP_REPLICATION,
+    };
+  }
+
+  // Priority 3: Generic S3 or other modern ISV applications
+  return {
+    displayName: modernTag || 'S3 Generic',
+    shouldShowVeeamCapacity: false,
+  };
+}
+
+/**
+ * Type guard to check if a tag value represents a Veeam application
+ */
+function isVeeamApplication(tag: string | undefined): tag is string {
+  if (!tag) return false;
+
+  return (
+    tag === VEEAM_BACKUP_REPLICATION ||
+    tag === VEEAM_VBO_APPLICATION ||
+    tag === VeeamApplicationType.VEEAM_BACKUP_REPLICATION ||
+    tag === VeeamApplicationType.VEEAM_OFFICE_365 ||
+    tag === VeeamApplicationType.VEEAM_OFFICE_365_V8
+  );
+}

--- a/src/react/endpoint/EndpointCreate.tsx
+++ b/src/react/endpoint/EndpointCreate.tsx
@@ -46,6 +46,7 @@ function EndpointCreate() {
     formState: { errors, isValid },
   } = useForm({
     mode: 'onChange',
+    // @ts-expect-error - Type conflict between @hookform/resolvers versions in zenko-ui and data-browser-library
     resolver: joiResolver(schema),
     defaultValues: {
       hostname: '',

--- a/src/react/next-architecture/ui/AlertProvider.tsx
+++ b/src/react/next-architecture/ui/AlertProvider.tsx
@@ -19,7 +19,7 @@ const AlertProvider = ({ children }: { children: React.ReactNode }) => {
   const xcoreConfig = useXcoreRuntimeConfig();
   const { AlertsProvider } = useShellAlerts();
 
-  let alertManagerUrl = '';
+  let alertManagerUrl = '/api/alertmanager';
   if (xcoreConfig) {
     alertManagerUrl = xcoreConfig.spec.selfConfiguration.url_alertmanager;
   } else {

--- a/src/react/ui-elements/Breadcrumb.tsx
+++ b/src/react/ui-elements/Breadcrumb.tsx
@@ -114,7 +114,7 @@ export const breadcrumbPathsBuckets = (
               to={{
                 pathname:
                   basePath +
-                  `${accountsURLPrefix}/buckets/${bucketName}/objects`,
+                  `/accounts/${accountName}/buckets/${bucketName}/objects`,
                 search: `?prefix=${prefix}/`,
               }}
             >
@@ -141,7 +141,7 @@ export const breadcrumbPathsBuckets = (
         <Link
           to={{
             pathname:
-              basePath + `${accountsURLPrefix}/buckets/${bucketName}/objects`,
+              basePath + `/accounts/${accountName}/buckets/${bucketName}/objects`,
           }}
         >
           {' '}

--- a/src/react/workflow/ConfigurationTab.tsx
+++ b/src/react/workflow/ConfigurationTab.tsx
@@ -531,6 +531,7 @@ function EditForm({
   const useFormMethods = useForm({
     mode: 'all',
     resolver: async (values, context, options) => {
+      // @ts-expect-error - Type conflict between @hookform/resolvers versions in zenko-ui and data-browser-library
       const joiValidator = joiResolver(schema);
       if (workflow && isExpirationWorkflow(workflow)) {
         return joiValidator(prepareExpirationQuery(values), context, options);

--- a/src/react/workflow/CreateWorkflow.tsx
+++ b/src/react/workflow/CreateWorkflow.tsx
@@ -174,6 +174,7 @@ const CreateWorkflow = () => {
           otherwise: Joi.valid(),
         }),
       });
+      // @ts-expect-error - Type conflict between @hookform/resolvers versions in zenko-ui and data-browser-library
       const joiValidator = joiResolver(schema);
       if (['replication', 'transition'].includes(values.type)) {
         const validation = await joiValidator(values, context, options);

--- a/src/react/workflow/__tests__/ExpirationForm.test.tsx
+++ b/src/react/workflow/__tests__/ExpirationForm.test.tsx
@@ -389,6 +389,7 @@ describe('ExpirationForm', () => {
     const WithFormProviderValidation = ({ children }) => {
       const formMethods = useForm({
         mode: 'all',
+        // @ts-expect-error - Type conflict between @hookform/resolvers versions in zenko-ui and data-browser-library
         resolver: joiResolver(minimalSchema),
         defaultValues: {
           filter: {

--- a/src/react/workflow/__tests__/TransitionForm.test.tsx
+++ b/src/react/workflow/__tests__/TransitionForm.test.tsx
@@ -81,6 +81,7 @@ const locations: Locations = {
 const WithFormProvider = ({ children }: { children: ReactNode }) => {
   const formMethods = useForm({
     mode: 'all',
+    // @ts-expect-error - Type conflict between @hookform/resolvers versions in zenko-ui and data-browser-library
     resolver: joiResolver(Joi.object(transitionSchema)),
     defaultValues: newTransition(),
   });


### PR DESCRIPTION
This is the first step to integrate, just for the UI component part.

The next step will replace the existing S3 API requests with the library’s hook.

At the same time fixed 2 issues:
1. [Setting default alertManagerUrl in AlertProvider](https://github.com/scality/zenko-ui/commit/7cc2c0bb746b13b747d44abd74c6df2d212b511d);
2. [Moving ISVStep Context to a separate file resolves the nested reference issue.](https://github.com/scality/zenko-ui/commit/3993dbba093b850da17ac8c04c5980136dea069d)
