### PR TITLE
refactor: update SingleMutationDef to use dynamic MutationLabel for improved label handling

### DIFF
--- a/src/react/ISV/engine/builders/buildMutations.ts
+++ b/src/react/ISV/engine/builders/buildMutations.ts
@@ -177,7 +177,8 @@ export function buildIAMMutations(config: PlatformConfig): SingleMutationDef[] {
     },
     {
       id: 'createPolicy',
-      label: 'Create Policy',
+      label: (_form: FormData, ctx: FullContext) =>
+        ctx.isNewAccount || ctx.needsIAMUser ? 'Create Policy' : 'Update Policy',
       action: 'createPolicy',
       variables: (
         form: FormData,

--- a/src/react/ISV/engine/types.ts
+++ b/src/react/ISV/engine/types.ts
@@ -218,9 +218,13 @@ export type ActionName =
   | 'attachPolicy'
   | 'createVeeamRepository';
 
+export type MutationLabel =
+  | string
+  | ((form: FormData, ctx: FullContext) => string);
+
 export type SingleMutationDef = {
   id: string;
-  label: string;
+  label: MutationLabel;
   action: ActionName;
   when?: (form: FormData, ctx: FullContext) => boolean;
   variables: (

--- a/src/react/ISV/hooks/useMutationExecutor.ts
+++ b/src/react/ISV/hooks/useMutationExecutor.ts
@@ -177,10 +177,16 @@ export function useMutationExecutor({
         continue;
       }
 
+      // Resolve dynamic label
+      const label =
+        typeof def.label === 'function'
+          ? def.label(formData, context)
+          : def.label;
+
       // Build MutationConfig - spread the action config (mutation or hook)
       mutationConfigs.push({
         id: def.id,
-        label: def.label,
+        label,
         ...actionConfig,
       } as MutationConfig);
 


### PR DESCRIPTION
 "Create policy" in the action list is not correct as the described action, when extending a policy. When the policy already exists, it should be “Update Policy”