### PR TITLE
add Veeam repository fields and auto-creation logic to ISVConfiguration

### DIFF
--- a/src/react/ISV/components/ISVConfiguration.tsx
+++ b/src/react/ISV/components/ISVConfiguration.tsx
@@ -68,9 +68,7 @@ export const ISVConfiguration = () => {
   const getDefaultValues = (): Partial<ISVConfig> => {
     const baseDefaults: Partial<ISVConfig> = {
       accountName: paramsAccountName || '',
-      accountNameType: (paramsAccountName ? 'existing' : 'create') as
-        | 'existing'
-        | 'create',
+      accountNameType: paramsAccountName ? 'existing' : 'create',
       enableImmutableBackup: true,
       buckets: [
         {
@@ -82,11 +80,7 @@ export const ISVConfiguration = () => {
       ],
     };
 
-    if (
-      isVeeamVBROnly &&
-      isAutoRepoFeatureEnabled &&
-      platform.id === 'veeam-vbr'
-    ) {
+    if (isVeeamVBROnly && isAutoRepoFeatureEnabled) {
       return {
         ...baseDefaults,
         autoCreateRepository: true,

--- a/src/react/ISV/components/ISVConfiguration.tsx
+++ b/src/react/ISV/components/ISVConfiguration.tsx
@@ -22,13 +22,20 @@ import BucketField from './BucketField';
 import { useIAMUser } from '../hooks/useIAMUser';
 import { useAccessibleAccountsAdapter } from '../../next-architecture/ui/AccessibleAccountsAdapterProvider';
 import { NoOpMetricsAdapter } from '../../ui-elements/SelectAccountIAMRole';
-import { unitChoices, VEEAM_OFFICE_365 } from '../constants';
+import { useIsVeeamVBROnly } from '../hooks/useIsVeeamVBROnly';
+import { useVeeamAutoRepositoryFeature } from '../hooks/useVeeamAutoRepositoryFeature';
+import {
+  DEFAULT_IMMUTABLE_PERIOD_DAYS,
+  unitChoices,
+  VEEAM_OFFICE_365,
+} from '../constants';
 import { getCapacityBytes } from '../hooks/useCapacityUnit';
 import { Account } from '../../next-architecture/domain/entities/account';
 import { CreateOrSelectNameField, Option } from './CreateOrSelectNameField';
 import { Checkbox } from '../../ui-elements/FormLayout';
 import { useSearchParams } from 'react-router';
 import { SelectRef } from '@scality/core-ui/dist/components/selectv2/Selectv2.component';
+import { VeeamRepositoryFields } from './VeeamRepositoryFields';
 
 const FORM_FIELDS = {
   ACCOUNT_NAME: 'accountName',
@@ -50,16 +57,20 @@ export const ISVConfiguration = () => {
   const paramsAccountName = searchParams.get('account');
   const accessibleAccountsAdapter = useAccessibleAccountsAdapter();
   const metricsAdapter = new NoOpMetricsAdapter();
+  const isVeeamVBROnly = useIsVeeamVBROnly();
+  const isAutoRepoFeatureEnabled = useVeeamAutoRepositoryFeature();
 
   const { accounts } = useListAccounts({
     accessibleAccountsAdapter,
     metricsAdapter,
   });
-  const formMethods = useForm<ISVConfig>({
-    mode: 'all',
-    defaultValues: {
+
+  const getDefaultValues = (): Partial<ISVConfig> => {
+    const baseDefaults: Partial<ISVConfig> = {
       accountName: paramsAccountName || '',
-      accountNameType: paramsAccountName ? 'existing' : 'create',
+      accountNameType: (paramsAccountName ? 'existing' : 'create') as
+        | 'existing'
+        | 'create',
       enableImmutableBackup: true,
       buckets: [
         {
@@ -69,7 +80,26 @@ export const ISVConfiguration = () => {
           capacityUnit: unitChoices.TiB.toString(),
         },
       ],
-    },
+    };
+
+    if (
+      isVeeamVBROnly &&
+      isAutoRepoFeatureEnabled &&
+      platform.id === 'veeam-vbr'
+    ) {
+      return {
+        ...baseDefaults,
+        autoCreateRepository: true,
+        immutablePeriodDays: DEFAULT_IMMUTABLE_PERIOD_DAYS,
+      };
+    }
+
+    return baseDefaults;
+  };
+
+  const formMethods = useForm<ISVConfig>({
+    mode: 'all',
+    defaultValues: getDefaultValues(),
     resolver: joiResolver(platform.validator),
     shouldUnregister: false,
   });
@@ -370,6 +400,11 @@ export const ISVConfiguration = () => {
               }
             />
           )}
+
+          <br />
+          <FormSection forceLabelWidth={280}>
+            <VeeamRepositoryFields />
+          </FormSection>
         </FormSection>
       </Form>
     </FormProvider>

--- a/src/react/ISV/components/VeeamRepositoryFields.tsx
+++ b/src/react/ISV/components/VeeamRepositoryFields.tsx
@@ -6,7 +6,11 @@ import { useIsVeeamVBROnly } from '../hooks/useIsVeeamVBROnly';
 import { useVeeamAutoRepositoryFeature } from '../hooks/useVeeamAutoRepositoryFeature';
 
 export const VeeamRepositoryFields = () => {
-  const { control, watch } = useFormContext();
+  const {
+    control,
+    watch,
+    formState: { errors },
+  } = useFormContext();
   const isVeeamVBROnly = useIsVeeamVBROnly();
   const isAutoRepoFeatureEnabled = useVeeamAutoRepositoryFeature();
   const autoCreateRepository = watch('autoCreateRepository');
@@ -47,6 +51,7 @@ export const VeeamRepositoryFields = () => {
           label="Veeam Immutable retention period"
           help="Minimum immutability period"
           helpErrorPosition="bottom"
+          error={(errors.immutablePeriodDays?.message as string) ?? ''}
           content={
             <Stack direction="horizontal">
               <Controller

--- a/src/react/ISV/components/VeeamRepositoryFields.tsx
+++ b/src/react/ISV/components/VeeamRepositoryFields.tsx
@@ -1,0 +1,74 @@
+import { FormGroup, Toggle, Stack, Text } from '@scality/core-ui';
+import { Input } from '@scality/core-ui/dist/next';
+import { Controller, useFormContext } from 'react-hook-form';
+import { MAX_IMMUTABLE_PERIOD_DAYS } from '../constants';
+import { useIsVeeamVBROnly } from '../hooks/useIsVeeamVBROnly';
+import { useVeeamAutoRepositoryFeature } from '../hooks/useVeeamAutoRepositoryFeature';
+
+export const VeeamRepositoryFields = () => {
+  const { control, watch } = useFormContext();
+  const isVeeamVBROnly = useIsVeeamVBROnly();
+  const isAutoRepoFeatureEnabled = useVeeamAutoRepositoryFeature();
+  const autoCreateRepository = watch('autoCreateRepository');
+  const enableImmutableBackup = watch('enableImmutableBackup');
+
+  if (!isVeeamVBROnly || !isAutoRepoFeatureEnabled) {
+    return null;
+  }
+
+  return (
+    <>
+      <FormGroup
+        id="autoCreateRepository"
+        label="Veeam repository creation"
+        help="Will automatically create the Veeam repository with all the needed information from ARTESCA Object storage."
+        helpErrorPosition="bottom"
+        content={
+          <Controller
+            name="autoCreateRepository"
+            control={control}
+            render={({ field: { value, onChange } }) => (
+              <Toggle
+                id="autoCreateRepository"
+                aria-label="autoCreateRepository"
+                name="autoCreateRepository"
+                toggle={value}
+                label={value ? 'Enabled' : 'Disabled'}
+                onChange={onChange}
+              />
+            )}
+          />
+        }
+      />
+
+      {autoCreateRepository && enableImmutableBackup && (
+        <FormGroup
+          id="immutablePeriodDays"
+          label="Veeam Immutable retention period"
+          help="Minimum immutability period"
+          helpErrorPosition="bottom"
+          content={
+            <Stack direction="horizontal">
+              <Controller
+                name="immutablePeriodDays"
+                control={control}
+                render={({ field: { value, onChange } }) => (
+                  <Input
+                    id="immutablePeriodDays"
+                    type="number"
+                    size="1/3"
+                    value={value}
+                    onChange={onChange}
+                    min={1}
+                    max={MAX_IMMUTABLE_PERIOD_DAYS}
+                  />
+                )}
+              />
+              <Text>day(s)</Text>
+            </Stack>
+          }
+        />
+      )}
+    </>
+  );
+};

--- a/src/react/ISV/modules/veeam/index.tsx
+++ b/src/react/ISV/modules/veeam/index.tsx
@@ -200,6 +200,16 @@ export const Veeam: ISVPlatformConfig = {
       otherwise: Joi.valid(),
     }),
     enableImmutableBackup: Joi.boolean().required().default(false),
+    autoCreateRepository: Joi.boolean().optional(),
+    immutablePeriodDays: Joi.when('autoCreateRepository', {
+      is: true,
+      then: Joi.when('enableImmutableBackup', {
+        is: true,
+        then: Joi.number().integer().min(1).max(3650).optional(),
+        otherwise: Joi.valid(),
+      }),
+      otherwise: Joi.valid(),
+    }),
     buckets: Joi.array().items(
       Joi.object({
         name: bucketNameValidationSchema,

--- a/src/react/ISV/modules/veeam/index.tsx
+++ b/src/react/ISV/modules/veeam/index.tsx
@@ -205,7 +205,7 @@ export const Veeam: ISVPlatformConfig = {
       is: true,
       then: Joi.when('enableImmutableBackup', {
         is: true,
-        then: Joi.number().integer().min(1).max(3650).optional(),
+        then: Joi.number().integer().min(1).max(3650).required(),
         otherwise: Joi.valid(),
       }),
       otherwise: Joi.valid(),


### PR DESCRIPTION
## Context

Currently, users must manually create Veeam repositories in Veeam Backup & Replication after configuring ARTESCA. This PR adds form fields to enable automatic repository creation during the ISV setup, reducing manual steps and configuration errors.

## What This PR Achieves
This PR adds the UI form fields that allow users to:
- Enable automatic Veeam repository creation via a toggle
- Configure the immutable retention period (when immutable backup is enabled)
- Set default values when the feature is enabled

The fields are feature-flag protected and only visible for Veeam VBR.

<img width="876" height="838" alt="Screenshot 2025-12-16 at 15 30 41" src="https://github.com/user-attachments/assets/986a275c-9926-4498-8f4c-c7703547a34d" />
