### PR TITLE
replace @hapi/joi with joi and update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "core-js": "^3.6.5",
         "downshift": "^6.1.7",
         "immutable": "^4.0.0-rc.12",
-        "joi": "^17.13.3",
+        "joi": "^18.0.1",
         "lodash.isequal": "^4.5.0",
         "lodash.set": "^4.3.2",
         "luxon": "^2.3.0",
@@ -3309,10 +3309,29 @@
         "react": "^16.3 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/@hapi/address": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@hapi/formula": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/@hapi/hoek": {
-      "version": "9.3.0",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
-      "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@hapi/pinpoint": {
       "version": "2.0.1",
@@ -3329,11 +3348,12 @@
       }
     },
     "node_modules/@hapi/topo": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-5.1.0.tgz",
-      "integrity": "sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/hoek": "^9.0.0"
+        "@hapi/hoek": "^11.0.2"
       }
     },
     "node_modules/@hookform/resolvers": {
@@ -5043,39 +5063,6 @@
         "styled-components": "^5.0.0"
       }
     },
-    "node_modules/@scality/data-browser-library/node_modules/@hapi/address": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
-      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^11.0.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/@scality/data-browser-library/node_modules/@hapi/formula": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
-      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@scality/data-browser-library/node_modules/@hapi/hoek": {
-      "version": "11.0.7",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
-      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@scality/data-browser-library/node_modules/@hapi/topo": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
-      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^11.0.2"
-      }
-    },
     "node_modules/@scality/data-browser-library/node_modules/file-selector": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/file-selector/-/file-selector-2.1.2.tgz",
@@ -5086,24 +5073,6 @@
       },
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/@scality/data-browser-library/node_modules/joi": {
-      "version": "18.0.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.2.tgz",
-      "integrity": "sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/address": "^5.1.1",
-        "@hapi/formula": "^3.0.2",
-        "@hapi/hoek": "^11.0.7",
-        "@hapi/pinpoint": "^2.0.1",
-        "@hapi/tlds": "^1.1.1",
-        "@hapi/topo": "^6.0.2",
-        "@standard-schema/spec": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
       }
     },
     "node_modules/@scality/data-browser-library/node_modules/react-dropzone": {
@@ -5151,27 +5120,6 @@
       "engines": {
         "node": ">=14.0.0"
       }
-    },
-    "node_modules/@sideway/address": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
-      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@sideway/formula": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
-      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/@sideway/pinpoint": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
-      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
-      "license": "BSD-3-Clause"
     },
     "node_modules/@sindresorhus/is": {
       "version": "0.14.0",
@@ -13895,16 +13843,21 @@
       }
     },
     "node_modules/joi": {
-      "version": "17.13.3",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
-      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.2.tgz",
+      "integrity": "sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/hoek": "^9.3.0",
-        "@hapi/topo": "^5.1.0",
-        "@sideway/address": "^4.1.5",
-        "@sideway/formula": "^3.0.1",
-        "@sideway/pinpoint": "^2.0.0"
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/js-levenshtein": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,7 @@
       "version": "2.1.0",
       "license": "ISC",
       "dependencies": {
-        "@hapi/joi": "^17.1.1",
-        "@hapi/joi-date": "^2.0.1",
-        "@hookform/resolvers": "^2.8.8",
+        "@hookform/resolvers": "^5.2.2",
         "@monaco-editor/react": "^4.4.5",
         "@scality/certchain": "1.4.0",
         "@scality/core-ui": "0.185.0",
@@ -25,6 +23,7 @@
         "core-js": "^3.6.5",
         "downshift": "^6.1.7",
         "immutable": "^4.0.0-rc.12",
+        "joi": "^17.13.3",
         "lodash.isequal": "^4.5.0",
         "lodash.set": "^4.3.2",
         "luxon": "^2.3.0",
@@ -66,7 +65,6 @@
         "@testing-library/react-hooks": "^7.0.2",
         "@testing-library/user-event": "^14.5.2",
         "@types/enzyme": "^3.10.13",
-        "@types/hapi__joi": "^17.1.8",
         "@types/jest": "^27.4.1",
         "@types/lodash.set": "^4.3.7",
         "@types/luxon": "^2.3.0",
@@ -3311,46 +3309,10 @@
         "react": "^16.3 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
-    "node_modules/@hapi/address": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-4.1.0.tgz",
-      "integrity": "sha512-SkszZf13HVgGmChdHo/PxchnSaCJ6cetVqLzyciudzZRT0jcOouIF/Q93mgjw8cce+D+4F4C1Z/WrfFN+O3VHQ==",
-      "deprecated": "Moved to 'npm install @sideway/address'",
-      "dependencies": {
-        "@hapi/hoek": "^9.0.0"
-      }
-    },
-    "node_modules/@hapi/formula": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-2.0.0.tgz",
-      "integrity": "sha512-V87P8fv7PI0LH7LiVi8Lkf3x+KCO7pQozXRssAHNXXL9L1K+uyu4XypLXwxqVDKgyQai6qj3/KteNlrqDx4W5A==",
-      "deprecated": "Moved to 'npm install @sideway/formula'"
-    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
       "integrity": "sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ=="
-    },
-    "node_modules/@hapi/joi": {
-      "version": "17.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/joi/-/joi-17.1.1.tgz",
-      "integrity": "sha512-p4DKeZAoeZW4g3u7ZeRo+vCDuSDgSvtsB/NpfjXEHTUjSeINAi/RrVOWiVQ1isaoLzMvFEhe8n5065mQq1AdQg==",
-      "deprecated": "Switch to 'npm install joi'",
-      "dependencies": {
-        "@hapi/address": "^4.0.1",
-        "@hapi/formula": "^2.0.0",
-        "@hapi/hoek": "^9.0.0",
-        "@hapi/pinpoint": "^2.0.0",
-        "@hapi/topo": "^5.0.0"
-      }
-    },
-    "node_modules/@hapi/joi-date": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/@hapi/joi-date/-/joi-date-2.0.1.tgz",
-      "integrity": "sha512-8be8JUEC8Wm1Do3ryJy+TXmkAL13b2JwXn7gILBoor8LopY/M+hJskodzOOxfJdckkfWnbmbnMEyJW3d/gZMfA==",
-      "dependencies": {
-        "moment": "2.x.x"
-      }
     },
     "node_modules/@hapi/pinpoint": {
       "version": "2.0.1",
@@ -3375,11 +3337,15 @@
       }
     },
     "node_modules/@hookform/resolvers": {
-      "version": "2.9.11",
-      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-2.9.11.tgz",
-      "integrity": "sha512-bA3aZ79UgcHj7tFV7RlgThzwSSHZgvfbt2wprldRkYBcMopdMvHyO17Wwp/twcJasNFischFfS7oz8Katz8DdQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
+      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/utils": "^0.3.0"
+      },
       "peerDependencies": {
-        "react-hook-form": "^7.0.0"
+        "react-hook-form": "^7.55.0"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -5077,16 +5043,37 @@
         "styled-components": "^5.0.0"
       }
     },
-    "node_modules/@scality/data-browser-library/node_modules/@hookform/resolvers": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
-      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
-      "license": "MIT",
+    "node_modules/@scality/data-browser-library/node_modules/@hapi/address": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
+      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
+      "license": "BSD-3-Clause",
       "dependencies": {
-        "@standard-schema/utils": "^0.3.0"
+        "@hapi/hoek": "^11.0.2"
       },
-      "peerDependencies": {
-        "react-hook-form": "^7.55.0"
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@scality/data-browser-library/node_modules/@hapi/formula": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
+      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@scality/data-browser-library/node_modules/@hapi/hoek": {
+      "version": "11.0.7",
+      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
+      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@scality/data-browser-library/node_modules/@hapi/topo": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
+      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^11.0.2"
       }
     },
     "node_modules/@scality/data-browser-library/node_modules/file-selector": {
@@ -5099,6 +5086,24 @@
       },
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "node_modules/@scality/data-browser-library/node_modules/joi": {
+      "version": "18.0.2",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.2.tgz",
+      "integrity": "sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/address": "^5.1.1",
+        "@hapi/formula": "^3.0.2",
+        "@hapi/hoek": "^11.0.7",
+        "@hapi/pinpoint": "^2.0.1",
+        "@hapi/tlds": "^1.1.1",
+        "@hapi/topo": "^6.0.2",
+        "@standard-schema/spec": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 20"
       }
     },
     "node_modules/@scality/data-browser-library/node_modules/react-dropzone": {
@@ -5146,6 +5151,27 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@sideway/address": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/@sideway/address/-/address-4.1.5.tgz",
+      "integrity": "sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@hapi/hoek": "^9.0.0"
+      }
+    },
+    "node_modules/@sideway/formula": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@sideway/formula/-/formula-3.0.1.tgz",
+      "integrity": "sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@sideway/pinpoint": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@sideway/pinpoint/-/pinpoint-2.0.0.tgz",
+      "integrity": "sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@sindresorhus/is": {
       "version": "0.14.0",
@@ -6768,12 +6794,6 @@
       "dependencies": {
         "@types/node": "*"
       }
-    },
-    "node_modules/@types/hapi__joi": {
-      "version": "17.1.15",
-      "resolved": "https://registry.npmjs.org/@types/hapi__joi/-/hapi__joi-17.1.15.tgz",
-      "integrity": "sha512-Ehq/YQB0ZqZGObrGngztxtThTiShrG0jlqyUSsNK3cebJSoyYgE/hdZvYt6lH4Wimi28RowDwnr87XseiemqAg==",
-      "dev": true
     },
     "node_modules/@types/history": {
       "version": "4.7.11",
@@ -13875,54 +13895,16 @@
       }
     },
     "node_modules/joi": {
-      "version": "18.0.2",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-18.0.2.tgz",
-      "integrity": "sha512-RuCOQMIt78LWnktPoeBL0GErkNaJPTBGcYuyaBvUOQSpcpcLfWrHPPihYdOGbV5pam9VTWbeoF7TsGiHugcjGA==",
+      "version": "17.13.3",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-17.13.3.tgz",
+      "integrity": "sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "@hapi/address": "^5.1.1",
-        "@hapi/formula": "^3.0.2",
-        "@hapi/hoek": "^11.0.7",
-        "@hapi/pinpoint": "^2.0.1",
-        "@hapi/tlds": "^1.1.1",
-        "@hapi/topo": "^6.0.2",
-        "@standard-schema/spec": "^1.0.0"
-      },
-      "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/joi/node_modules/@hapi/address": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@hapi/address/-/address-5.1.1.tgz",
-      "integrity": "sha512-A+po2d/dVoY7cYajycYI43ZbYMXukuopIsqCjh5QzsBCipDtdofHntljDlpccMjIfTy6UOkg+5KPriwYch2bXA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^11.0.2"
-      },
-      "engines": {
-        "node": ">=14.0.0"
-      }
-    },
-    "node_modules/joi/node_modules/@hapi/formula": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/formula/-/formula-3.0.2.tgz",
-      "integrity": "sha512-hY5YPNXzw1He7s0iqkRQi+uMGh383CGdyyIGYtB+W5N3KHPXoqychklvHhKCC9M3Xtv0OCs/IHw+r4dcHtBYWw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/joi/node_modules/@hapi/hoek": {
-      "version": "11.0.7",
-      "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-11.0.7.tgz",
-      "integrity": "sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/joi/node_modules/@hapi/topo": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/@hapi/topo/-/topo-6.0.2.tgz",
-      "integrity": "sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "@hapi/hoek": "^11.0.2"
+        "@hapi/hoek": "^9.3.0",
+        "@hapi/topo": "^5.1.0",
+        "@sideway/address": "^4.1.5",
+        "@sideway/formula": "^3.0.1",
+        "@sideway/pinpoint": "^2.0.0"
       }
     },
     "node_modules/js-levenshtein": {
@@ -14734,14 +14716,6 @@
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.30.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.30.1.tgz",
-      "integrity": "sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/monaco-editor": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
-    "joi": "^17.13.3",
+    "joi": "^18.0.1",
     "@monaco-editor/react": "^4.4.5",
     "@scality/certchain": "1.4.0",
     "@scality/core-ui": "0.185.0",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@testing-library/react-hooks": "^7.0.2",
     "@testing-library/user-event": "^14.5.2",
     "@types/enzyme": "^3.10.13",
-    "@types/hapi__joi": "^17.1.8",
     "@types/jest": "^27.4.1",
     "@types/lodash.set": "^4.3.7",
     "@types/luxon": "^2.3.0",
@@ -65,9 +64,8 @@
     "vega-lite": "^4.0.0-beta.10"
   },
   "dependencies": {
-    "@hapi/joi": "^17.1.1",
-    "@hapi/joi-date": "^2.0.1",
-    "@hookform/resolvers": "^2.8.8",
+    "@hookform/resolvers": "^5.2.2",
+    "joi": "^17.13.3",
     "@monaco-editor/react": "^4.4.5",
     "@scality/certchain": "1.4.0",
     "@scality/core-ui": "0.185.0",

--- a/src/react/ISV/components/ISVConfiguration.tsx
+++ b/src/react/ISV/components/ISVConfiguration.tsx
@@ -95,8 +95,7 @@ export const ISVConfiguration = () => {
   const formMethods = useForm<ISVConfig>({
     mode: 'all',
     defaultValues: getDefaultValues(),
-    // @ts-expect-error - fix this when you are working on it
-    resolver: joiResolver(platform.validator),
+    resolver: platform.validator ? joiResolver(platform.validator) : undefined,
     shouldUnregister: false,
   });
 

--- a/src/react/ISV/modules/commvault/index.tsx
+++ b/src/react/ISV/modules/commvault/index.tsx
@@ -1,5 +1,5 @@
 import { ISVCardConfig, ISVInfo, ISVPlatformConfig } from '../../types';
-import Joi from '@hapi/joi';
+import Joi from 'joi';
 import { Stack, Text } from '@scality/core-ui';
 import { ListItem } from '..';
 import { accountNameValidationSchema } from '../../../account/AccountCreate';

--- a/src/react/ISV/modules/index.tsx
+++ b/src/react/ISV/modules/index.tsx
@@ -1,4 +1,4 @@
-import Joi from '@hapi/joi';
+import Joi from 'joi';
 import styled from 'styled-components';
 import { accountNameValidationSchema } from '../../account/AccountCreate';
 import { bucketNameValidationSchema } from '../utils/bucketNameValidation';

--- a/src/react/ISV/modules/veeam-vbo/index.tsx
+++ b/src/react/ISV/modules/veeam-vbo/index.tsx
@@ -1,6 +1,6 @@
 import { ISVCardConfig, ISVInfo, ISVPlatformConfig } from '../../types';
 import { VeeamLogo } from '../veeam/components/VeeamLogo';
-import Joi from '@hapi/joi';
+import Joi from 'joi';
 import { FormGroup, Stack, Text } from '@scality/core-ui';
 import { ListItem } from '../index';
 import { accountNameValidationSchema } from '../../../account/AccountCreate';

--- a/src/react/ISV/modules/veeam/components/VeeamCapacityModal.tsx
+++ b/src/react/ISV/modules/veeam/components/VeeamCapacityModal.tsx
@@ -1,4 +1,4 @@
-import Joi from '@hapi/joi';
+import Joi from 'joi';
 import { joiResolver } from '@hookform/resolvers/joi';
 import {
   Icon,
@@ -53,7 +53,6 @@ export const VeeamCapacityModalInternal = ({
   const { capacityValue, capacityUnit } = useCapacityUnit(maxCapacity);
   const methods = useForm<VeeamCapacityForm>({
     mode: 'all',
-    // @ts-expect-error - Type conflict between @hookform/resolvers versions in zenko-ui and data-browser-library
     resolver: joiResolver(schema),
     defaultValues: {
       capacity: capacityValue,

--- a/src/react/ISV/modules/veeam/index.tsx
+++ b/src/react/ISV/modules/veeam/index.tsx
@@ -1,6 +1,6 @@
 import { ISVCardConfig, ISVInfo, ISVPlatformConfig } from '../../types';
 import { VeeamLogo } from './components/VeeamLogo';
-import Joi from '@hapi/joi';
+import Joi from 'joi';
 import { Banner, Stack, Text } from '@scality/core-ui';
 import { checkDecimals, ListItem } from '../index';
 import { accountNameValidationSchema } from '../../../account/AccountCreate';

--- a/src/react/ISV/types/index.ts
+++ b/src/react/ISV/types/index.ts
@@ -1,4 +1,4 @@
-import Joi from '@hapi/joi';
+import Joi from 'joi';
 import React from 'react';
 
 export type ISVPlatform = 'veeam-vbr' | 'commvault' | 'veeam-vbo';

--- a/src/react/ISV/utils/bucketNameValidation.ts
+++ b/src/react/ISV/utils/bucketNameValidation.ts
@@ -1,4 +1,4 @@
-import Joi from '@hapi/joi';
+import Joi from 'joi';
 
 export const bucketErrorMessage =
   'Bucket names can include only lowercase letters, numbers, dots (.), and hyphens (-)';
@@ -32,4 +32,3 @@ export const bucketNameValidationSchema = Joi.string()
     }
     return value;
   }, 'Unique name validation');
-

--- a/src/react/account/AccountCreate.tsx
+++ b/src/react/account/AccountCreate.tsx
@@ -1,4 +1,4 @@
-import Joi from '@hapi/joi';
+import Joi from 'joi';
 import { joiResolver } from '@hookform/resolvers/joi';
 import {
   Banner,
@@ -48,7 +48,6 @@ function AccountCreate() {
     formState: { errors },
   } = useForm<AccountFormField>({
     mode: 'all',
-    // @ts-expect-error - Type conflict between @hookform/resolvers versions in zenko-ui and data-browser-library
     resolver: joiResolver(schema),
   });
   const navigate = useNavigate();

--- a/src/react/account/AccountCreateUser.tsx
+++ b/src/react/account/AccountCreateUser.tsx
@@ -1,4 +1,4 @@
-import Joi from '@hapi/joi';
+import Joi from 'joi';
 import { joiResolver } from '@hookform/resolvers/joi';
 import {
   Banner,
@@ -53,7 +53,6 @@ const AccountCreateUser = () => {
     formState: { errors },
   } = useForm({
     mode: 'all',
-    // @ts-expect-error - Type conflict between @hookform/resolvers versions in zenko-ui and data-browser-library
     resolver: joiResolver(schema),
     defaultValues: { name: '' },
   });

--- a/src/react/account/AccountUpdateUser.tsx
+++ b/src/react/account/AccountUpdateUser.tsx
@@ -11,7 +11,7 @@ import {
   Stack,
 } from '@scality/core-ui';
 import { Button, Input } from '@scality/core-ui/dist/next';
-import Joi from '@hapi/joi';
+import Joi from 'joi';
 import { joiResolver } from '@hookform/resolvers/joi';
 import { useForm } from 'react-hook-form';
 import { useOutsideClick } from '../utils/hooks';
@@ -49,7 +49,6 @@ const AccountUpdateUser = () => {
 
     formState: { errors },
   } = useForm({
-    // @ts-expect-error - Type conflict between @hookform/resolvers versions in zenko-ui and data-browser-library
     resolver: joiResolver(schema),
     defaultValues: { name: IAMUserName },
   });

--- a/src/react/endpoint/EndpointCreate.tsx
+++ b/src/react/endpoint/EndpointCreate.tsx
@@ -1,4 +1,4 @@
-import Joi from '@hapi/joi';
+import Joi from 'joi';
 import { joiResolver } from '@hookform/resolvers/joi';
 import {
   Banner,
@@ -46,7 +46,6 @@ function EndpointCreate() {
     formState: { errors, isValid },
   } = useForm({
     mode: 'onChange',
-    // @ts-expect-error - Type conflict between @hookform/resolvers versions in zenko-ui and data-browser-library
     resolver: joiResolver(schema),
     defaultValues: {
       hostname: '',


### PR DESCRIPTION
# Migrate from @hapi/joi to joi and update @hookform/resolvers

## Context

This PR is part of the feature plan to improve type safety and maintainability of form validation across the application. We identified type conflicts between `@hookform/resolvers` and `@hapi/joi` that required `@ts-expect-error` comments to suppress TypeScript errors, creating technical debt and reducing type safety.

## Problem

- `@hapi/joi` is deprecated and no longer maintained
- Type incompatibility between `@hookform/resolvers` v2.8.8 and `@hapi/joi` v17.1.1 caused TypeScript errors
- Multiple `@ts-expect-error` comments were used to suppress these errors, hiding potential type issues
- The deprecated package poses long-term maintenance risks

## Solution

Migrated the codebase from `@hapi/joi` to the actively maintained `joi` package and updated `@hookform/resolvers` to the latest version (v5.2.2) for better compatibility and type safety.

## Changes

### Dependencies
- **Removed**: `@hapi/joi` (^17.1.1), `@hapi/joi-date` (^2.0.1), `@types/hapi__joi` (^17.1.8)
- **Added**: `joi` (^18.0.1)
- **Updated**: `@hookform/resolvers` (^2.8.8 → ^5.2.2)

## Testing

Please verify form validation works correctly in:
- ISV configuration forms (Veeam, Commvault, Veeam VBO)
- Account creation and update forms
- Endpoint creation form