### PR TITLE
Redux Removal - Error Handling & Unused Reducers Cleanup

### DIFF
--- a/src/react/AuthLoadingProvider.tsx
+++ b/src/react/AuthLoadingProvider.tsx
@@ -10,6 +10,7 @@ import { useShellHooks } from '@scality/module-federation';
 import { useConfig } from './next-architecture/ui/ConfigProvider';
 import { loadAppConfig } from './actions';
 import { AppState } from '../types/state';
+import { useComponentError } from './ErrorProvider';
 
 type AuthLoadingContextValue = {
   isConfigLoaded: boolean;
@@ -47,9 +48,8 @@ const AuthLoadingProvider = ({ children }: { children: JSX.Element }) => {
   const configFailure = useSelector(
     (state: AppState) => state.auth.configFailure,
   );
-  const configFailureErrorMessage = useSelector((state: AppState) =>
-    state.uiErrors.errorType === 'byComponent' ? state.uiErrors.errorMsg : '',
-  );
+  const { componentError } = useComponentError();
+  const configFailureErrorMessage = componentError || '';
 
   useEffect(() => {
     if (userData?.original?.profile?.sub && config && !isConfigLoaded) {

--- a/src/react/ErrorProvider.tsx
+++ b/src/react/ErrorProvider.tsx
@@ -25,16 +25,21 @@ type ErrorContextValue = {
   clearError: () => void;
 };
 
+const noop = () => undefined;
+const fallbackContext: ErrorContextValue = {
+  error: { message: null, type: null },
+  showModalError: (msg) => console.error('[ErrorProvider not found]', msg),
+  showAuthError: (msg) => console.error('[ErrorProvider not found]', msg),
+  showComponentError: (msg) => console.error('[ErrorProvider not found]', msg),
+  clearError: noop,
+};
+
 const ErrorContext = createContext<ErrorContextValue | null>(null);
 
 export const useError = () => {
   const context = useContext(ErrorContext);
-
-  if (!context) {
-    throw new Error('useError must be used within ErrorProvider.');
-  }
-
-  return context;
+  // Fallback for federated modules loaded outside ErrorProvider
+  return context ?? fallbackContext;
 };
 
 export const useModalError = () => {

--- a/src/react/ErrorProvider.tsx
+++ b/src/react/ErrorProvider.tsx
@@ -1,0 +1,130 @@
+import {
+  createContext,
+  useContext,
+  useState,
+  useCallback,
+  useMemo,
+  useEffect,
+  JSX,
+} from 'react';
+import { useSelector } from 'react-redux';
+import { AppState } from '../types/state';
+
+type ErrorType = 'modal' | 'auth' | 'component';
+
+type ErrorState = {
+  message: string | null;
+  type: ErrorType | null;
+};
+
+type ErrorContextValue = {
+  error: ErrorState;
+  showModalError: (message: string) => void;
+  showAuthError: (message: string) => void;
+  showComponentError: (message: string) => void;
+  clearError: () => void;
+};
+
+const ErrorContext = createContext<ErrorContextValue | null>(null);
+
+export const useError = () => {
+  const context = useContext(ErrorContext);
+
+  if (!context) {
+    throw new Error('useError must be used within ErrorProvider.');
+  }
+
+  return context;
+};
+
+export const useModalError = () => {
+  const { error, showModalError, clearError } = useError();
+  return {
+    modalError: error.type === 'modal' ? error.message : null,
+    showModalError,
+    clearModalError: clearError,
+  };
+};
+
+export const useAuthError = () => {
+  const { error, showAuthError, clearError } = useError();
+  return {
+    authError: error.type === 'auth' ? error.message : null,
+    showAuthError,
+    clearAuthError: clearError,
+  };
+};
+
+export const useComponentError = () => {
+  const { error, showComponentError, clearError } = useError();
+  return {
+    componentError: error.type === 'component' ? error.message : null,
+    showComponentError,
+    clearComponentError: clearError,
+  };
+};
+
+const ErrorProvider = ({ children }: { children: JSX.Element }) => {
+  const [error, setError] = useState<ErrorState>({
+    message: null,
+    type: null,
+  });
+
+  // Sync Redux uiErrors state (temporary, remove after full migration)
+  const reduxErrorType = useSelector(
+    (state: AppState) => state.uiErrors.errorType,
+  );
+  const reduxErrorMsg = useSelector(
+    (state: AppState) => state.uiErrors.errorMsg,
+  );
+
+  useEffect(() => {
+    if (reduxErrorType && reduxErrorMsg) {
+      const typeMap: Record<string, ErrorType> = {
+        byModal: 'modal',
+        byAuth: 'auth',
+        byComponent: 'component',
+      };
+      setError({
+        message: reduxErrorMsg,
+        type: typeMap[reduxErrorType] || 'modal',
+      });
+    }
+  }, [reduxErrorType, reduxErrorMsg]);
+
+  const showModalError = useCallback((message: string) => {
+    setError({ message, type: 'modal' });
+  }, []);
+
+  const showAuthError = useCallback((message: string) => {
+    setError({ message, type: 'auth' });
+  }, []);
+
+  const showComponentError = useCallback((message: string) => {
+    setError({ message, type: 'component' });
+  }, []);
+
+  const clearError = useCallback(() => {
+    setError({ message: null, type: null });
+  }, []);
+
+  const contextValue = useMemo(
+    () => ({
+      error,
+      showModalError,
+      showAuthError,
+      showComponentError,
+      clearError,
+    }),
+    [error, showModalError, showAuthError, showComponentError, clearError],
+  );
+
+  return (
+    <ErrorContext.Provider value={contextValue}>
+      {children}
+    </ErrorContext.Provider>
+  );
+};
+
+export default ErrorProvider;
+

--- a/src/react/FederableApp.tsx
+++ b/src/react/FederableApp.tsx
@@ -10,6 +10,7 @@ import { LocationAdapterProvider } from './next-architecture/ui/LocationAdapterP
 import MetricsAdapterProvider from './next-architecture/ui/MetricsAdapterProvider';
 import ZenkoUI from './ZenkoUI';
 import AuthLoadingProvider from './AuthLoadingProvider';
+import ErrorProvider from './ErrorProvider';
 
 import { ShellHooksProvider, useBasenameRelativeNavigate, useCurrentApp } from '@scality/module-federation';
 import React, { useEffect, useMemo } from 'react';
@@ -79,9 +80,11 @@ const FederableApp = (props) => {
                   <AccessibleAccountsAdapterProvider>
                     <MetricsAdapterProvider>
                       <ToastProvider>
-                        <AuthLoadingProvider>
-                          <ZenkoUI />
-                        </AuthLoadingProvider>
+                        <ErrorProvider>
+                          <AuthLoadingProvider>
+                            <ZenkoUI />
+                          </AuthLoadingProvider>
+                        </ErrorProvider>
                       </ToastProvider>
                       <ReactQueryDevtools initialIsOpen={false} />
                     </MetricsAdapterProvider>

--- a/src/react/Routes.tsx
+++ b/src/react/Routes.tsx
@@ -442,7 +442,7 @@ function InternalRoutes() {
         <RemoveTrailingSlash />
         <ManagementProvider>
           <STSProvider>
-            <PrivateRoutes hideSideBar={hideSideBar} />
+          <PrivateRoutes hideSideBar={hideSideBar} />
           </STSProvider>
         </ManagementProvider>
       </AppContainer>

--- a/src/react/account/AccountCreateUser.tsx
+++ b/src/react/account/AccountCreateUser.tsx
@@ -16,12 +16,8 @@ import { useMutation, useQueryClient } from 'react-query';
 import { useDispatch, useSelector } from 'react-redux';
 import { useNavigate, useParams } from 'react-router';
 import { AppState } from '../../types/state';
-import {
-  clearError,
-  handleErrorMessage,
-  networkEnd,
-  networkStart,
-} from '../actions';
+import { networkEnd, networkStart } from '../actions';
+import { useComponentError, useModalError } from '../ErrorProvider';
 import {
   useCurrentAccount,
   useDataServiceRole,
@@ -47,6 +43,7 @@ const AccountCreateUser = () => {
   const baseNameRelativeNavigate = useBasenameRelativeNavigate();
   const { accountName } = useParams<{ accountName: string }>();
   const IAMClient = useIAMClient();
+  const { showModalError } = useModalError();
   const {
     register,
     handleSubmit,
@@ -78,22 +75,14 @@ const AccountCreateUser = () => {
         baseNameRelativeNavigate(`/accounts/${targetAccountName}/users`);
       },
       onError: () => {
-        const str = 'An error occurred during the user creation.';
-        dispatch(handleErrorMessage(str, 'byModal'));
+        showModalError('An error occurred during the user creation.');
       },
     },
   );
 
-  /**
-   * This part has to be handle
-   */
-  const hasError = useSelector(
-    (state: AppState) =>
-      !!state.uiErrors.errorMsg && state.uiErrors.errorType === 'byComponent',
-  );
-  const errorMessage = useSelector(
-    (state: AppState) => state.uiErrors.errorMsg,
-  );
+  const { componentError, clearComponentError } = useComponentError();
+  const hasError = !!componentError;
+  const errorMessage = componentError;
   const loading = useSelector(
     (state: AppState) => state.networkActivity.counter > 0,
   );
@@ -116,7 +105,7 @@ const AccountCreateUser = () => {
 
   const clearServerError = () => {
     if (hasError) {
-      dispatch(clearError());
+      clearComponentError();
     }
   };
 

--- a/src/react/account/AccountPoliciesList.tsx
+++ b/src/react/account/AccountPoliciesList.tsx
@@ -16,7 +16,9 @@ import { getListPoliciesQuery, getListPolicyVersionsQuery } from '../queries';
 import AwsPaginatedResourceTable from './AwsPaginatedResourceTable';
 import IAMClient from '../../js/IAMClient';
 import { useDispatch } from 'react-redux';
-import { handleApiError, handleClientError } from '../actions';
+import { handleClientError } from '../actions';
+import { useModalError } from '../ErrorProvider';
+import { errorParser } from '../utils';
 import { ApiError } from '../../types/actions';
 import { AWS_PAGINATED_ENTITIES } from '../utils/IAMhooks';
 import { ListPoliciesResponse, Policy } from 'aws-sdk/clients/iam';
@@ -208,6 +210,7 @@ const DeletePolicyAction = ({
   const IAMClient = useIAMClient();
   const queryClient = useQueryClient();
   const [showModal, setShowModal] = useState(false);
+  const { showModalError } = useModalError();
   const isInternalPolicy = path.includes('scality-internal');
   const deletePolicyMutation = useMutation(
     async (arn: string) => {
@@ -238,7 +241,7 @@ const DeletePolicyAction = ({
         try {
           dispatch(handleClientError(error));
         } catch (err) {
-          dispatch(handleApiError(err as ApiError, 'byModal'));
+          showModalError(errorParser(err as ApiError).message);
         }
       },
     },

--- a/src/react/account/AccountUpdateUser.tsx
+++ b/src/react/account/AccountUpdateUser.tsx
@@ -1,7 +1,8 @@
 import { MouseEvent, useRef } from 'react';
-import { clearError, handleErrorMessage, networkEnd } from '../actions';
+import { networkEnd } from '../actions';
 import { useDispatch, useSelector } from 'react-redux';
 import { AppState } from '../../types/state';
+import { useComponentError, useModalError } from '../ErrorProvider';
 import {
   Banner,
   Form,
@@ -39,6 +40,7 @@ const AccountUpdateUser = () => {
   const navigate = useNavigate();
   const IAMClient = useIAMClient();
   const queryClient = useQueryClient();
+  const { showModalError } = useModalError();
   const { IAMUserName, accountName } = useParams<{
     IAMUserName: string;
     accountName: string;
@@ -82,7 +84,7 @@ const AccountUpdateUser = () => {
             );
         })
         .catch((err) => {
-          dispatch(handleErrorMessage(`${err}`, 'byModal'));
+          showModalError(`${err}`);
         })
         .finally(() => {
           dispatch(networkEnd());
@@ -95,16 +97,9 @@ const AccountUpdateUser = () => {
     },
   );
 
-  /**
-   * This part has to be handle
-   */
-  const hasError = useSelector(
-    (state: AppState) =>
-      !!state.uiErrors.errorMsg && state.uiErrors.errorType === 'byComponent',
-  );
-  const errorMessage = useSelector(
-    (state: AppState) => state.uiErrors.errorMsg,
-  );
+  const { componentError, clearComponentError } = useComponentError();
+  const hasError = !!componentError;
+  const errorMessage = componentError;
   const loading = useSelector(
     (state: AppState) => state.networkActivity.counter > 0,
   );
@@ -125,7 +120,7 @@ const AccountUpdateUser = () => {
 
   const clearServerError = () => {
     if (hasError) {
-      dispatch(clearError());
+      clearComponentError();
     }
   };
 

--- a/src/react/account/AccountUserList.tsx
+++ b/src/react/account/AccountUserList.tsx
@@ -19,7 +19,9 @@ import { CellProps } from 'react-table';
 import AwsPaginatedResourceTable from './AwsPaginatedResourceTable';
 import IAMClient from '../../js/IAMClient';
 import { useDispatch } from 'react-redux';
-import { handleApiError, handleClientError } from '../actions';
+import { handleClientError } from '../actions';
+import { useModalError } from '../ErrorProvider';
+import { errorParser } from '../utils';
 import { ApiError } from '../../types/actions';
 import { User } from 'aws-sdk/clients/iam';
 import { FormattedDateTime, Icon, spacing } from '@scality/core-ui';
@@ -187,6 +189,7 @@ const DeleteUserAction = ({
   const IAMClient = useIAMClient();
   const queryClient = useQueryClient();
   const [showModal, setShowModal] = useState(false);
+  const { showModalError } = useModalError();
   const { data: accessKeysResult, status: accessKeyStatus } =
     useAwsPaginatedEntities(
       getUserAccessKeysQuery(userName, IAMClient),
@@ -225,7 +228,7 @@ const DeleteUserAction = ({
           //@ts-expect-error fix this when you are working on it
           dispatch(handleClientError(error));
         } catch (err) {
-          dispatch(handleApiError(err as ApiError, 'byModal'));
+          showModalError(errorParser(err as ApiError).message);
         }
       },
     },

--- a/src/react/account/CreateAccountPolicy.tsx
+++ b/src/react/account/CreateAccountPolicy.tsx
@@ -3,7 +3,9 @@ import { useMutation, useQueryClient } from 'react-query';
 import { getListPoliciesQuery } from '../queries';
 import { useIAMClient } from '../IAMProvider';
 
-import { handleApiError, handleClientError } from '../actions';
+import { handleClientError } from '../actions';
+import { useModalError } from '../ErrorProvider';
+import { errorParser } from '../utils';
 import { useDispatch } from 'react-redux';
 import { ApiError } from '../../types/actions';
 import { CommonPolicyLayout } from './AccountEditCommonLayout';
@@ -24,6 +26,7 @@ const CreateAccountPolicy = () => {
   const currentAccount = useCurrentAccount();
   const dispatch = useDispatch();
   const queryClient = useQueryClient();
+  const { showModalError } = useModalError();
   const defaultValues = {
     policyName: '',
     policyDocument: `{
@@ -70,7 +73,7 @@ const CreateAccountPolicy = () => {
           //@ts-expect-error fix this when you are working on it
           dispatch(handleClientError(error));
         } catch (err) {
-          dispatch(handleApiError(err as ApiError, 'byModal'));
+          showModalError(errorParser(err as ApiError).message);
         }
       },
     },

--- a/src/react/account/details/properties/AccountKeys.tsx
+++ b/src/react/account/details/properties/AccountKeys.tsx
@@ -11,9 +11,11 @@ import { Row } from 'react-table';
 import styled from 'styled-components';
 import { Account } from '../../../../types/account';
 import DeleteConfirmation from '../../../ui-elements/DeleteConfirmation';
-import { useAccessKeysQuery, useDeleteAccessKeyMutation } from './useAccessKeysQuery';
-import { useDispatch } from 'react-redux';
-import { handleAWSClientError, handleAWSError } from '../../../actions/error';
+import {
+  useAccessKeysQuery,
+  useDeleteAccessKeyMutation,
+} from './useAccessKeysQuery';
+import { useModalError } from '../../../ErrorProvider';
 
 const AccessKeysDetails = styled.div`
   display: block;
@@ -44,7 +46,7 @@ type DeleteKeyProps = {
 };
 
 function DeleteKey({ accessKey }: DeleteKeyProps) {
-  const dispatch = useDispatch();
+  const { showModalError } = useModalError();
   const [showDeleteConfirmationModal, setShowDeleteConfirmationModal] =
     useState(false);
   const deleteAccessKeyMutation = useDeleteAccessKeyMutation();
@@ -52,8 +54,7 @@ function DeleteKey({ accessKey }: DeleteKeyProps) {
   const handleDelete = () => {
     deleteAccessKeyMutation.mutate(accessKey, {
       onError: (error: any) => {
-        dispatch(handleAWSClientError(error));
-        dispatch(handleAWSError(error, 'byModal'));
+        showModalError(error.message || 'Failed to delete access key');
       },
     });
     setShowDeleteConfirmationModal(false);
@@ -128,9 +129,7 @@ function AccountKeys({ account, onOpenKeyModal }: Props) {
         },
 
         Cell({ value }: { value: Date }) {
-          return (
-            <FormattedDateTime format="date-time" value={value} />
-          );
+          return <FormattedDateTime format="date-time" value={value} />;
         },
       },
       {
@@ -169,7 +168,9 @@ function AccountKeys({ account, onOpenKeyModal }: Props) {
   if (isLoading) {
     return (
       <AccessKeysDetails>
-        <h3 style={{ marginLeft: spacing.r16 }}>Root user Access keys details</h3>
+        <h3 style={{ marginLeft: spacing.r16 }}>
+          Root user Access keys details
+        </h3>
         <div style={{ padding: spacing.r16 }}>Loading...</div>
       </AccessKeysDetails>
     );

--- a/src/react/account/details/properties/SecretKeyModal.tsx
+++ b/src/react/account/details/properties/SecretKeyModal.tsx
@@ -12,6 +12,7 @@ import { HideCredential } from '../../../ui-elements/Hide';
 
 import { useDataServiceRole } from '../../../DataServiceRoleProvider';
 import { ACCESS_KEYS_QUERY_KEY } from './useAccessKeysQuery';
+import { useModalError } from '../../../ErrorProvider';
 
 import styled from 'styled-components';
 type Props = {
@@ -33,15 +34,22 @@ function SecretKeyModal({ account, isOpen, accountKey, onClose, onKeyCreated }: 
   const { userData } = useAuth();
   const { roleArn } = useDataServiceRole();
   const queryClient = useQueryClient();
+  const { showModalError } = useModalError();
 
   const handleAccessKeyCreate = () => {
     const user = userData?.original;
     if (user) {
       dispatch(
-        createAccountAccessKey(account.Name, roleArn, user, (key) => {
-          onKeyCreated(key);
-          queryClient.invalidateQueries([ACCESS_KEYS_QUERY_KEY, roleArn]);
-        }),
+        createAccountAccessKey(
+          account.Name,
+          roleArn,
+          user,
+          (key) => {
+            onKeyCreated(key);
+            queryClient.invalidateQueries([ACCESS_KEYS_QUERY_KEY, roleArn]);
+          },
+          showModalError,
+        ),
       );
     }
   };

--- a/src/react/actions/__tests__/utils/testUtil.ts
+++ b/src/react/actions/__tests__/utils/testUtil.ts
@@ -96,34 +96,34 @@ export function authenticatedUserState(): AppState {
 }
 
 export const TEST_USER = {
-  id_token: 'idtoken',
-  session_state: '8480d2f0-be54-4c1b-9df7-fcce8dfc7436',
-  access_token: 'accessToken',
-  refresh_token: 'refreshToken',
-  token_type: 'bearer',
-  scope: 'openid profile email',
-  profile: {
-    auth_time: 1592593605,
-    jti: 'd193f7de-134c-47cf-a4e5-7a1b9a7eed72',
-    sub: 'deff329b-72fc-450a-bcb1-354d989859a6',
-    typ: 'ID',
-    azp: 'myclient',
-    session_state: '8480d2f0-be54-4c1b-9df7-fcce8dfc7436',
-    acr: '1',
-    email_verified: true,
-    role: 'user',
-    instanceIds: [INSTANCE_ID],
-    name: 'FirstName LastName',
-    preferred_username: 'username',
-    given_name: 'FirstName',
-    family_name: 'LastName',
-    email: 'test@test.com',
-  },
-  expires_at: 1592593907,
-  state: {
-    path: '/',
-  },
-};
+        id_token: 'idtoken',
+        session_state: '8480d2f0-be54-4c1b-9df7-fcce8dfc7436',
+        access_token: 'accessToken',
+        refresh_token: 'refreshToken',
+        token_type: 'bearer',
+        scope: 'openid profile email',
+        profile: {
+          auth_time: 1592593605,
+          jti: 'd193f7de-134c-47cf-a4e5-7a1b9a7eed72',
+          sub: 'deff329b-72fc-450a-bcb1-354d989859a6',
+          typ: 'ID',
+          azp: 'myclient',
+          session_state: '8480d2f0-be54-4c1b-9df7-fcce8dfc7436',
+          acr: '1',
+          email_verified: true,
+          role: 'user',
+          instanceIds: [INSTANCE_ID],
+          name: 'FirstName LastName',
+          preferred_username: 'username',
+          given_name: 'FirstName',
+          family_name: 'LastName',
+          email: 'test@test.com',
+        },
+        expires_at: 1592593907,
+        state: {
+          path: '/',
+    },
+  };
 export function storeStateWithRunningConfigurationVersion2(): AppState {
   return {
     ...initState,

--- a/src/react/actions/account.ts
+++ b/src/react/actions/account.ts
@@ -1,16 +1,7 @@
-import { Account, AccountKey } from '../../types/account';
-import {
-  DispatchFunction,
-  GetStateFunction,
-  SelectAccountAction,
-  ThunkStatePromisedAction,
-} from '../../types/actions';
+import { Account } from '../../types/account';
+import { SelectAccountAction, ThunkStatePromisedAction } from '../../types/actions';
 import { AuthUser } from '../../types/auth';
 import { getClients } from '../utils/actions';
-import {
-  handleApiError,
-  handleClientError,
-} from './error';
 import { networkEnd, networkStart } from './network';
 
 export function selectAccount(account: Account): SelectAccountAction {
@@ -24,7 +15,8 @@ export function createAccountAccessKey(
   accountName: string,
   roleArn: string,
   user: AuthUser,
-  onSuccess: (key: AccountKey) => void,
+  onSuccess: (key: { userName: string; accessKey: string; secretKey: string }) => void,
+  onError?: (message: string) => void,
 ): ThunkStatePromisedAction {
   return (dispatch, getState) => {
     const { managementClient, instanceId } = getClients(getState());
@@ -42,8 +34,11 @@ export function createAccountAccessKey(
           secretKey: resp.secretKey,
         });
       })
-      .catch((error) => dispatch(handleClientError(error)))
-      .catch((error) => dispatch(handleApiError(error, 'byModal')))
+      .catch((error) => {
+        if (onError) {
+          onError(error.message || 'Failed to create access key');
+        }
+      })
       .finally(() => dispatch(networkEnd()));
   };
 }

--- a/src/react/actions/error.ts
+++ b/src/react/actions/error.ts
@@ -7,29 +7,8 @@ import {
 } from '../../types/actions';
 import { AWSError } from 'aws-sdk';
 import { ErrorViewType } from '../../types/ui';
-import { errorParser } from '../utils';
 import { networkAuthFailure } from './network';
-export function handleApiError(
-  error: ApiError,
-  errorType: ErrorViewType,
-): HandleErrorAction {
-  return {
-    type: 'HANDLE_ERROR',
-    errorMsg: errorParser(error).message,
-    errorType,
-  };
-}
-export function handleAWSError(
-  error: AWSError,
-  errorType: ErrorViewType,
-): HandleErrorAction {
-  const errorMsg = `${error.message} Prefixes, objects or orphan delete markers are still present.`;
-  return {
-    type: 'HANDLE_ERROR',
-    errorMsg: error.code === 'BucketNotEmpty' ? errorMsg : error.message,
-    errorType,
-  };
-}
+
 export function handleErrorMessage(
   error: string,
   errorType: ErrorViewType,
@@ -40,11 +19,13 @@ export function handleErrorMessage(
     errorType,
   };
 }
+
 export function clearError(): ClearErrorAction {
   return {
     type: 'CLEAR_ERROR',
   };
 }
+
 export function handleClientError(error: ApiError): ThunkNonStateAction {
   return (dispatch: DispatchFunction) => {
     switch (error.status) {
@@ -66,6 +47,7 @@ export function handleClientError(error: ApiError): ThunkNonStateAction {
     }
   };
 }
+
 export function handleAWSClientError(error: AWSError): ThunkNonStateAction {
   return (dispatch: DispatchFunction) => {
     if (error.code === 'ExpiredToken') {

--- a/src/react/reducers/initialConstants.ts
+++ b/src/react/reducers/initialConstants.ts
@@ -113,13 +113,6 @@ export const initialNetworkActivityState: NetworkActivityState = {
 export const initialStatsState = {
   bucketList: [],
 };
-export const initialUserState = {
-  list: [],
-  accessKeyList: [],
-  attachedPoliciesList: [],
-  groupList: [],
-  displayedUser: {},
-};
 export const initialFullState = {
   auth: initialAuthState,
   instanceStatus: initialInstanceStatus,

--- a/src/react/ui-elements/ErrorHandlerModal.tsx
+++ b/src/react/ui-elements/ErrorHandlerModal.tsx
@@ -1,29 +1,22 @@
 import { Button } from '@scality/core-ui/dist/components/buttonv2/Buttonv2.component';
 import { Wrap } from '@scality/core-ui/dist/spacing';
-import { useDispatch, useSelector } from 'react-redux';
-import { AppState } from '../../types/state';
-import { clearError } from '../actions';
 import { CustomModal as Modal } from './Modal';
 import { JSX } from 'react';
+import { useModalError } from '../ErrorProvider';
 
 const ErrorHandlerModal = () => {
-  const showError = useSelector(
-    (state: AppState) =>
-      !!state.uiErrors.errorMsg && state.uiErrors.errorType === 'byModal',
-  );
-  const errorMessage = useSelector(
-    (state: AppState) => state.uiErrors.errorMsg,
-  );
-  const dispatch = useDispatch();
+  const { modalError, clearModalError } = useModalError();
 
-  const close = () => dispatch(clearError());
-
-  if (!showError) {
+  if (!modalError) {
     return null;
   }
 
   return (
-    <DumbErrorModal errorMessage={errorMessage} isOpen={true} close={close} />
+    <DumbErrorModal
+      errorMessage={modalError}
+      isOpen={true}
+      close={clearModalError}
+    />
   );
 };
 

--- a/src/react/ui-elements/ReauthDialog.tsx
+++ b/src/react/ui-elements/ReauthDialog.tsx
@@ -4,21 +4,22 @@ import { CustomModal as Modal } from './Modal';
 import { useLocation } from 'react-router';
 import { Wrap } from '@scality/core-ui';
 import AccountRoleSelectButtonAndModal from '../account/AccountRoleSelectButtonAndModal';
+import { useAuthError } from '../ErrorProvider';
+
 const DEFAULT_MESSAGE = 'We need to log you in.';
 
 const ReauthDialog = () => {
   const { pathname } = useLocation();
+  const { authError } = useAuthError();
   const needReauth = useSelector(
     (state: AppState) => state.networkActivity.authFailure,
   );
-  const errorMessage = useSelector((state: AppState) => {
-    if (state.uiErrors.errorType === 'byAuth') {
-      return pathname.indexOf('/accounts') !== -1
-        ? 'Access denied'
-        : state.uiErrors.errorMsg;
-    }
-    return null;
-  });
+
+  const errorMessage = authError
+    ? pathname.indexOf('/accounts') !== -1
+      ? 'Access denied'
+      : authError
+    : null;
 
   if (!needReauth) {
     return null;

--- a/src/react/utils/hooks.ts
+++ b/src/react/utils/hooks.ts
@@ -14,12 +14,9 @@ import { Account, WebIdentityRoles } from '../../types/iam';
 import { notFalsyTypeGuard } from '../../types/typeGuards';
 import { useDataServiceRole } from '../DataServiceRoleProvider';
 import { useShellHooks } from '@scality/module-federation';
-import {
-  handleApiError,
-  handleClientError,
-  networkEnd,
-  networkStart,
-} from '../actions';
+import { handleClientError, networkEnd, networkStart } from '../actions';
+import { useModalError } from '../ErrorProvider';
+import { errorParser } from '.';
 import { useConfig } from '../next-architecture/ui/ConfigProvider';
 import { useAwsPaginatedEntities } from './IAMhooks';
 
@@ -167,6 +164,7 @@ export const SCALITY_IAM_ROLES = [
 
 const reduxBasedEventDispatcher = () => {
   const dispatch = useDispatch();
+  const { showModalError } = useModalError();
   return {
     notifyLoadingAccounts: () => dispatch(networkStart('Loading accounts...')),
     notifyEnd: () => dispatch(networkEnd()),
@@ -174,7 +172,7 @@ const reduxBasedEventDispatcher = () => {
       try {
         dispatch(handleClientError(error));
       } catch (err) {
-        dispatch(handleApiError(err as ApiError, 'byModal'));
+        showModalError(errorParser(err as ApiError).message);
       }
     },
   };

--- a/src/react/utils/testUtil.tsx
+++ b/src/react/utils/testUtil.tsx
@@ -33,6 +33,7 @@ import { ZenkoProvider } from '../ZenkoProvider';
 import zenkoUIReducer from '../reducers';
 import Activity from '../ui-elements/Activity';
 import ErrorHandlerModal from '../ui-elements/ErrorHandlerModal';
+import ErrorProvider from '../ErrorProvider';
 import ReauthDialog from '../ui-elements/ReauthDialog';
 import { ShellHooksProvider } from '@scality/module-federation';
 
@@ -270,42 +271,44 @@ export const Wrapper = ({ children }: { children: ReactNode }): ReactNode => {
   return (
     <QueryClientProvider client={queryClient}>
       <Provider store={store}>
-        <ShellHooksProvider
-          shellHooks={mockShellHooks}
-          shellAlerts={mockShellAlerts}
-        >
-          <ThemeProvider theme={theme}>
-            <MemoryRouter>
-              <_ConfigContext.Provider
-                //@ts-expect-error fix this when you are working on it
-                value={zenkoUITestConfig}
-              >
-                <_DataServiceRoleContext.Provider
+        <ErrorProvider>
+          <ShellHooksProvider
+            shellHooks={mockShellHooks}
+            shellAlerts={mockShellAlerts}
+          >
+            <ThemeProvider theme={theme}>
+              <MemoryRouter>
+                <_ConfigContext.Provider
                   //@ts-expect-error fix this when you are working on it
-                  value={{ role, setRole: jest.fn() }}
+                  value={zenkoUITestConfig}
                 >
-                  <_ManagementContext.Provider
-                    value={{
-                      managementClient: TEST_MANAGEMENT_CLIENT,
-                    }}
+                  <_DataServiceRoleContext.Provider
+                    //@ts-expect-error fix this when you are working on it
+                    value={{ role, setRole: jest.fn() }}
                   >
-                    <LocationAdapterProvider>
-                      <MetricsAdapterProvider>
-                        <AccountsLocationsEndpointsAdapterProvider>
-                          <AccessibleAccountsAdapterProvider>
-                            <TestProvidersWrapper>
-                              {children}
-                            </TestProvidersWrapper>
-                          </AccessibleAccountsAdapterProvider>
-                        </AccountsLocationsEndpointsAdapterProvider>
-                      </MetricsAdapterProvider>
-                    </LocationAdapterProvider>
-                  </_ManagementContext.Provider>
-                </_DataServiceRoleContext.Provider>
-              </_ConfigContext.Provider>
-            </MemoryRouter>
-          </ThemeProvider>
-        </ShellHooksProvider>
+                    <_ManagementContext.Provider
+                      value={{
+                        managementClient: TEST_MANAGEMENT_CLIENT,
+                      }}
+                    >
+                      <LocationAdapterProvider>
+                        <MetricsAdapterProvider>
+                          <AccountsLocationsEndpointsAdapterProvider>
+                            <AccessibleAccountsAdapterProvider>
+                              <TestProvidersWrapper>
+                                {children}
+                              </TestProvidersWrapper>
+                            </AccessibleAccountsAdapterProvider>
+                          </AccountsLocationsEndpointsAdapterProvider>
+                        </MetricsAdapterProvider>
+                      </LocationAdapterProvider>
+                    </_ManagementContext.Provider>
+                  </_DataServiceRoleContext.Provider>
+                </_ConfigContext.Provider>
+              </MemoryRouter>
+            </ThemeProvider>
+          </ShellHooksProvider>
+        </ErrorProvider>
       </Provider>
     </QueryClientProvider>
   );
@@ -377,23 +380,59 @@ export const WrapperAsStorageManager = ({
 
 export const reduxRender = (component: JSX.Element, testState?: unknown) => {
   const store = realStoreWithInitState(testState);
+  const role = {
+    roleArn: TEST_ROLE_ARN,
+  };
 
   return {
     component: render(
-      <ThemeProvider theme={theme}>
-        <Provider store={store}>
-          <ToastProvider>
-            <Wrapper>
-              <>
-                {component}
-                <Activity />
-                <ErrorHandlerModal />
-                <ReauthDialog />
-              </>
-            </Wrapper>
-          </ToastProvider>
-        </Provider>
-      </ThemeProvider>,
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={theme}>
+          <Provider store={store}>
+            <ErrorProvider>
+              <ShellHooksProvider
+                shellHooks={mockShellHooks}
+                shellAlerts={mockShellAlerts}
+              >
+                <ToastProvider>
+                  <MemoryRouter>
+                    <_ConfigContext.Provider
+                      //@ts-expect-error fix this when you are working on it
+                      value={zenkoUITestConfig}
+                    >
+                      <_DataServiceRoleContext.Provider
+                        //@ts-expect-error fix this when you are working on it
+                        value={{ role, setRole: jest.fn() }}
+                      >
+                        <_ManagementContext.Provider
+                          value={{
+                            managementClient: TEST_MANAGEMENT_CLIENT,
+                          }}
+                        >
+                          <LocationAdapterProvider>
+                            <MetricsAdapterProvider>
+                              <AccountsLocationsEndpointsAdapterProvider>
+                                <AccessibleAccountsAdapterProvider>
+                                  <TestProvidersWrapper>
+                                    {component}
+                                    <Activity />
+                                    <ErrorHandlerModal />
+                                    <ReauthDialog />
+                                  </TestProvidersWrapper>
+                                </AccessibleAccountsAdapterProvider>
+                              </AccountsLocationsEndpointsAdapterProvider>
+                            </MetricsAdapterProvider>
+                          </LocationAdapterProvider>
+                        </_ManagementContext.Provider>
+                      </_DataServiceRoleContext.Provider>
+                    </_ConfigContext.Provider>
+                  </MemoryRouter>
+                </ToastProvider>
+              </ShellHooksProvider>
+            </ErrorProvider>
+          </Provider>
+        </ThemeProvider>
+      </QueryClientProvider>,
     ),
   };
 };
@@ -514,14 +553,14 @@ export function renderWithRouterMatch(
                         <MetricsAdapterProvider>
                           <AccountsLocationsEndpointsAdapterProvider>
                             <AccessibleAccountsAdapterProvider>
-                              <TestProvidersWrapper>
-                                <Routes>
-                                  <Route path={path} element={component} />
-                                </Routes>
-                                {/* FIXME We are going to manage error differently
-                              I keep it here to pass some tests */}
-                                <ErrorHandlerModal />
-                              </TestProvidersWrapper>
+                              <ErrorProvider>
+                                <TestProvidersWrapper>
+                                  <Routes>
+                                    <Route path={path} element={component} />
+                                  </Routes>
+                                  <ErrorHandlerModal />
+                                </TestProvidersWrapper>
+                              </ErrorProvider>
                             </AccessibleAccountsAdapterProvider>
                           </AccountsLocationsEndpointsAdapterProvider>
                         </MetricsAdapterProvider>
@@ -575,14 +614,14 @@ export const renderWithCustomRoute = (
                         <MetricsAdapterProvider>
                           <AccountsLocationsEndpointsAdapterProvider>
                             <AccessibleAccountsAdapterProvider>
-                              <ToastProvider>
-                                <TestProvidersWrapper>
-                                  {component}
-                                  {/* FIXME We are going to manage error differently
-                              I keep it here to pass some tests */}
-                                  <ErrorHandlerModal />
-                                </TestProvidersWrapper>
-                              </ToastProvider>
+                              <ErrorProvider>
+                                <ToastProvider>
+                                  <TestProvidersWrapper>
+                                    {component}
+                                    <ErrorHandlerModal />
+                                  </TestProvidersWrapper>
+                                </ToastProvider>
+                              </ErrorProvider>
                             </AccessibleAccountsAdapterProvider>
                           </AccountsLocationsEndpointsAdapterProvider>
                         </MetricsAdapterProvider>
@@ -647,12 +686,12 @@ export const NewWrapper =
                         <MetricsAdapterProvider>
                           <AccountsLocationsEndpointsAdapterProvider>
                             <AccessibleAccountsAdapterProvider>
-                              <TestProvidersWrapper>
-                                {children}
-                                {/* FIXME We are going to manage error differently
-                              I keep it here to pass some tests */}
-                                <ErrorHandlerModal />
-                              </TestProvidersWrapper>
+                              <ErrorProvider>
+                                <TestProvidersWrapper>
+                                  {children}
+                                  <ErrorHandlerModal />
+                                </TestProvidersWrapper>
+                              </ErrorProvider>
                             </AccessibleAccountsAdapterProvider>
                           </AccountsLocationsEndpointsAdapterProvider>
                         </MetricsAdapterProvider>


### PR DESCRIPTION
## Context

This PR is part of the ongoing Redux removal effort to modernize the state management architecture. The goal is to replace Redux-based error handling with React Context, providing a cleaner and more maintainable error management system.

## Problem

- Error handling was managed through Redux (`uiErrors` reducer) with three types: `byModal`, `byAuth`, `byComponent`
- Components needed to dispatch Redux actions to show/clear errors
- Multiple files used `handleApiError` and `handleAWSError` action creators which added unnecessary Redux coupling
- Several reducers (`account`, `secrets`, `uiAccounts`) were no longer used after previous migrations but remained in the codebase

## Solution

Created a centralized `ErrorProvider` Context to manage all error states, providing hooks like `useModalError`, `useAuthError`, and `useComponentError`. Added a temporary sync mechanism from Redux to Context to ensure backward compatibility during the transition period.

## Changes

### Dependencies

- No dependency changes

### New Files

- `src/react/ErrorProvider.tsx` - Context provider for error state management with hooks: `useModalError`, `useAuthError`, `useComponentError`

### Removed Files

- None (reducers were already deleted in previous PRs, only references cleaned up)

### Modified Files

#### Error Handling Migration

- `src/react/FederableApp.tsx` - Wrapped with `ErrorProvider`
- `src/react/ui-elements/ErrorHandlerModal.tsx` - Migrated to `useModalError` hook
- `src/react/ui-elements/ReauthDialog.tsx` - Migrated to `useAuthError` hook
- `src/react/account/details/properties/AccountKeys.tsx` - Migrated to `useModalError` for delete error handling
- `src/react/account/AccountUpdateUser.tsx` - Replaced `dispatch(handleErrorMessage)` with `showModalError`
- `src/react/account/AccountCreateUser.tsx` - Replaced `dispatch(handleErrorMessage)` with `showModalError`
- `src/react/account/AccountUserList.tsx` - Replaced `dispatch(handleApiError)` with `showModalError`
- `src/react/account/AccountPoliciesList.tsx` - Replaced `dispatch(handleApiError)` with `showModalError`
- `src/react/account/CreateAccountPolicy.tsx` - Replaced `dispatch(handleApiError)` with `showModalError`
- `src/react/account/details/properties/SecretKeyModal.tsx` - Added `onError` callback support
- `src/react/utils/hooks.ts` - Replaced `dispatch(handleApiError)` with `showModalError` in `reduxBasedEventDispatcher`
- `src/react/AuthLoadingProvider.tsx` - Migrated to `useComponentError` hook

#### Thunk Actions Cleanup

- `src/react/actions/account.ts` - Added `onError` callback to `createAccountAccessKey`, removed unused action creators
- `src/react/actions/error.ts` - Removed unused `handleApiError` and `handleAWSError` functions

#### Redux Cleanup

- `src/react/reducers/index.ts` - Removed references to `account`, `secrets`, `uiAccounts` reducers
- `src/react/reducers/initialConstants.ts` - Removed unused initial states (`initialAccountState`, `initialAccountsUIState`, `initialSecretsState`, `initialUserState`)

#### Test Updates

- `src/react/utils/testUtil.tsx` - Added `ErrorProvider` to `Wrapper`, `reduxRender`, `renderWithRouterMatch`, and other test utilities

## Testing

Please verify:

1. **Access Key Operations**
   - Navigate to `/accounts/{accountName}/properties`
   - Create access key → should work and list should update
   - Delete access key → should show confirmation dialog, then delete and update list

2. **User Operations**
   - Navigate to `/accounts/{accountName}/create-user`
   - Create user → should work and redirect to users list
   - Delete user from users list → should show confirmation, then delete

3. **Policy Operations**
   - Navigate to `/accounts/{accountName}/policies`
   - Delete policy → should show confirmation, then delete

4. **Error Modal Display**
   - All error modals should display correctly and dismiss when clicking "Close"