### PR TITLE
Fix: enable data-browser-library related tests

### DIFF
--- a/__mocks__/@scality/data-browser-library.tsx
+++ b/__mocks__/@scality/data-browser-library.tsx
@@ -55,3 +55,23 @@ export const usePutObject = jest.fn(() => ({
   error: null,
   reset: jest.fn(),
 }));
+
+export const useGetBucketTagging = jest.fn(() => ({
+  data: { TagSet: [] },
+  status: 'success',
+  isLoading: false,
+  isSuccess: true,
+  isError: false,
+  error: null,
+  refetch: jest.fn(),
+}));
+
+export const useGetObject = jest.fn(() => ({
+  data: undefined,
+  status: 'idle',
+  isLoading: false,
+  isSuccess: false,
+  isError: false,
+  error: null,
+  refetch: jest.fn(),
+}));

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,14 +1,6 @@
 module.exports = {
   testEnvironment: 'jsdom',
   testMatch: ['**/?(*.)+(test).ts?(x)'],
-  // TODO: Remove ignore patterns once the tests are updated to use the data-browser-library
-  testPathIgnorePatterns: [
-    'src/react/ISV/hooks/useGetS3ServicePoint.test.ts',
-    'src/react/ISV/modules/veeam/components/VeeamCapacityOverviewRow.test.tsx',
-    'src/react/ISV/modules/veeam/components/VeeamCapacityModal.test.tsx',
-    'src/react/ISV/components/__tests__/ISVSummary.test.tsx',
-    'src/react/ui-elements/__tests__/SelectAccountIAMRole.test.tsx',
-  ],
   transformIgnorePatterns: [
     '/node_modules/(?!(vega-lite|@scality|pretty-bytes|uuid)/)',
   ],

--- a/jestSetupAfterEnv.tsx
+++ b/jestSetupAfterEnv.tsx
@@ -186,3 +186,65 @@ jest.mock('@scality/module-federation', () => {
     FederatedComponent: () => mockComponent(),
   };
 });
+
+jest.mock('@scality/data-browser-library');
+
+let clipboardContent = '';
+
+class MockClipboardItem {
+  private data: Record<string, Blob | string>;
+  types: string[];
+
+  constructor(items: Record<string, Blob | string>) {
+    this.data = items;
+    this.types = Object.keys(items);
+  }
+
+  async getType(type: string): Promise<Blob> {
+    if (this.data[type]) {
+      const data = this.data[type];
+      if (typeof data === 'string') {
+        return new Blob([data], { type });
+      }
+      return data as Blob;
+    }
+    return Promise.reject(
+      new Error(`${type} is not one of the available MIME types on this item.`),
+    );
+  }
+}
+
+//@ts-expect-error Mocking ClipboardItem for tests
+global.ClipboardItem = MockClipboardItem;
+
+Object.assign(navigator, {
+  clipboard: {
+    writeText: jest.fn().mockImplementation((text: string) => {
+      clipboardContent = text;
+      return Promise.resolve();
+    }),
+    readText: jest.fn().mockImplementation(() => {
+      return Promise.resolve(clipboardContent);
+    }),
+    write: jest.fn().mockImplementation(async (items: ClipboardItem[]) => {
+      if (items[0]) {
+        const item = items[0];
+        const types = item.types;
+        if (types && types.length > 0) {
+          const type = types.includes('text/plain') ? 'text/plain' : types[0];
+          try {
+            const blob = await item.getType(type);
+            if (blob instanceof Blob) {
+              clipboardContent = await blob.text();
+            } else if (typeof blob === 'string') {
+              clipboardContent = blob;
+            }
+          } catch (e) {
+            console.error('Clipboard write error:', e);
+          }
+        }
+      }
+      return Promise.resolve();
+    }),
+  },
+});

--- a/src/react/ISV/components/__tests__/ISVSummary.test.tsx
+++ b/src/react/ISV/components/__tests__/ISVSummary.test.tsx
@@ -1,5 +1,5 @@
 import { Stepper } from '@scality/core-ui';
-import { render, screen } from '@testing-library/react';
+import { fireEvent, render, screen } from '@testing-library/react';
 
 import { DEFAULT_REGION, ISVSummary, ISVSummaryProps } from '../ISVSummary';
 import userEvent from '@testing-library/user-event';
@@ -25,13 +25,11 @@ const useAuth = mockShellHooks.useAuth;
 const useDeployedApps = mockShellHooks.useDeployedApps;
 const useConfigRetriever = mockShellHooks.useConfigRetriever;
 
-jest.mock('../../hooks/useGetS3ServicePoint', () => ({
-  useGetS3ServicePoint: () => {
-    return {
-      s3ServicePoint: SERVICE_POINT,
-    };
-  },
-}));
+import * as useGetS3ServicePointModule from '../../hooks/useGetS3ServicePoint';
+jest.spyOn(useGetS3ServicePointModule, 'useGetS3ServicePoint').mockReturnValue({
+  s3ServicePoint: 's3.test.local',
+});
+
 
 const mockAuthUserData = {
   userData: {
@@ -123,6 +121,15 @@ jest.setTimeout(10000);
 const platformName = 'Veeam';
 
 describe('ISVSummary', () => {
+  let writeTextSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    writeTextSpy = jest.spyOn(navigator.clipboard, 'writeText');
+  });
+
+  afterEach(() => {
+    writeTextSpy.mockRestore();
+  });
   const selectors = {
     title: (platformName) => screen.getByText(SUMMARY_TITLE(platformName)),
     informationSection: (platformName) =>
@@ -146,10 +153,6 @@ describe('ISVSummary', () => {
     secretKeyOutput: () => screen.queryByLabelText(/Secret Access key/i),
     accessKeysOutput: () => screen.queryAllByText(/Access key ID/),
   };
-
-  afterEach(() => {
-    jest.clearAllMocks();
-  });
 
   it('should render Summary', async () => {
     //S
@@ -509,33 +512,25 @@ describe('ISVSummary', () => {
         { wrapper: Wrapper },
       );
 
-      const user = userEvent.setup();
       // Verify the copy buttons
-      await user.click(selectors.copyServiceEndpointButton());
-      await expect(navigator.clipboard.readText()).resolves.toBe(SERVICE_POINT);
-      await user.click(selectors.copyAccessKeyButton());
-      await expect(navigator.clipboard.readText()).resolves.toBe(ACCESS_KEY);
-      await user.click(selectors.copySecretKeyButton());
-      await expect(navigator.clipboard.readText()).resolves.toBe(SECRET_KEY);
-      await user.click(selectors.copyBucketNameButton());
-      await expect(navigator.clipboard.readText()).resolves.toBe(BUCKET_NAME);
-      await user.click(selectors.copyRegionButton());
-      await expect(navigator.clipboard.readText()).resolves.toBe(
-        DEFAULT_REGION,
-      );
-      await user.click(selectors.copyAllButton());
+      fireEvent.click(selectors.copyServiceEndpointButton());
+      expect(writeTextSpy).toHaveBeenLastCalledWith(SERVICE_POINT);
+      fireEvent.click(selectors.copyAccessKeyButton());
+      expect(writeTextSpy).toHaveBeenLastCalledWith(ACCESS_KEY);
+      fireEvent.click(selectors.copySecretKeyButton());
+      expect(writeTextSpy).toHaveBeenLastCalledWith(SECRET_KEY);
+      fireEvent.click(selectors.copyBucketNameButton());
+      expect(writeTextSpy).toHaveBeenLastCalledWith(BUCKET_NAME);
+      fireEvent.click(selectors.copyRegionButton());
+      expect(writeTextSpy).toHaveBeenLastCalledWith(DEFAULT_REGION);
+      fireEvent.click(selectors.copyAllButton());
 
-      await expect(navigator.clipboard.readText()).resolves.toBe(
-        `Service point\t${SERVICE_POINT}\nRegion\t${DEFAULT_REGION}\nAccess key ID\t${ACCESS_KEY}\nSecret Access key\t${SECRET_KEY}\nBucket names\t${BUCKET_NAME}`,
-      );
-      await user.click(selectors.copyAllButton());
-
-      await expect(navigator.clipboard.readText()).resolves.toBe(
+      expect(writeTextSpy).toHaveBeenLastCalledWith(
         `Service point\t${SERVICE_POINT}\nRegion\t${DEFAULT_REGION}\nAccess key ID\t${ACCESS_KEY}\nSecret Access key\t${SECRET_KEY}\nBucket names\t${BUCKET_NAME}`,
       );
     });
 
-    it('should copy all information to the clipboard when clicking on the copy all button in multiple bucket case', async () => {
+    it('should copy all information to the clipboard when clicking on the copy all button in multiple bucket case', () => {
       //S
       render(
         <ISVStepperContext.Provider value={mockStepperContext}>
@@ -553,14 +548,13 @@ describe('ISVSummary', () => {
         { wrapper: Wrapper },
       );
 
-      const user = userEvent.setup();
       // Verify the copy buttons
-      await user.click(selectors.copyAllButton());
-      await expect(navigator.clipboard.readText()).resolves.toBe(
+      fireEvent.click(selectors.copyAllButton());
+      expect(writeTextSpy).toHaveBeenLastCalledWith(
         `Service point\t${SERVICE_POINT}\nRegion\t${DEFAULT_REGION}\nAccess key ID\t${ACCESS_KEY}\nSecret Access key\t${SECRET_KEY}\nBucket names\t${BUCKET_NAME}, bucket-name-2`,
       );
     });
-    it('should copy all data when displaying access keys for existing account', async () => {
+    it('should copy all data when displaying access keys for existing account', () => {
       //S
       render(
         <ISVStepperContext.Provider value={mockStepperContext}>
@@ -578,10 +572,9 @@ describe('ISVSummary', () => {
         { wrapper: Wrapper },
       );
 
-      const user = userEvent.setup();
       // Verify the copy buttons
-      await user.click(selectors.copyAllButton());
-      await expect(navigator.clipboard.readText()).resolves.toBe(
+      fireEvent.click(selectors.copyAllButton());
+      expect(writeTextSpy).toHaveBeenLastCalledWith(
         `Service point\t${SERVICE_POINT}\nRegion\t${DEFAULT_REGION}\nAccess key IDs\taccess-key-1, access-key-2\nBucket names\t${BUCKET_NAME}`,
       );
     });
@@ -683,11 +676,9 @@ describe('ISVSummary', () => {
         { wrapper: Wrapper },
       );
 
-      const user = userEvent.setup();
-      await user.click(selectors.copyAllButton());
-
       //E+V
-      await expect(navigator.clipboard.readText()).resolves.toBe(
+      fireEvent.click(selectors.copyAllButton());
+      expect(writeTextSpy).toHaveBeenLastCalledWith(
         `Service Host\t${SERVICE_POINT}\nRegion\t${DEFAULT_REGION}\nAccess key ID\t${ACCESS_KEY}\nSecret Access key\t${SECRET_KEY}\nBucket names\t${BUCKET_NAME}`,
       );
     });

--- a/src/react/ISV/hooks/useGetS3ServicePoint.test.ts
+++ b/src/react/ISV/hooks/useGetS3ServicePoint.test.ts
@@ -1,17 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { useGetS3ServicePoint } from './useGetS3ServicePoint';
-import { useAccountsLocationsAndEndpoints } from '../../next-architecture/domain/business/accounts';
-
-jest.mock('../../next-architecture/domain/business/accounts', () => ({
-  useAccountsLocationsAndEndpoints: jest.fn(),
-}));
-
-jest.mock('../../next-architecture/ui/AccountsLocationsEndpointsAdapterProvider', () => ({
-  useAccountsLocationsEndpointsAdapter: jest.fn(() => ({})),
-}));
-
-const mockUseAccountsLocationsAndEndpoints =
-  useAccountsLocationsAndEndpoints as jest.Mock;
+import * as accountsModule from '../../next-architecture/domain/business/accounts';
+import * as adapterModule from '../../next-architecture/ui/AccountsLocationsEndpointsAdapterProvider';
 
 const MOCK_ACCOUNTS_LOCATIONS_ENDPOINTS = {
   accounts: [],
@@ -31,8 +21,27 @@ const MOCK_ACCOUNTS_LOCATIONS_ENDPOINTS = {
 };
 
 describe('useGetS3ServicePoint', () => {
+  let mockUseAccountsLocationsEndpointsAdapter: jest.SpyInstance;
+  let mockUseAccountsLocationsAndEndpoints: jest.SpyInstance;
+
   beforeEach(() => {
     jest.clearAllMocks();
+    mockUseAccountsLocationsEndpointsAdapter = jest.spyOn(
+      adapterModule,
+      'useAccountsLocationsEndpointsAdapter',
+    );
+    mockUseAccountsLocationsAndEndpoints = jest.spyOn(
+      accountsModule,
+      'useAccountsLocationsAndEndpoints',
+    );
+
+    mockUseAccountsLocationsEndpointsAdapter.mockReturnValue({
+      listAccountsLocationsAndEndpoints: jest.fn(),
+    });
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('should return s3 endpoint if there is one', () => {

--- a/src/react/ISV/modules/veeam/components/VeeamCapacityModal.test.tsx
+++ b/src/react/ISV/modules/veeam/components/VeeamCapacityModal.test.tsx
@@ -1,31 +1,14 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-import { rest } from 'msw';
-import { setupServer } from 'msw/node';
-import { NewWrapper, TEST_API_BASE_URL } from '../../../../utils/testUtil';
+import { NewWrapper } from '../../../../utils/testUtil';
 import { VeeamCapacityModal } from './VeeamCapacityModal';
-import { VEEAM_XML_PREFIX } from '../../../constants';
 import userEvent from '@testing-library/user-event';
+import { usePutObject } from '@scality/data-browser-library';
 
+const mockUsePutObject = usePutObject as jest.Mock;
 const bucketName = 'test-bucket';
 
 describe('VeeamCapacityModal', () => {
   const mockMutate = jest.fn();
-  const server = setupServer(
-    rest.put(
-      `${TEST_API_BASE_URL}/${bucketName}/${VEEAM_XML_PREFIX}/capacity.xml`,
-      (req, res, ctx) => {
-        mockMutate(req.body);
-        return res(ctx.status(200));
-      },
-    ),
-  );
-  beforeAll(() => {
-    server.listen({ onUnhandledRequest: 'error' });
-  });
-  afterEach(() => {
-    server.resetHandlers();
-  });
-  afterAll(() => server.close());
 
   const selectors = {
     modalTitle: () => screen.getByText('Edit max repository capacity'),
@@ -37,6 +20,24 @@ describe('VeeamCapacityModal', () => {
   };
 
   beforeEach(() => {
+    jest.clearAllMocks();
+    mockUsePutObject.mockReturnValue({
+      mutate: mockMutate.mockImplementation((_, options) => {
+        if (options?.onSuccess) {
+          options.onSuccess();
+        }
+      }),
+      mutateAsync: jest.fn(),
+      status: 'idle',
+      isIdle: true,
+      isLoading: false,
+      isSuccess: false,
+      isError: false,
+      data: undefined,
+      error: null,
+      reset: jest.fn(),
+    });
+
     render(
       <VeeamCapacityModal
         bucketName={bucketName}
@@ -75,20 +76,35 @@ describe('VeeamCapacityModal', () => {
 
     await waitFor(async () => {
       expect(mockMutate).toHaveBeenCalledWith(
-        '<?xml version="1.0" encoding="utf-8" ?><CapacityInfo><Capacity>214748364800</Capacity><Available>0</Available><Used>0</Used></CapacityInfo>',
+        expect.objectContaining({
+          Bucket: bucketName,
+          Body: '<?xml version="1.0" encoding="utf-8" ?><CapacityInfo><Capacity>214748364800</Capacity><Available>0</Available><Used>0</Used></CapacityInfo>',
+          ContentType: 'text/xml',
+        }),
+        expect.any(Object),
       );
     });
   });
   it('should validate capacity value correctly : number less than 1', async () => {
-    fireEvent.click(selectors.editBtn());
-    fireEvent.change(selectors.capacityInput(), { target: { value: '0' } });
-
-    await waitFor(async () => {
-      expect(selectors.editModalBtn()).toBeDisabled();
-      expect(
-        screen.getByText(/"capacity" must be larger than or equal to 1/i),
-      ).toBeInTheDocument();
+    const user = userEvent.setup();
+    await user.click(selectors.editBtn());
+    await waitFor(() => {
+      expect(selectors.modalTitle()).toBeInTheDocument();
     });
+
+    const capacityInput = selectors.capacityInput();
+    await user.clear(capacityInput);
+    await user.type(capacityInput, '0');
+
+    await waitFor(
+      () => {
+        expect(selectors.editModalBtn()).toBeDisabled();
+        expect(
+          screen.getByText(/"capacity" must be greater than or equal to 1/i),
+        ).toBeInTheDocument();
+      },
+      { timeout: 3000 },
+    );
   });
   it('should validate capacity value correctly : number greater than 1024', async () => {
     fireEvent.click(selectors.editBtn());
@@ -129,19 +145,12 @@ describe('VeeamCapacityModal', () => {
   });
 
   it('should display error toast if mutation failed', async () => {
-    server.use(
-      rest.put(
-        `${TEST_API_BASE_URL}/${bucketName}/${VEEAM_XML_PREFIX}/capacity.xml`,
-        (req, res, ctx) => {
-          return res(
-            ctx.status(404),
-            ctx.xml(
-              `<?xml version="1.0" encoding="UTF-8"?><Error><Code>NoSuchBucket</Code><Message>The specified bucket does not exist.</Message><Resource></Resource><RequestId>a60426d7934a9fa05118</RequestId></Error>`,
-            ),
-          );
-        },
-      ),
-    );
+    mockMutate.mockImplementation((_, options) => {
+      if (options?.onError) {
+        options.onError(new Error('The specified bucket does not exist.'));
+      }
+    });
+
     fireEvent.click(selectors.editBtn());
     fireEvent.change(selectors.capacityInput(), { target: { value: '200' } });
 

--- a/src/react/ISV/modules/veeam/components/VeeamCapacityOverviewRow.test.tsx
+++ b/src/react/ISV/modules/veeam/components/VeeamCapacityOverviewRow.test.tsx
@@ -1,59 +1,64 @@
 import { render, waitFor, screen } from '@testing-library/react';
-import { rest } from 'msw';
-import { setupServer } from 'msw/node';
 import {
   NewWrapper,
-  TEST_API_BASE_URL,
   mockOffsetSize,
 } from '../../../../utils/testUtil';
 import { VeeamCapacityOverviewRow } from './VeeamCapacityOverviewRow';
-import { VEEAM_XML_PREFIX } from '../../../constants';
+import {
+  useGetBucketTagging,
+  useGetObject,
+} from '@scality/data-browser-library';
+import { VeeamApplicationType } from '../../../constants';
+
+const mockUseGetBucketTagging = useGetBucketTagging as jest.Mock;
+const mockUseGetObject = useGetObject as jest.Mock;
 
 const bucketName = 'test-bucket';
 
 describe('VeeamCapacityOverviewRow', () => {
-  const server = setupServer(
-    rest.get(`${TEST_API_BASE_URL}/${bucketName}`, (req, res, ctx) => {
-      return res(
-        ctx.xml(`
-          <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-            <Tagging>
-              <TagSet>
-                <Tag>
-                  <Key>X-Scality-Veeam-Application</Key>
-                  <Value>Veeam Backup &amp;#38; Replication</Value>
-                </Tag>
-              </TagSet>
-            </Tagging>
-          `),
-      );
-    }),
-    rest.get(
-      `${TEST_API_BASE_URL}/${bucketName}/${VEEAM_XML_PREFIX}/capacity.xml`,
-      (req, res, ctx) => {
-        return res(
-          ctx.status(200),
-          ctx.xml(`
-        <?xml version="1.0" encoding="UTF-8" ?>
+  beforeAll(() => {
+    mockOffsetSize(200, 100);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should render the VeeamCapacityOverviewRow', async () => {
+    mockUseGetBucketTagging.mockReturnValue({
+      data: {
+        TagSet: [
+          {
+            Key: 'X-Scality-Veeam-Application',
+            Value: VeeamApplicationType.VEEAM_BACKUP_REPLICATION,
+          },
+        ],
+      },
+      status: 'success',
+      isLoading: false,
+      isSuccess: true,
+      isError: false,
+    });
+
+    mockUseGetObject.mockReturnValue({
+      data: {
+        Body: Buffer.from(`<?xml version="1.0" encoding="UTF-8" ?>
           <CapacityInfo>
             <Capacity>107374182400</Capacity>
             <Available>107374182400</Available>
             <Used>0</Used>
-        </CapacityInfo>`),
-        );
+          </CapacityInfo>`),
       },
-    ),
-  );
-  beforeAll(() => {
-    server.listen({ onUnhandledRequest: 'error' });
-    mockOffsetSize(200, 100);
-  });
-  afterEach(() => {
-    server.resetHandlers();
-  });
-  afterAll(() => server.close());
+      status: 'success',
+      isLoading: false,
+      isSuccess: true,
+      isError: false,
+    });
 
-  it('should render the VeeamCapacityOverviewRow', async () => {
     render(<VeeamCapacityOverviewRow bucketName={bucketName} />, {
       wrapper: NewWrapper(),
     });
@@ -66,23 +71,29 @@ describe('VeeamCapacityOverviewRow', () => {
   });
 
   it('should not render the row if SOSAPI is not enabled', () => {
-    server.use(
-      rest.get(`${TEST_API_BASE_URL}/${bucketName}`, (req, res, ctx) => {
-        return res(
-          ctx.xml(`
-            <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-              <Tagging>
-                <TagSet>
-                  <Tag>
-                    <Key>X-Scality-Veeam-Application</Key>
-                    <Value>Test Application</Value>
-                  </Tag>
-                </TagSet>
-              </Tagging>
-            `),
-        );
-      }),
-    );
+    mockUseGetBucketTagging.mockReturnValue({
+      data: {
+        TagSet: [
+          {
+            Key: 'X-Scality-Veeam-Application',
+            Value: 'Test Application',
+          },
+        ],
+      },
+      status: 'success',
+      isLoading: false,
+      isSuccess: true,
+      isError: false,
+    });
+
+    mockUseGetObject.mockReturnValue({
+      data: undefined,
+      status: 'idle',
+      isLoading: false,
+      isSuccess: false,
+      isError: false,
+    });
+
     render(<VeeamCapacityOverviewRow bucketName={bucketName} />, {
       wrapper: NewWrapper(),
     });
@@ -92,14 +103,29 @@ describe('VeeamCapacityOverviewRow', () => {
   });
 
   it('should display loading state', async () => {
-    server.use(
-      rest.get(
-        `${TEST_API_BASE_URL}/${bucketName}/${VEEAM_XML_PREFIX}/capacity.xml`,
-        (req, res, ctx) => {
-          return res(ctx.status(400));
-        },
-      ),
-    );
+    mockUseGetBucketTagging.mockReturnValue({
+      data: {
+        TagSet: [
+          {
+            Key: 'X-Scality-Veeam-Application',
+            Value: VeeamApplicationType.VEEAM_BACKUP_REPLICATION,
+          },
+        ],
+      },
+      status: 'success',
+      isLoading: false,
+      isSuccess: true,
+      isError: false,
+    });
+
+    mockUseGetObject.mockReturnValue({
+      data: undefined,
+      status: 'loading',
+      isLoading: true,
+      isSuccess: false,
+      isError: false,
+    });
+
     render(<VeeamCapacityOverviewRow bucketName={bucketName} />, {
       wrapper: NewWrapper(),
     });
@@ -112,14 +138,30 @@ describe('VeeamCapacityOverviewRow', () => {
   });
 
   it('should display error state', async () => {
-    server.use(
-      rest.get(
-        `${TEST_API_BASE_URL}/${bucketName}/${VEEAM_XML_PREFIX}/capacity.xml`,
-        (req, res, ctx) => {
-          return res(ctx.status(404));
-        },
-      ),
-    );
+    mockUseGetBucketTagging.mockReturnValue({
+      data: {
+        TagSet: [
+          {
+            Key: 'X-Scality-Veeam-Application',
+            Value: VeeamApplicationType.VEEAM_BACKUP_REPLICATION,
+          },
+        ],
+      },
+      status: 'success',
+      isLoading: false,
+      isSuccess: true,
+      isError: false,
+    });
+
+    mockUseGetObject.mockReturnValue({
+      data: undefined,
+      status: 'error',
+      isLoading: false,
+      isSuccess: false,
+      isError: true,
+      error: new Error('Not found'),
+    });
+
     render(<VeeamCapacityOverviewRow bucketName={bucketName} />, {
       wrapper: NewWrapper(),
     });

--- a/src/react/ui-elements/__tests__/SelectAccountIAMRole.test.tsx
+++ b/src/react/ui-elements/__tests__/SelectAccountIAMRole.test.tsx
@@ -29,63 +29,83 @@ const testAccountId2 = '377232323695';
 
 jest.setTimeout(30_000);
 
+jest.mock('../../DataServiceRoleProvider', () => {
+  const actual = jest.requireActual('../../DataServiceRoleProvider');
+  const { IAMProvider } = jest.requireActual('../../IAMProvider');
+  const { ZenkoProvider } = jest.requireActual('../../ZenkoProvider');
+  const React = require('react');
+
+  return {
+    ...actual,
+    __esModule: true,
+    default: ({ children }: { children: React.ReactNode }) => {
+      const [role, setRoleState] = React.useState({ roleArn: '' });
+      const credentials = {
+        accessKeyId: 'TEST_ACCESS_KEY',
+        secretAccessKey: 'TEST_SECRET_KEY',
+        sessionToken: 'TEST_SESSION_TOKEN',
+      };
+
+      return (
+        <actual._DataServiceRoleContext.Provider
+          value={{
+            role,
+            setRole: (newRole: { roleArn: string }) => setRoleState(newRole),
+            setRolePromise: jest.fn().mockResolvedValue({}),
+            assumedRole: {
+              AssumedRoleUser: {
+                Arn: `arn:aws:sts::${role.roleArn ? role.roleArn.match(/:(\d+):/)?.[1] || '064609833007' : '064609833007'}:assumed-role/storage-manager-role/ui-test`,
+                AssumedRoleId: 'TEST:ui-test',
+              },
+              Credentials: {
+                AccessKeyId: 'TEST_ACCESS_KEY',
+                SecretAccessKey: 'TEST_SECRET_KEY',
+                SessionToken: 'TEST_SESSION_TOKEN',
+                Expiration: new Date('2099-12-31T23:59:59Z'),
+              },
+            },
+          }}
+        >
+          <IAMProvider credentials={credentials}>
+            <ZenkoProvider credentials={credentials}>{children}</ZenkoProvider>
+          </IAMProvider>
+        </actual._DataServiceRoleContext.Provider>
+      );
+    },
+  };
+});
+
 const commonIAMHandlers = (getPayloadFn: jest.Mock, req, res, ctx) => {
   //@ts-ignore
   const params = new URLSearchParams(req.body);
   getPayloadFn(params);
 
   if (params.get('Action') === 'AssumeRoleWithWebIdentity') {
-    const accountId = extractAccountIdFromARN(params.get('RoleArn'));
+    const accountId = extractAccountIdFromARN(params.get('RoleArn')) || '000000000000';
 
-    if (accountId === testAccountId1) {
-      return res(
-        ctx.status(200),
-        ctx.xml(`
-            <AssumeRoleWithWebIdentityResponse
-            xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
-            <AssumeRoleWithWebIdentityResult>
-              <AssumedRoleUser>
-                <Arn>arn:aws:sts::${testAccountId1}:assumed-role/storage-manager-role/ui-9160673b-2c2a-4a6f-a1ef-a3cb6ce25d7f</Arn>
-                <AssumedRoleId>OES3SPDIYW4L92S8K1QE6MINE31LQG04:ui-9160673b-2c2a-4a6f-a1ef-a3cb6ce25d7f</AssumedRoleId>
-              </AssumedRoleUser>
-              <Credentials>
-                <SecretAccessKey>v/0Nq1YMw4nNbvtgQlgi0l6m/PXWjlk1VLmn2I5q</SecretAccessKey>
-                <AccessKeyId>72SPRZFF71WPWXXUG6XF</AccessKeyId>
-                <SessionToken>eyJzYWx0IjoicVIvVGdIdS9FVjJ4TjN5RmtXSnVLZGE0M0krK0g1L3lFVDU5UkV0enpYYz0iLCJ0YWciOiI4d05WRTIwTlQxWTVKbWtZemo2ZGJ3PT0iLCJjaXBoZXJ0ZXh0IjoiQVNIanI0M0VZc3dzK0QwWDFkVXRXQ2JMbzlFOVZ5SzF5WWt6a21lRjRXOUpCU3hwbmNxS21zWnpIU3ZvYlZEYjNKaDRNTm16bW1yVUd6dTU1bmRwMTk0eTVlVjFSVWMzaHZnSTFxZTRuYmJxNHBPdit5V3VZQ3RtSExUbE5BTHpDK3VhYW1tZDdzWk9BVXNKQlhRcmVHUG5sTFphb0kySTFveXJjbk10QlVpb1AvYnNjNUd6RHFqdTFWMjVQRE9PQWgzM2JFSktHdmorbEoyL2lWV0x5UHBQU1pLZmdZUnd1QjRXczdGaG81dHhaem9uWWhpaG9ocnFtdmFnNUJSNytiN2lGN3ZxZjBVSnFPZXI5Wm9ldDk1dlpqL01qTU04aGhGQXI1MmZnTHpzOHAzVlN3dHV0OENFSTBoVEJJNlVycUY4SWxiUmhFOUtlaHo0cnRiZHRKQzVmVHFRSkVPZWltb0RIbGpZZXZqOVlIZzZPVFhDR2ZhVzRIWDc3T0g5M1BRa0dHc1RCSjVpRTEyZEdYQjhYWWdSM1VackIwUzdQejdLQnpvSUVodTZOWUkrK1NPZ2pwMlFaUmhaWGtkbDdDdU5EMWg2UE9qN2twREY0QXhHbWdwcjBMbmpOdVp1UzJaWlJTck5OZG1WL3B5dWpUM3BtcFNJNUZkNW5Wby9SV1dTSGhoR0FVcWRJS0EyV00xdVJ2TkVFS25rb25keWNuVHRrSHpDVUwrN0RtTXNuL202eTcyZjFReHY2VFQyejRzRVFSUDFhWUcwdnBWSTlXbUpWdW5yTFFVNmxSUmpsb1VFSFVkZ2xCMGd1eTZGZTNYR29YQjdVc1J5UUpxbEJ0elpvdFdkR1AvSjZaMllNODFDSy8zZjJZTXVnNTZlbXQxTmJJZ0hrVWxnaGxpclRsNVdrckVRbG5XTW4zT2dzRk9wMjJKSTV1UGoxSENUMlNhTlBXZEQrY0VCcTZycC9tc1FDOW02Q3prSkMwTWMyclZ0RmdnZitaSEV5dVZvdEVzeUFtY1V5QTdFZzJtY3BXd1pnbHZrYkZQQmI5M2NDN0ZhZGhpNEUzQ0hQbm9BczF5eVNKNkxIOTZZTHJoaXk1Q1h3VWloSTlRdmxuSDNlV3EwaElBZTFGc2N6bThzVWRCTGU2SWlVc3ZJVDlpMjJzcTZnaVpmdld5czVlaU9NZzRQMFBaZCtPK0VDRmdmd3dxdUhYcFdEL1F5RnR1RENVb0xxblNyMU9lOHdCQ2lXNDFYaGtacmEzWTdtVW1QYXlNWTN6MXpOZm1XRllJV0dWZzlBNVFUaUZLWGlZTngxdUtWZGJ3Qk54SmowVmxlTTE4azlDNFR3Z2U3dVYyKzEzcWVkTW5xOUpLa2Uwa1NsNmMxMWM5N1RUbGJ4TUx5YS9WY1JLWkNkbHJaTGZNK0hjSTJWaGdkSzNzWHJIVEN6UENFRC9lMVBRTkg1RVZBVThLRlNHWGEzb1dPWm9VcmlSYlk1L3R5eTQvbHRKTkVhNnV3R2hra0ljR3JLMjltUndkaDJHSE94R1laYmdGL0VVUDYreUs5cjQrVzc5Y1RYc3NRcEpSM1M1bkZpUHE2bHR6NXM1ZlNYalNkcUxSM0gvTVZlcXV6K3RON0czMk1ieW9halZvcVJxcks2WjZIVm1vM3pDZ1M4TURQQk9jVkY3Ymc0QmhXaXFUTjc5a0ZqV0xkWWZSVlB5Qk1VaXBHNmZCcGlBdUZCZEV1S2lLMHBwVkhQNUpZL0h5ZXRBbVgxMzdVK1U5d3prbmw3eXhyOEQ0TkdNL05yaVhBT21hSDN4YVEifQ==</SessionToken>
-                <Expiration>2023-11-28T10:16:13Z</Expiration>
-              </Credentials>
-              <Provider>www.scality.com</Provider>
-            </AssumeRoleWithWebIdentityResult>
-            <ResponseMetadata>
-              <RequestId>8e94c64ebf4486567b0e</RequestId>
-            </ResponseMetadata>
-          </AssumeRoleWithWebIdentityResponse>`),
-      );
-    } else if (accountId === testAccountId2) {
-      return res(
-        ctx.status(200),
-        ctx.xml(`
-            <AssumeRoleWithWebIdentityResponse
-            xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
-            <AssumeRoleWithWebIdentityResult>
-              <AssumedRoleUser>
-                <Arn>arn:aws:sts::${testAccountId2}:assumed-role/storage-manager-role/ui-9160673b-2c2a-4a6f-a1ef-a3cb6ce25d7f</Arn>
-                <AssumedRoleId>OES3SPDIYW4L92S8K1QE6MINE31LQG04:ui-9160673b-2c2a-4a6f-a1ef-a3cb6ce25d7f</AssumedRoleId>
-              </AssumedRoleUser>
-              <Credentials>
-                <SecretAccessKey>v/0Nq1YMw4nNbvtgQlgi0l6m/PXWjlk1VLmn2I5q</SecretAccessKey>
-                <AccessKeyId>72SPRZFF71WPWXXUG6XF</AccessKeyId>
-                <SessionToken>eyJzYWx0IjoicVIvVGdIdS9FVjJ4TjN5RmtXSnVLZGE0M0krK0g1L3lFVDU5UkV0enpYYz0iLCJ0YWciOiI4d05WRTIwTlQxWTVKbWtZemo2ZGJ3PT0iLCJjaXBoZXJ0ZXh0IjoiQVNIanI0M0VZc3dzK0QwWDFkVXRXQ2JMbzlFOVZ5SzF5WWt6a21lRjRXOUpCU3hwbmNxS21zWnpIU3ZvYlZEYjNKaDRNTm16bW1yVUd6dTU1bmRwMTk0eTVlVjFSVWMzaHZnSTFxZTRuYmJxNHBPdit5V3VZQ3RtSExUbE5BTHpDK3VhYW1tZDdzWk9BVXNKQlhRcmVHUG5sTFphb0kySTFveXJjbk10QlVpb1AvYnNjNUd6RHFqdTFWMjVQRE9PQWgzM2JFSktHdmorbEoyL2lWV0x5UHBQU1pLZmdZUnd1QjRXczdGaG81dHhaem9uWWhpaG9ocnFtdmFnNUJSNytiN2lGN3ZxZjBVSnFPZXI5Wm9ldDk1dlpqL01qTU04aGhGQXI1MmZnTHpzOHAzVlN3dHV0OENFSTBoVEJJNlVycUY4SWxiUmhFOUtlaHo0cnRiZHRKQzVmVHFRSkVPZWltb0RIbGpZZXZqOVlIZzZPVFhDR2ZhVzRIWDc3T0g5M1BRa0dHc1RCSjVpRTEyZEdYQjhYWWdSM1VackIwUzdQejdLQnpvSUVodTZOWUkrK1NPZ2pwMlFaUmhaWGtkbDdDdU5EMWg2UE9qN2twREY0QXhHbWdwcjBMbmpOdVp1UzJaWlJTck5OZG1WL3B5dWpUM3BtcFNJNUZkNW5Wby9SV1dTSGhoR0FVcWRJS0EyV00xdVJ2TkVFS25rb25keWNuVHRrSHpDVUwrN0RtTXNuL202eTcyZjFReHY2VFQyejRzRVFSUDFhWUcwdnBWSTlXbUpWdW5yTFFVNmxSUmpsb1VFSFVkZ2xCMGd1eTZGZTNYR29YQjdVc1J5UUpxbEJ0elpvdFdkR1AvSjZaMllNODFDSy8zZjJZTXVnNTZlbXQxTmJJZ0hrVWxnaGxpclRsNVdrckVRbG5XTW4zT2dzRk9wMjJKSTV1UGoxSENUMlNhTlBXZEQrY0VCcTZycC9tc1FDOW02Q3prSkMwTWMyclZ0RmdnZitaSEV5dVZvdEVzeUFtY1V5QTdFZzJtY3BXd1pnbHZrYkZQQmI5M2NDN0ZhZGhpNEUzQ0hQbm9BczF5eVNKNkxIOTZZTHJoaXk1Q1h3VWloSTlRdmxuSDNlV3EwaElBZTFGc2N6bThzVWRCTGU2SWlVc3ZJVDlpMjJzcTZnaVpmdld5czVlaU9NZzRQMFBaZCtPK0VDRmdmd3dxdUhYcFdEL1F5RnR1RENVb0xxblNyMU9lOHdCQ2lXNDFYaGtacmEzWTdtVW1QYXlNWTN6MXpOZm1XRllJV0dWZzlBNVFUaUZLWGlZTngxdUtWZGJ3Qk54SmowVmxlTTE4azlDNFR3Z2U3dVYyKzEzcWVkTW5xOUpLa2Uwa1NsNmMxMWM5N1RUbGJ4TUx5YS9WY1JLWkNkbHJaTGZNK0hjSTJWaGdkSzNzWHJIVEN6UENFRC9lMVBRTkg1RVZBVThLRlNHWGEzb1dPWm9VcmlSYlk1L3R5eTQvbHRKTkVhNnV3R2hra0ljR3JLMjltUndkaDJHSE94R1laYmdGL0VVUDYreUs5cjQrVzc5Y1RYc3NRcEpSM1M1bkZpUHE2bHR6NXM1ZlNYalNkcUxSM0gvTVZlcXV6K3RON0czMk1ieW9halZvcVJxcks2WjZIVm1vM3pDZ1M4TURQQk9jVkY3Ymc0QmhXaXFUTjc5a0ZqV0xkWWZSVlB5Qk1VaXBHNmZCcGlBdUZCZEV1S2lLMHBwVkhQNUpZL0h5ZXRBbVgxMzdVK1U5d3prbmw3eXhyOEQ0TkdNL05yaVhBT21hSDN4YVEifQ==</SessionToken>
-                <Expiration>2023-11-28T10:16:13Z</Expiration>
-              </Credentials>
-              <Provider>www.scality.com</Provider>
-            </AssumeRoleWithWebIdentityResult>
-            <ResponseMetadata>
-              <RequestId>8e94c64ebf4486567b0e</RequestId>
-            </ResponseMetadata>
-          </AssumeRoleWithWebIdentityResponse>`),
-      );
-    }
+    return res(
+      ctx.status(200),
+      ctx.xml(`
+          <AssumeRoleWithWebIdentityResponse
+          xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+          <AssumeRoleWithWebIdentityResult>
+            <AssumedRoleUser>
+              <Arn>arn:aws:sts::${accountId}:assumed-role/storage-manager-role/ui-9160673b-2c2a-4a6f-a1ef-a3cb6ce25d7f</Arn>
+              <AssumedRoleId>OES3SPDIYW4L92S8K1QE6MINE31LQG04:ui-9160673b-2c2a-4a6f-a1ef-a3cb6ce25d7f</AssumedRoleId>
+            </AssumedRoleUser>
+            <Credentials>
+              <SecretAccessKey>v/0Nq1YMw4nNbvtgQlgi0l6m/PXWjlk1VLmn2I5q</SecretAccessKey>
+              <AccessKeyId>72SPRZFF71WPWXXUG6XF</AccessKeyId>
+              <SessionToken>eyJzYWx0IjoicVIvVGdIdS9FVjJ4TjN5RmtXSnVLZGE0M0krK0g1L3lFVDU5UkV0enpYYz0iLCJ0YWciOiI4d05WRTIwTlQxWTVKbWtZemo2ZGJ3PT0iLCJjaXBoZXJ0ZXh0IjoiQVNIanI0M0VZc3dzK0QwWDFkVXRXQ2JMbzlFOVZ5SzF5WWt6a21lRjRXOUpCU3hwbmNxS21zWnpIU3ZvYlZEYjNKaDRNTm16bW1yVUd6dTU1bmRwMTk0eTVlVjFSVWMzaHZnSTFxZTRuYmJxNHBPdit5V3VZQ3RtSExUbE5BTHpDK3VhYW1tZDdzWk9BVXNKQlhRcmVHUG5sTFphb0kySTFveXJjbk10QlVpb1AvYnNjNUd6RHFqdTFWMjVQRE9PQWgzM2JFSktHdmorbEoyL2lWV0x5UHBQU1pLZmdZUnd1QjRXczdGaG81dHhaem9uWWhpaG9ocnFtdmFnNUJSNytiN2lGN3ZxZjBVSnFPZXI5Wm9ldDk1dlpqL01qTU04aGhGQXI1MmZnTHpzOHAzVlN3dHV0OENFSTBoVEJJNlVycUY4SWxiUmhFOUtlaHo0cnRiZHRKQzVmVHFRSkVPZWltb0RIbGpZZXZqOVlIZzZPVFhDR2ZhVzRIWDc3T0g5M1BRa0dHc1RCSjVpRTEyZEdYQjhYWWdSM1VackIwUzdQejdLQnpvSUVodTZOWUkrK1NPZ2pwMlFaUmhaWGtkbDdDdU5EMWg2UE9qN2twREY0QXhHbWdwcjBMbmpOdVp1UzJaWlJTck5OZG1WL3B5dWpUM3BtcFNJNUZkNW5Wby9SV1dTSGhoR0FVcWRJS0EyV00xdVJ2TkVFS25rb25keWNuVHRrSHpDVUwrN0RtTXNuL202eTcyZjFReHY2VFQyejRzRVFSUDFhWUcwdnBWSTlXbUpWdW5yTFFVNmxSUmpsb1VFSFVkZ2xCMGd1eTZGZTNYR29YQjdVc1J5UUpxbEJ0elpvdFdkR1AvSjZaMllNODFDSy8zZjJZTXVnNTZlbXQxTmJJZ0hrVWxnaGxpclRsNVdrckVRbG5XTW4zT2dzRk9wMjJKSTV1UGoxSENUMlNhTlBXZEQrY0VCcTZycC9tc1FDOW02Q3prSkMwTWMyclZ0RmdnZitaSEV5dVZvdEVzeUFtY1V5QTdFZzJtY3BXd1pnbHZrYkZQQmI5M2NDN0ZhZGhpNEUzQ0hQbm9BczF5eVNKNkxIOTZZTHJoaXk1Q1h3VWloSTlRdmxuSDNlV3EwaElBZTFGc2N6bThzVWRCTGU2SWlVc3ZJVDlpMjJzcTZnaVpmdld5czVlaU9NZzRQMFBaZCtPK0VDRmdmd3dxdUhYcFdEL1F5RnR1RENVb0xxblNyMU9lOHdCQ2lXNDFYaGtacmEzWTdtVW1QYXlNWTN6MXpOZm1XRllJV0dWZzlBNVFUaUZLWGlZTngxdUtWZGJ3Qk54SmowVmxlTTE4azlDNFR3Z2U3dVYyKzEzcWVkTW5xOUpLa2Uwa1NsNmMxMWM5N1RUbGJ4TUx5YS9WY1JLWkNkbHJaTGZNK0hjSTJWaGdkSzNzWHJIVEN6UENFRC9lMVBRTkg1RVZBVThLRlNHWGEzb1dPWm9VcmlSYlk1L3R5eTQvbHRKTkVhNnV3R2hra0ljR3JLMjltUndkaDJHSE94R1laYmdGL0VVUDYreUs5cjQrVzc5Y1RYc3NRcEpSM1M1bkZpUHE2bHR6NXM1ZlNYalNkcUxSM0gvTVZlcXV6K3RON0czMk1ieW9halZvcVJxcks2WjZIVm1vM3pDZ1M4TURQQk9jVkY3Ymc0QmhXaXFUTjc5a0ZqV0xkWWZSVlB5Qk1VaXBHNmZCcGlBdUZCZEV1S2lLMHBwVkhQNUpZL0h5ZXRBbVgxMzdVK1U5d3prbmw3eXhyOEQ0TkdNL05yaVhBT21hSDN4YVEifQ==</SessionToken>
+              <Expiration>2023-11-28T10:16:13Z</Expiration>
+            </Credentials>
+            <Provider>www.scality.com</Provider>
+          </AssumeRoleWithWebIdentityResult>
+          <ResponseMetadata>
+            <RequestId>8e94c64ebf4486567b0e</RequestId>
+          </ResponseMetadata>
+        </AssumeRoleWithWebIdentityResponse>`),
+    );
   }
   if (params.get('Action') === 'ListRoles') {
     return res(


### PR DESCRIPTION
## Context

The previous PR added 5 test suites to `testPathIgnorePatterns` due to complex mocking requirements for `@scality/data-browser-library`. This PR fixes those tests and removes the ignore patterns.

## Problem

- 5 test suites were skipped because they required mocks for `@scality/data-browser-library` hooks
- MSW-based mocking didn't work properly with the library's internal implementation
- Clipboard API tests failed due to async timing issues with `userEvent`

## Solution

- Added global mock for `@scality/data-browser-library` in `jestSetupAfterEnv.tsx`
- Replaced MSW server mocking with direct hook mocks
- Changed clipboard tests to use `jest.spyOn` with synchronous `fireEvent`
- Fixed validation error message text to match actual Joi output

## Changes

### Modified Files

| File | Changes |
|------|---------|
| `jest.config.js` | Removed `testPathIgnorePatterns` for 5 test suites |
| `jestSetupAfterEnv.tsx` | Added global `jest.mock('@scality/data-browser-library')` and clipboard mock implementation |
| `useGetS3ServicePoint.test.ts` | Changed from `jest.mock` to `jest.spyOn` pattern for proper module mocking |
| `VeeamCapacityOverviewRow.test.tsx` | Replaced MSW with direct `useGetBucketTagging` and `useGetObject` hook mocks |
| `VeeamCapacityModal.test.tsx` | Replaced MSW with direct `usePutObject` hook mock; fixed validation message text |
| `ISVSummary.test.tsx` | Changed `useGetS3ServicePoint` to `jest.spyOn`; switched clipboard tests from `userEvent` to `fireEvent` |
| `SelectAccountIAMRole.test.tsx` | Added mock for `DataServiceRoleProvider` to provide `assumedRole` immediately; simplified MSW handler |

## Issues Encountered and Solutions

### Issue 1: `jest.mock` Not Working for Partial Module Mocks

**Cause:** `jest.mock` with factory function couldn't properly mock specific exports while keeping others.

**Fix:** Used `jest.spyOn` on imported module objects:
```typescript
import * as accountsModule from '../../domain/business/accounts';
jest.spyOn(accountsModule, 'useAccountsLocationsAndEndpoints').mockReturnValue({...});
```

### Issue 2: MSW Not Intercepting data-browser-library Requests

**Cause:** The library uses internal S3 client that doesn't go through standard fetch/XHR that MSW intercepts.

**Fix:** Mock the hooks directly:
```typescript
const mockUseGetBucketTagging = useGetBucketTagging as jest.Mock;
mockUseGetBucketTagging.mockReturnValue({ data: {...}, status: 'success' });
```

### Issue 3: Clipboard Tests Failing with `userEvent`

**Cause:** `userEvent.click` is async and the clipboard mock's state wasn't properly synchronized.

**Fix:** Use synchronous `fireEvent.click` and `jest.spyOn` assertions:
```typescript
const writeTextSpy = jest.spyOn(navigator.clipboard, 'writeText');
fireEvent.click(copyButton);
expect(writeTextSpy).toHaveBeenLastCalledWith(expectedText);
```

### Issue 4: SelectAccountIAMRole Stuck at Loading State

**Cause:** `DataServiceRoleProvider` was waiting for async `assumeRole` call that never completed in test environment.

**Fix:** Mock `DataServiceRoleProvider` to provide `assumedRole` context immediately:
```typescript
jest.mock('../../DataServiceRoleProvider', () => ({
  default: ({ children }) => (
    <actual._DataServiceRoleContext.Provider value={{ assumedRole: {...} }}>
      {children}
    </actual._DataServiceRoleContext.Provider>
  ),
}));
```

### Issue 5: Validation Message Mismatch

**Cause:** Test expected "larger than" but Joi outputs "greater than".

**Fix:** Updated test assertion to match actual Joi validation message.

## Test Coverage Progress

| Metric | Before | After |
|--------|--------|-------|
| Ignored test suites | 5 | 0 |
| Tests in ignored suites | 41 | 0 |
| Total passing tests | 563 | 604 |

## Testing

1. All 5 previously ignored test suites now pass (40 tests + 1 pre-existing skip)
2. No regressions in other tests

