### PR TITLE
implement capacity calculations and parsing functions with unit tests

### DIFF
--- a/src/react/ISV/utils/capacityCalculations.test.ts
+++ b/src/react/ISV/utils/capacityCalculations.test.ts
@@ -1,0 +1,53 @@
+import {
+  calculateStorageConsumptionLimit,
+  parseCapacityBytes,
+} from './capacityCalculations';
+
+describe('capacityCalculations', () => {
+  it('converts string capacity bytes to integer', () => {
+    expect(parseCapacityBytes('1099511627776')).toBe(1099511627776);
+  });
+
+  it('converts number capacity bytes to integer', () => {
+    expect(parseCapacityBytes(1099511627776)).toBe(1099511627776);
+  });
+
+  it('returns 0 for invalid capacity bytes', () => {
+    expect(parseCapacityBytes('invalid')).toBe(0);
+    expect(parseCapacityBytes('')).toBe(0);
+  });
+
+  it('calculates storage limit in PB for large capacities', () => {
+    const result = calculateStorageConsumptionLimit(2 * 1024 ** 5);
+    expect(result.kind).toBe('PB');
+    expect(result.count).toBe(2);
+  });
+
+  it('calculates storage limit in TB for medium capacities', () => {
+    const result = calculateStorageConsumptionLimit(5 * 1024 ** 4);
+    expect(result.kind).toBe('TB');
+    expect(result.count).toBe(5);
+  });
+
+  it('rounds up fractional storage limits', () => {
+    const pbResult = calculateStorageConsumptionLimit(1.5 * 1024 ** 5);
+    expect(pbResult.kind).toBe('PB');
+    expect(pbResult.count).toBe(2);
+
+    const tbResult = calculateStorageConsumptionLimit(1.2 * 1024 ** 4);
+    expect(tbResult.kind).toBe('TB');
+    expect(tbResult.count).toBe(2);
+  });
+
+  it('sets minimum 1 TB for small positive capacities', () => {
+    const result = calculateStorageConsumptionLimit(0.5 * 1024 ** 4);
+    expect(result.kind).toBe('TB');
+    expect(result.count).toBe(1);
+  });
+
+  it('returns 0 TB for zero capacity', () => {
+    const result = calculateStorageConsumptionLimit(0);
+    expect(result.kind).toBe('TB');
+    expect(result.count).toBe(0);
+  });
+});

--- a/src/react/ISV/utils/capacityCalculations.ts
+++ b/src/react/ISV/utils/capacityCalculations.ts
@@ -1,0 +1,47 @@
+export const BYTES_IN_TIB = 1024 ** 4;
+export const BYTES_IN_PIB = 1024 ** 5;
+
+export type StorageConsumptionLimitKind = 'TB' | 'PB';
+
+export interface StorageConsumptionLimit {
+  kind: StorageConsumptionLimitKind;
+  count: number;
+}
+
+export function parseCapacityBytes(capacityBytes: string | number): number {
+  const parsed =
+    typeof capacityBytes === 'string'
+      ? parseInt(capacityBytes, 10)
+      : capacityBytes;
+  return isNaN(parsed) ? 0 : parsed;
+}
+
+export function calculateStorageConsumptionLimit(
+  capacityBytes: number,
+): StorageConsumptionLimit {
+  if (capacityBytes >= BYTES_IN_PIB) {
+    return {
+      kind: 'PB',
+      count: Math.ceil(capacityBytes / BYTES_IN_PIB),
+    };
+  }
+
+  if (capacityBytes >= BYTES_IN_TIB) {
+    return {
+      kind: 'TB',
+      count: Math.ceil(capacityBytes / BYTES_IN_TIB),
+    };
+  }
+
+  if (capacityBytes > 0) {
+    return {
+      kind: 'TB',
+      count: 1,
+    };
+  }
+
+  return {
+    kind: 'TB',
+    count: 0,
+  };
+}

--- a/src/react/ISV/utils/capacityCalculations.ts
+++ b/src/react/ISV/utils/capacityCalculations.ts
@@ -13,7 +13,12 @@ export function parseCapacityBytes(capacityBytes: string | number): number {
     typeof capacityBytes === 'string'
       ? parseInt(capacityBytes, 10)
       : capacityBytes;
-  return isNaN(parsed) ? 0 : parsed;
+
+  if (isNaN(parsed) || parsed < 0) {
+    return 0;
+  }
+
+  return parsed;
 }
 
 export function calculateStorageConsumptionLimit(


### PR DESCRIPTION
When creating a Veeam repository, the API requires:
- `storageConsumptionLimitKind`: `'TB'` or `'PB'`
- `storageConsumptionLimitCount`: integer count

The form provides capacity as bytes in string. These utilities:
- Parse string bytes to integer
- Determine if capacity should be expressed in TB or PB
- Calculate the count (rounded up)


Example Usage :
```
// Form provides: bucket.capacityBytes = "1099511627776" (string)

const capacityBytes = parseCapacityBytes(bucket.capacityBytes); // 1099511627776 (number)
const limit = calculateStorageConsumptionLimit(capacityBytes);
// Returns: { kind: 'TB', count: 1 }

// Used in API request:
{
  storageConsumptionLimitKind: limit.kind,    // 'TB'
  storageConsumptionLimitCount: limit.count,  // 1
}
```