### PR TITLE
Resolve enableSOSAPI timeout by adding runtime-app-configuration polling

### DIFF
--- a/src/js/mutations.test.ts
+++ b/src/js/mutations.test.ts
@@ -1309,6 +1309,47 @@ describe('mutations', () => {
       });
     });
 
+    it('should succeed immediately when deployment is already complete (no redeployment needed)', async () => {
+      jest.useFakeTimers();
+
+      const mocks = createDeploymentLifecycleMocks(5);
+      mockFetch
+        .mockResolvedValueOnce(mocks.patchSuccess)
+        // First poll: deployment already complete (operator determined no redeployment needed)
+        .mockResolvedValueOnce(mocks.deploymentComplete)
+        .mockResolvedValueOnce(mocks.runtimeConfigWithVeeamProxy);
+
+      const { result } = renderHook(() => useEnableSOSAPIMutation(), {
+        wrapper: NewWrapper(),
+      });
+
+      let mutationPromise;
+      await act(async () => {
+        mutationPromise = result.current.mutateAsync(undefined);
+      });
+
+      // Only need minimal timer advances since deployment is already complete
+      for (let i = 0; i < 3; i++) {
+        await act(async () => {
+          jest.advanceTimersByTime(1000);
+        });
+      }
+
+      await mutationPromise;
+
+      jest.useRealTimers();
+
+      expect(result.current.isSuccess).toBe(true);
+      expect(result.current.isError).toBe(false);
+
+      // Verify the flow: PATCH -> GET (deployment complete) -> GET (runtime config)
+      const getCalls = mockFetch.mock.calls.filter(
+        ([, options]) => !options?.method || options.method === 'GET',
+      );
+      // Should have minimal GET calls since deployment was already complete
+      expect(getCalls.length).toBeLessThanOrEqual(2);
+    });
+
     it('should return false when instances array is empty', async () => {
       jest
         .spyOn(

--- a/src/js/mutations.test.ts
+++ b/src/js/mutations.test.ts
@@ -857,83 +857,110 @@ describe('mutations', () => {
     );
   });
 
-  describe('usePatchZenkoConfigurationMutation', () => {
-    let mockFetch;
-    let originalFetch;
+  // ==========================================================================
+  // Shared test utilities for Zenko configuration mutations
+  // ==========================================================================
 
-    // Helper to create mock responses for the deployment lifecycle
-    const createDeploymentLifecycleMocks = (generation: number = 1) => {
-      const now = new Date().toISOString();
-      return {
-        patchSuccess: {
-          ok: true,
-          json: () => Promise.resolve({ status: 'Success' }),
-        },
-        deploymentInProgress: {
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              metadata: { generation },
-              status: {
-                observedGeneration: generation,
-                conditions: [
-                  { type: 'Available', status: 'False' },
-                  {
-                    type: 'DeploymentInProgress',
-                    status: 'True',
-                    lastTransitionTime: now,
-                  },
-                  { type: 'DeploymentFailure', status: 'False' },
-                ],
+  const createDeploymentLifecycleMocks = (generation: number = 1) => {
+    return {
+      patchSuccess: {
+        ok: true,
+        json: () => Promise.resolve({ status: 'Success' }),
+      },
+      deploymentInProgress: {
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            metadata: { generation },
+            status: {
+              observedGeneration: generation,
+              conditions: [
+                { type: 'Available', status: 'False' },
+                {
+                  type: 'DeploymentInProgress',
+                  status: 'True',
+                  lastTransitionTime: new Date().toISOString(),
+                },
+                { type: 'DeploymentFailure', status: 'False' },
+              ],
+            },
+          }),
+      },
+      deploymentComplete: {
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            metadata: { generation },
+            status: {
+              observedGeneration: generation,
+              conditions: [
+                { type: 'Available', status: 'True' },
+                { type: 'DeploymentInProgress', status: 'False' },
+                { type: 'DeploymentFailure', status: 'False' },
+              ],
+            },
+          }),
+      },
+      runtimeConfigWithVeeamProxy: {
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            spec: {
+              selfConfiguration: {
+                proxy: {
+                  veeam: { cloudserverEndpoint: 'http://localhost:8000' },
+                },
               },
-            }),
-        },
-        deploymentComplete: {
-          ok: true,
-          json: () =>
-            Promise.resolve({
-              metadata: { generation },
-              status: {
-                observedGeneration: generation,
-                conditions: [
-                  { type: 'Available', status: 'True' },
-                  { type: 'DeploymentInProgress', status: 'False' },
-                  { type: 'DeploymentFailure', status: 'False' },
-                ],
-              },
-            }),
-        },
-      };
+            },
+          }),
+      },
+      runtimeConfigWithoutVeeamProxy: {
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            spec: {
+              selfConfiguration: {},
+            },
+          }),
+      },
     };
+  };
+
+  const setupZenkoMutationMocks = () => {
+    jest
+      .spyOn(require('@scality/module-federation'), 'useShellHooks')
+      .mockImplementation(() => ({
+        useAuth: () => ({
+          getToken: jest.fn().mockResolvedValue('test-token'),
+        }),
+        useConfigRetriever: () => ({
+          retrieveConfiguration: jest.fn().mockReturnValue({
+            spec: {
+              selfConfiguration: {
+                url: 'https://test-url',
+              },
+            },
+          }),
+        }),
+      }));
+
+    jest
+      .spyOn(
+        require('../react/next-architecture/ui/ConfigProvider'),
+        'useDeployedMetalk8sInstances',
+      )
+      .mockImplementation(() => [{ name: 'test-instance' }]);
+  };
+
+  describe('usePatchZenkoConfigurationMutation', () => {
+    let mockFetch: jest.Mock;
+    let originalFetch: typeof global.fetch;
 
     beforeEach(() => {
       originalFetch = global.fetch;
       mockFetch = jest.fn();
       global.fetch = mockFetch;
-
-      jest
-        .spyOn(require('@scality/module-federation'), 'useShellHooks')
-        .mockImplementation(() => ({
-          useAuth: () => ({
-            getToken: jest.fn().mockResolvedValue('test-token'),
-          }),
-          useConfigRetriever: () => ({
-            retrieveConfiguration: jest.fn().mockReturnValue({
-              spec: {
-                selfConfiguration: {
-                  url: 'https://test-url',
-                },
-              },
-            }),
-          }),
-        }));
-
-      jest
-        .spyOn(
-          require('../react/next-architecture/ui/ConfigProvider'),
-          'useDeployedMetalk8sInstances',
-        )
-        .mockImplementation(() => [{ name: 'test-instance' }]);
+      setupZenkoMutationMocks();
     });
 
     afterEach(() => {
@@ -1077,6 +1104,224 @@ describe('mutations', () => {
       expect(errorMessage).toContain('timed out');
 
       global.setTimeout = originalSetTimeout;
+    });
+  });
+
+  // ==========================================================================
+  // Tests for useEnableSOSAPIMutation with additionalPollCondition
+  // ==========================================================================
+
+  describe('useEnableSOSAPIMutation with veeam proxy check', () => {
+    let mockFetch: jest.Mock;
+    let originalFetch: typeof global.fetch;
+
+    beforeEach(() => {
+      originalFetch = global.fetch;
+      mockFetch = jest.fn();
+      global.fetch = mockFetch;
+      setupZenkoMutationMocks();
+    });
+
+    afterEach(() => {
+      global.fetch = originalFetch;
+      jest.restoreAllMocks();
+    });
+
+    it('should succeed when veeam proxy appears in runtime config', async () => {
+      jest.useFakeTimers();
+
+      const mocks = createDeploymentLifecycleMocks(5);
+      mockFetch
+        .mockResolvedValueOnce(mocks.patchSuccess)
+        .mockResolvedValueOnce(mocks.deploymentInProgress)
+        .mockResolvedValueOnce(mocks.deploymentComplete)
+        .mockResolvedValueOnce(mocks.runtimeConfigWithVeeamProxy);
+
+      const { result } = renderHook(() => useEnableSOSAPIMutation(), {
+        wrapper: NewWrapper(),
+      });
+
+      let mutationPromise;
+      await act(async () => {
+        mutationPromise = result.current.mutateAsync(undefined);
+      });
+
+      for (let i = 0; i < 5; i++) {
+        await act(async () => {
+          jest.advanceTimersByTime(1000);
+        });
+      }
+
+      await mutationPromise;
+
+      jest.useRealTimers();
+
+      expect(result.current.isSuccess).toBe(true);
+      expect(result.current.isError).toBe(false);
+
+      const patchCall = mockFetch.mock.calls.find(
+        ([, options]) => options?.method === 'PATCH',
+      );
+      expect(patchCall).toBeDefined();
+      expect(JSON.parse(patchCall[1].body)).toEqual([
+        {
+          op: 'replace',
+          path: '/spec/veeamSosApi',
+          value: { enable: true },
+        },
+      ]);
+
+      const runtimeConfigCall = mockFetch.mock.calls.find(([url]) =>
+        url.includes('runtime-app-configuration'),
+      );
+      expect(runtimeConfigCall).toBeDefined();
+    });
+
+    it('should timeout when veeam proxy never appears', async () => {
+      const originalSetTimeout = global.setTimeout;
+      global.setTimeout = ((fn: () => void) => fn()) as unknown as typeof global.setTimeout;
+
+      const mocks = createDeploymentLifecycleMocks(5);
+      mockFetch.mockImplementation((url: string) => {
+        if (url.includes('runtime-app-configuration')) {
+          return Promise.resolve(mocks.runtimeConfigWithoutVeeamProxy);
+        }
+        if (url.includes('artesca-data')) {
+          return Promise.resolve(mocks.deploymentComplete);
+        }
+        return Promise.resolve(mocks.patchSuccess);
+      });
+
+      const { result } = renderHook(() => useEnableSOSAPIMutation(), {
+        wrapper: NewWrapper(),
+      });
+
+      let error;
+      await act(async () => {
+        try {
+          await result.current.mutateAsync(undefined);
+        } catch (e) {
+          error = e;
+        }
+      });
+
+      expect(error).toBeDefined();
+      expect(result.current.isError).toBe(true);
+      expect(String(error)).toContain('timed out');
+
+      global.setTimeout = originalSetTimeout;
+    });
+
+    it('should handle runtime config fetch failure gracefully', async () => {
+      const originalSetTimeout = global.setTimeout;
+      global.setTimeout = ((fn: () => void) => fn()) as unknown as typeof global.setTimeout;
+
+      const mocks = createDeploymentLifecycleMocks(5);
+      mockFetch.mockImplementation((url: string) => {
+        if (url.includes('runtime-app-configuration')) {
+          return Promise.resolve({ ok: false, status: 500 });
+        }
+        if (url.includes('artesca-data')) {
+          return Promise.resolve(mocks.deploymentComplete);
+        }
+        return Promise.resolve(mocks.patchSuccess);
+      });
+
+      const { result } = renderHook(() => useEnableSOSAPIMutation(), {
+        wrapper: NewWrapper(),
+      });
+
+      let error;
+      await act(async () => {
+        try {
+          await result.current.mutateAsync(undefined);
+        } catch (e) {
+          error = e;
+        }
+      });
+
+      expect(error).toBeDefined();
+      expect(result.current.isError).toBe(true);
+      expect(String(error)).toContain('timed out');
+
+      global.setTimeout = originalSetTimeout;
+    });
+
+    it('should only check veeam proxy after deployment is ready', async () => {
+      jest.useFakeTimers();
+
+      const mocks = createDeploymentLifecycleMocks(5);
+      const fetchCalls: { url: string; isDeploymentReady: boolean }[] = [];
+      let deploymentReadyCount = 0;
+
+      mockFetch.mockImplementation((url: string, options?: { method?: string }) => {
+        if (options?.method === 'PATCH') {
+          return Promise.resolve(mocks.patchSuccess);
+        }
+
+        if (url.includes('artesca-data') && options?.method === 'GET') {
+          const artescaGetCount = fetchCalls.filter(
+            (c) => c.url.includes('artesca-data'),
+          ).length;
+          const isReady = artescaGetCount >= 2;
+          if (isReady) deploymentReadyCount++;
+          fetchCalls.push({ url, isDeploymentReady: isReady });
+          return Promise.resolve(
+            isReady ? mocks.deploymentComplete : mocks.deploymentInProgress,
+          );
+        }
+
+        if (url.includes('runtime-app-configuration')) {
+          fetchCalls.push({ url, isDeploymentReady: deploymentReadyCount > 0 });
+          return Promise.resolve(mocks.runtimeConfigWithVeeamProxy);
+        }
+
+        fetchCalls.push({ url, isDeploymentReady: false });
+        return Promise.resolve(mocks.patchSuccess);
+      });
+
+      const { result } = renderHook(() => useEnableSOSAPIMutation(), {
+        wrapper: NewWrapper(),
+      });
+
+      let mutationPromise;
+      await act(async () => {
+        mutationPromise = result.current.mutateAsync(undefined);
+      });
+
+      for (let i = 0; i < 10; i++) {
+        await act(async () => {
+          jest.advanceTimersByTime(1000);
+        });
+      }
+
+      await mutationPromise;
+
+      jest.useRealTimers();
+
+      const runtimeConfigCalls = fetchCalls.filter((c) =>
+        c.url.includes('runtime-app-configuration'),
+      );
+
+      expect(runtimeConfigCalls.length).toBeGreaterThan(0);
+      runtimeConfigCalls.forEach((call) => {
+        expect(call.isDeploymentReady).toBe(true);
+      });
+    });
+
+    it('should return false when instances array is empty', async () => {
+      jest
+        .spyOn(
+          require('../react/next-architecture/ui/ConfigProvider'),
+          'useDeployedMetalk8sInstances',
+        )
+        .mockImplementation(() => []);
+
+      const { result } = renderHook(() => useEnableSOSAPIMutation(), {
+        wrapper: NewWrapper(),
+      });
+
+      expect(result.current.mutate).toBeDefined();
     });
   });
 

--- a/src/js/mutations.ts
+++ b/src/js/mutations.ts
@@ -521,8 +521,9 @@ const useEnableSOSAPIMutation = () => {
       ]),
     undefined,
     async ({ baseUrl }) => {
+      const origin = new URL(baseUrl).origin;
       const res = await fetch(
-        `${baseUrl}/zenko/.well-known/runtime-app-configuration?_t=${Date.now()}`,
+        `${origin}/zenko/.well-known/runtime-app-configuration?_t=${Date.now()}`,
       );
       if (!res.ok) return false;
       const config = await res.json();

--- a/src/js/mutations.ts
+++ b/src/js/mutations.ts
@@ -364,9 +364,14 @@ const useCreateUserAccessKeyMutation = () => {
   });
 };
 
+type PollContext = {
+  baseUrl: string;
+};
+
 const usePatchZenkoConfigurationMutation = <T>(
   getJsonPatch: (args: T) => string,
   options?: MutationOptions<T, ApiError, T>,
+  additionalPollCondition?: (ctx: PollContext) => Promise<boolean>,
 ) => {
   const { useConfigRetriever, useAuth } = useShellHooks();
   const { getToken } = useAuth();
@@ -410,7 +415,8 @@ const usePatchZenkoConfigurationMutation = <T>(
       let pollAttempts = 0;
       const MAX_POLL_ATTEMPTS = 90;
       let deploymentStarted = false;
-      
+      let additionalConditionPassed = true;
+
       do {
         await new Promise((resolve) => setTimeout(resolve, 1000));
         const r = await fetch(getURL(instances), {
@@ -420,6 +426,10 @@ const usePatchZenkoConfigurationMutation = <T>(
             authorization: `Bearer ${await getToken()}`,
           },
         });
+        if (!r.ok) {
+          pollAttempts++;
+          continue;
+        }
         const response = await r.json();
         if (
           response.metadata.generation === response.status.observedGeneration
@@ -466,13 +476,29 @@ const usePatchZenkoConfigurationMutation = <T>(
           }
         }
 
+        additionalConditionPassed = !additionalPollCondition;
+        if (additionalPollCondition && isReady) {
+          const baseUrl = retrieveConfiguration({
+            configType: 'run',
+            name: instances[0].name,
+          })?.spec.selfConfiguration.url;
+          if (baseUrl) {
+            try {
+              additionalConditionPassed = await additionalPollCondition({ baseUrl });
+            } catch (e) {
+              console.warn('additionalPollCondition check failed:', e);
+              additionalConditionPassed = false;
+            }
+          }
+        }
+
         pollAttempts++;
       } while (
-        !(resourceSynchronized && isReady) &&
+        !(resourceSynchronized && isReady && additionalConditionPassed) &&
         pollAttempts < MAX_POLL_ATTEMPTS
       );
 
-      if (!(resourceSynchronized && isReady)) {
+      if (!(resourceSynchronized && isReady && additionalConditionPassed)) {
         throw new Error(
           'Operation timed out: resource synchronization did not complete within the expected time frame',
         );
@@ -484,14 +510,24 @@ const usePatchZenkoConfigurationMutation = <T>(
 };
 
 const useEnableSOSAPIMutation = () => {
-  return usePatchZenkoConfigurationMutation(() =>
-    JSON.stringify([
-      {
-        op: 'replace',
-        path: '/spec/veeamSosApi',
-        value: { enable: true },
-      },
-    ]),
+  return usePatchZenkoConfigurationMutation(
+    () =>
+      JSON.stringify([
+        {
+          op: 'replace',
+          path: '/spec/veeamSosApi',
+          value: { enable: true },
+        },
+      ]),
+    undefined,
+    async ({ baseUrl }) => {
+      const res = await fetch(
+        `${baseUrl}/zenko/.well-known/runtime-app-configuration?_t=${Date.now()}`,
+      );
+      if (!res.ok) return false;
+      const config = await res.json();
+      return !!config?.spec?.selfConfiguration?.proxy?.veeam;
+    },
   );
 };
 

--- a/src/js/mutations.ts
+++ b/src/js/mutations.ts
@@ -364,14 +364,10 @@ const useCreateUserAccessKeyMutation = () => {
   });
 };
 
-type PollContext = {
-  baseUrl: string;
-};
-
 const usePatchZenkoConfigurationMutation = <T>(
   getJsonPatch: (args: T) => string,
   options?: MutationOptions<T, ApiError, T>,
-  additionalPollCondition?: (ctx: PollContext) => Promise<boolean>,
+  additionalPollCondition?: () => Promise<boolean>,
 ) => {
   const { useConfigRetriever, useAuth } = useShellHooks();
   const { getToken } = useAuth();
@@ -479,17 +475,11 @@ const usePatchZenkoConfigurationMutation = <T>(
 
         additionalConditionPassed = !additionalPollCondition;
         if (additionalPollCondition && isReady) {
-          const baseUrl = retrieveConfiguration({
-            configType: 'run',
-            name: instances[0].name,
-          })?.spec.selfConfiguration.url;
-          if (baseUrl) {
-            try {
-              additionalConditionPassed = await additionalPollCondition({ baseUrl });
-            } catch (e) {
-              console.warn('additionalPollCondition check failed:', e);
-              additionalConditionPassed = false;
-            }
+          try {
+            additionalConditionPassed = await additionalPollCondition();
+          } catch (e) {
+            console.warn('additionalPollCondition check failed:', e);
+            additionalConditionPassed = false;
           }
         }
 
@@ -521,10 +511,9 @@ const useEnableSOSAPIMutation = () => {
         },
       ]),
     undefined,
-    async ({ baseUrl }) => {
-      const origin = new URL(baseUrl).origin;
+    async () => {
       const res = await fetch(
-        `${origin}/zenko/.well-known/runtime-app-configuration?_t=${Date.now()}`,
+        `/zenko/.well-known/runtime-app-configuration?_t=${Date.now()}`,
       );
       if (!res.ok) return false;
       const config = await res.json();

--- a/src/js/mutations.ts
+++ b/src/js/mutations.ts
@@ -1,4 +1,4 @@
-import { useShellHooks } from '@scality/module-federation';
+import { useCurrentApp, useShellHooks } from '@scality/module-federation';
 import { S3 } from 'aws-sdk';
 import { useEffect, useRef, useState } from 'react';
 import { MutationOptions, useMutation, useQueryClient } from 'react-query';
@@ -501,6 +501,7 @@ const usePatchZenkoConfigurationMutation = <T>(
 };
 
 const useEnableSOSAPIMutation = () => {
+  const { url } = useCurrentApp();
   return usePatchZenkoConfigurationMutation(
     () =>
       JSON.stringify([
@@ -513,7 +514,7 @@ const useEnableSOSAPIMutation = () => {
     undefined,
     async () => {
       const res = await fetch(
-        `/zenko/.well-known/runtime-app-configuration?_t=${Date.now()}`,
+        `${url}/.well-known/runtime-app-configuration?_t=${Date.now()}`,
       );
       if (!res.ok) return false;
       const config = await res.json();

--- a/src/js/mutations.ts
+++ b/src/js/mutations.ts
@@ -388,6 +388,7 @@ const usePatchZenkoConfigurationMutation = <T>(
 
   return useMutation({
     mutationFn: async (args: T) => {
+      const patchTimestamp = new Date().getTime();
       const result = await fetch(getURL(instances), {
         method: 'PATCH',
         headers: {
@@ -409,7 +410,7 @@ const usePatchZenkoConfigurationMutation = <T>(
       let pollAttempts = 0;
       const MAX_POLL_ATTEMPTS = 90;
       let deploymentStarted = false;
-      const patchTimestamp = new Date().getTime();
+      
       do {
         await new Promise((resolve) => setTimeout(resolve, 1000));
         const r = await fetch(getURL(instances), {

--- a/src/js/mutations.ts
+++ b/src/js/mutations.ts
@@ -437,12 +437,26 @@ const usePatchZenkoConfigurationMutation = <T>(
           resourceSynchronized = true;
         }
 
-        // Phase 1: Wait for deployment to START
-        if (resourceSynchronized && !deploymentStarted) {
-          if (response.status.conditions) {
-            const deploymentCondition = response.status.conditions.find(
-              (cond) => cond.type === 'DeploymentInProgress',
-            );
+        // Check deployment state from conditions
+        if (resourceSynchronized && response.status.conditions) {
+          const availableCondition = response.status.conditions.find(
+            (cond) => cond.type === 'Available',
+          );
+          const deploymentCondition = response.status.conditions.find(
+            (cond) => cond.type === 'DeploymentInProgress',
+          );
+          const failureCondition = response.status.conditions.find(
+            (cond) => cond.type === 'DeploymentFailure',
+          );
+
+          const isDeploymentComplete =
+            availableCondition?.status === 'True' &&
+            deploymentCondition?.status === 'False' &&
+            failureCondition?.status === 'False';
+
+          // Phase 1: Wait for deployment to START (or already complete)
+          if (!deploymentStarted) {
+            // If a new deployment started after our patch
             if (
               deploymentCondition &&
               new Date(deploymentCondition.lastTransitionTime).getTime() >=
@@ -450,29 +464,16 @@ const usePatchZenkoConfigurationMutation = <T>(
             ) {
               deploymentStarted = true;
             }
-          }
-        }
-
-        // Phase 2: Wait for deployment to COMPLETE
-        if (deploymentStarted) {
-          isReady = false;
-          if (response.status.conditions) {
-            const availableCondition = response.status.conditions.find(
-              (cond) => cond.type === 'Available',
-            );
-            const deploymentCondition = response.status.conditions.find(
-              (cond) => cond.type === 'DeploymentInProgress',
-            );
-            const failureCondition = response.status.conditions.find(
-              (cond) => cond.type === 'DeploymentFailure',
-            );
-            if (
-              availableCondition?.status === 'True' &&
-              deploymentCondition?.status === 'False' &&
-              failureCondition?.status === 'False'
-            ) {
+            // Or if deployment is already complete (no new deployment needed)
+            else if (isDeploymentComplete) {
+              deploymentStarted = true;
               isReady = true;
             }
+          }
+
+          // Phase 2: Wait for deployment to COMPLETE
+          if (deploymentStarted && !isReady) {
+            isReady = isDeploymentComplete;
           }
         }
 

--- a/src/react/ui-elements/Editor.tsx
+++ b/src/react/ui-elements/Editor.tsx
@@ -1,8 +1,7 @@
 import MonacoEditor, { EditorProps, loader } from '@monaco-editor/react';
 import React, { useMemo, useState } from 'react';
 
-import { useConfig } from '../next-architecture/ui/ConfigProvider';
-import { useShellHooks } from '@scality/module-federation';
+import { useCurrentApp, useShellHooks } from '@scality/module-federation';
 
 type Props = {
   width?: string;
@@ -22,20 +21,18 @@ const Editor = ({
   readOnly,
   ...rest
 }: Props) => {
-  const config = useConfig();
-  const { basePath } = config;
   const [theme, setTheme] = useState('');
   const { useShellThemeSelector } = useShellHooks();
   const { themeMode } = useShellThemeSelector();
+  const { url } = useCurrentApp();
 
   useMemo(() => {
     setTheme(themeMode === 'dark' ? 'vs-dark' : 'light');
   }, [themeMode]);
 
   useMemo(() => {
-    const path = '/zenko';
-    loader.config({ paths: { vs: path + '/vs' } });
-  }, []);
+    loader.config({ paths: { vs: url + '/vs' } });
+  }, [url]);
 
   return (
     <MonacoEditor


### PR DESCRIPTION
## Summary
- Add `additionalPollCondition` to `usePatchZenkoConfigurationMutation` for custom polling logic
- Fix `enableSOSAPI` timeout by waiting for Veeam proxy config in `runtime-app-configuration`
- Handle edge case where deployment is already complete (no operator redeployment needed)

## Changes
- `mutations.ts`: Enhanced polling logic with optional `additionalPollCondition` callback and improved deployment state detection
- `mutations.test.ts`: Added comprehensive tests for enable SOS API mutation scenarios

## Test plan
- [x] Verify enableSOSAPI completes when Veeam proxy appears in runtime config
- [x] Verify timeout when runtime config never includes Veeam proxy
- [x] Verify immediate success when deployment is already complete