### PR TITLE
implement useCreateVeeamRepository hook with API integration and unit tests

### DIFF
--- a/src/react/ISV/hooks/useCreateVeeamRepository.test.ts
+++ b/src/react/ISV/hooks/useCreateVeeamRepository.test.ts
@@ -1,0 +1,99 @@
+import { act, renderHook } from '@testing-library/react-hooks';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { NewWrapper } from '../../utils/testUtil';
+import { useCreateVeeamRepository } from './useCreateVeeamRepository';
+
+const server = setupServer();
+
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('useCreateVeeamRepository', () => {
+  it('creates a Veeam repository successfully', async () => {
+    const repositoryConfig = {
+      repositoryName: 'test-repo',
+      servicePoint: 'https://s3.test.local',
+      accessKey: 'AKIAIOSFODNN7EXAMPLE',
+      secretKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+      bucketName: 'test-bucket',
+      region: 'us-east-1',
+      immutable: true,
+      immutablePeriodDays: 14,
+      storageConsumptionLimitKind: 'TB' as const,
+      storageConsumptionLimitCount: 1,
+    };
+
+    server.use(
+      rest.post(`*/api/veeam-automation/create-s3-repo`, (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.json({
+            repositoryId: 'repo-123',
+            repositoryName: 'test-repo',
+            message: 'Repository created successfully',
+          }),
+        );
+      }),
+    );
+
+    const { result, waitFor } = renderHook(() => useCreateVeeamRepository(), {
+      wrapper: NewWrapper(),
+    });
+
+    act(() => {
+      result.current.mutate(repositoryConfig);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isSuccess).toBe(true);
+    });
+
+    expect(result.current.data).toEqual({
+      repositoryId: 'repo-123',
+      repositoryName: 'test-repo',
+      message: 'Repository created successfully',
+    });
+  });
+
+  it('handles API errors correctly', async () => {
+    const repositoryConfig = {
+      repositoryName: 'test-repo',
+      servicePoint: 'https://s3.test.local',
+      accessKey: 'AKIAIOSFODNN7EXAMPLE',
+      secretKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+      bucketName: 'test-bucket',
+      region: 'us-east-1',
+      storageConsumptionLimitKind: 'TB' as const,
+      storageConsumptionLimitCount: 1,
+    };
+
+    server.use(
+      rest.post(`*/api/veeam-automation/create-s3-repo`, (req, res, ctx) => {
+        return res(
+          ctx.status(400),
+          ctx.json({
+            message: 'Invalid repository configuration',
+          }),
+        );
+      }),
+    );
+
+    const { result, waitFor } = renderHook(() => useCreateVeeamRepository(), {
+      wrapper: NewWrapper(),
+    });
+
+    act(() => {
+      result.current.mutate(repositoryConfig);
+    });
+
+    await waitFor(() => {
+      expect(result.current.isError).toBe(true);
+    });
+
+    expect(result.current.error?.message).toBe(
+      'Invalid repository configuration',
+    );
+  });
+});

--- a/src/react/ISV/hooks/useCreateVeeamRepository.test.ts
+++ b/src/react/ISV/hooks/useCreateVeeamRepository.test.ts
@@ -1,6 +1,7 @@
-import { act, renderHook } from '@testing-library/react-hooks';
+import { act, renderHook, waitFor } from '@testing-library/react';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
+import React, { type ReactNode } from 'react';
 import { NewWrapper } from '../../utils/testUtil';
 import { useCreateVeeamRepository } from './useCreateVeeamRepository';
 
@@ -9,6 +10,10 @@ const server = setupServer();
 beforeAll(() => server.listen());
 afterEach(() => server.resetHandlers());
 afterAll(() => server.close());
+
+const Wrapper = NewWrapper() as React.ComponentType<{
+  children: ReactNode;
+}>;
 
 describe('useCreateVeeamRepository', () => {
   it('creates a Veeam repository successfully', async () => {
@@ -38,8 +43,8 @@ describe('useCreateVeeamRepository', () => {
       }),
     );
 
-    const { result, waitFor } = renderHook(() => useCreateVeeamRepository(), {
-      wrapper: NewWrapper(),
+    const { result } = renderHook(() => useCreateVeeamRepository(), {
+      wrapper: Wrapper,
     });
 
     act(() => {
@@ -80,8 +85,8 @@ describe('useCreateVeeamRepository', () => {
       }),
     );
 
-    const { result, waitFor } = renderHook(() => useCreateVeeamRepository(), {
-      wrapper: NewWrapper(),
+    const { result } = renderHook(() => useCreateVeeamRepository(), {
+      wrapper: Wrapper,
     });
 
     act(() => {
@@ -92,7 +97,7 @@ describe('useCreateVeeamRepository', () => {
       expect(result.current.isError).toBe(true);
     });
 
-    expect(result.current.error?.message).toBe(
+    expect((result.current.error as { message?: string })?.message).toBe(
       'Invalid repository configuration',
     );
   });

--- a/src/react/ISV/hooks/useCreateVeeamRepository.ts
+++ b/src/react/ISV/hooks/useCreateVeeamRepository.ts
@@ -1,0 +1,75 @@
+import { useShellHooks } from '@scality/module-federation';
+import { useMutation } from 'react-query';
+import { ApiError } from '../../../types/actions';
+import { StorageConsumptionLimitKind } from '../utils/capacityCalculations';
+
+export type VeeamRepositoryRequest = {
+  repositoryName: string;
+  servicePoint: string;
+  accessKey: string;
+  secretKey: string;
+  bucketName: string;
+  region: string;
+  immutable?: boolean;
+  immutablePeriodDays?: number;
+  storageConsumptionLimitKind: StorageConsumptionLimitKind;
+  storageConsumptionLimitCount: number;
+};
+
+export type VeeamRepositoryResponse = {
+  repositoryId?: string;
+  repositoryName?: string;
+  message?: string;
+};
+
+async function createVeeamRepository(
+  repositoryConfig: VeeamRepositoryRequest,
+  token: string,
+): Promise<VeeamRepositoryResponse> {
+  const response = await fetch('/api/veeam-automation/create-s3-repo', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: JSON.stringify({
+      repositoryName: repositoryConfig.repositoryName,
+      servicePoint: repositoryConfig.servicePoint,
+      accessKey: repositoryConfig.accessKey,
+      secretKey: repositoryConfig.secretKey,
+      bucketName: repositoryConfig.bucketName,
+      region: repositoryConfig.region,
+      immutable: repositoryConfig.immutable,
+      immutablePeriodDays: repositoryConfig.immutablePeriodDays,
+      storageConsumptionLimitKind: repositoryConfig.storageConsumptionLimitKind,
+      storageConsumptionLimitCount:
+        repositoryConfig.storageConsumptionLimitCount,
+    }),
+  });
+
+  if (!response.ok) {
+    const errorData = await response.json().catch(() => ({}));
+    throw errorData;
+  }
+
+  const data = await response.json();
+  return {
+    repositoryId: data.repositoryId,
+    repositoryName: data.repositoryName,
+    message: data.message,
+  };
+}
+
+export const useCreateVeeamRepository = () => {
+  const { useAuth } = useShellHooks();
+  const { getToken } = useAuth();
+
+  return useMutation<VeeamRepositoryResponse, ApiError, VeeamRepositoryRequest>(
+    {
+      mutationFn: async (repositoryConfig) => {
+        const token = await getToken();
+        return createVeeamRepository(repositoryConfig, token);
+      },
+    },
+  );
+};

--- a/src/react/ISV/hooks/useCreateVeeamRepository.ts
+++ b/src/react/ISV/hooks/useCreateVeeamRepository.ts
@@ -1,6 +1,5 @@
 import { useShellHooks } from '@scality/module-federation';
 import { useMutation } from 'react-query';
-import { ApiError } from '../../../types/actions';
 import { StorageConsumptionLimitKind } from '../utils/capacityCalculations';
 
 export type VeeamRepositoryRequest = {
@@ -32,19 +31,7 @@ async function createVeeamRepository(
       'Content-Type': 'application/json',
       Authorization: `Bearer ${token}`,
     },
-    body: JSON.stringify({
-      repositoryName: repositoryConfig.repositoryName,
-      servicePoint: repositoryConfig.servicePoint,
-      accessKey: repositoryConfig.accessKey,
-      secretKey: repositoryConfig.secretKey,
-      bucketName: repositoryConfig.bucketName,
-      region: repositoryConfig.region,
-      immutable: repositoryConfig.immutable,
-      immutablePeriodDays: repositoryConfig.immutablePeriodDays,
-      storageConsumptionLimitKind: repositoryConfig.storageConsumptionLimitKind,
-      storageConsumptionLimitCount:
-        repositoryConfig.storageConsumptionLimitCount,
-    }),
+    body: JSON.stringify(repositoryConfig),
   });
 
   if (!response.ok) {
@@ -53,23 +40,17 @@ async function createVeeamRepository(
   }
 
   const data = await response.json();
-  return {
-    repositoryId: data.repositoryId,
-    repositoryName: data.repositoryName,
-    message: data.message,
-  };
+  return data as VeeamRepositoryResponse;
 }
 
 export const useCreateVeeamRepository = () => {
   const { useAuth } = useShellHooks();
   const { getToken } = useAuth();
 
-  return useMutation<VeeamRepositoryResponse, ApiError, VeeamRepositoryRequest>(
-    {
-      mutationFn: async (repositoryConfig) => {
-        const token = await getToken();
-        return createVeeamRepository(repositoryConfig, token);
-      },
+  return useMutation<VeeamRepositoryResponse, unknown, VeeamRepositoryRequest>({
+    mutationFn: async (repositoryConfig) => {
+      const token = await getToken();
+      return createVeeamRepository(repositoryConfig, token);
     },
-  );
+  });
 };


### PR DESCRIPTION
This PR adds the API layer for Veeam auto-repository creation. 
Currently, users manually create Veeam repositories after the ISV setup. This PR introduces the API integration to automate repository creation.

**API Contract**
*Endpoint:* `POST /api/veeam-automation/create-s3-repo`

*Request Body:*
```
{
  repositoryName: string;
  servicePoint: string;
  accessKey: string;
  secretKey: string;
  bucketName: string;
  region: string;
  immutable?: boolean;              // Optional, only if immutable backup enabled
  immutablePeriodDays?: number;     // Optional, only if immutable is true
  storageConsumptionLimitKind: StorageConsumptionLimitKind;  
  storageConsumptionLimitCount: number;
}
```

*Response:*
```
{
  repositoryId?: string;
  repositoryName?: string;
  message?: string;
}
```