### PR TITLE
fix: prevent cache invalidation on OIDC token refresh

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@monaco-editor/react": "^4.4.5",
         "@scality/certchain": "1.4.0",
         "@scality/core-ui": "0.193.0",
-        "@scality/data-browser-library": "1.0.0-preview.17",
+        "@scality/data-browser-library": "1.0.1",
         "@scality/module-federation": "1.6.1",
         "@scality/react-chained-query": "^2.0.1",
         "@types/react-table": "^7.7.10",
@@ -5389,9 +5389,10 @@
       }
     },
     "node_modules/@scality/data-browser-library": {
-      "version": "1.0.0-preview.17",
-      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.0.0-preview.17.tgz",
-      "integrity": "sha512-w57fGNTOk/3rLbiTZOYkyavIjVcCF+whOn/R/JRBjQvFzec6DIU+SgNA8967hVNiLdy1jQzGSgK0L4y6eSgL+Q==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.0.1.tgz",
+      "integrity": "sha512-mT+b+SEp4f0BZ0+fxhrYVZ7sk6g+Uqk4u8Ohi5NF/YYc0UwqJgCSDkfgxvV/cbr/SNQBDlLkS/9pP4JWhKWSqg==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.478.0",
         "@aws-sdk/protocol-http": "^3.370.0",
@@ -5408,7 +5409,7 @@
         "react-hook-form": "^7.48.0"
       },
       "peerDependencies": {
-        "@scality/core-ui": "0.185.0",
+        "@scality/core-ui": "0.194.0",
         "react": ">=18.0.0",
         "react-dom": ">=18.0.0",
         "react-router-dom": ">=6.0.0",

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "@monaco-editor/react": "^4.4.5",
     "@scality/certchain": "1.4.0",
     "@scality/core-ui": "0.193.0",
-    "@scality/data-browser-library": "1.0.0-preview.17",
+    "@scality/data-browser-library": "1.0.1",
     "@scality/module-federation": "1.6.1",
     "@scality/react-chained-query": "^2.0.1",
     "@types/react-table": "^7.7.10",

--- a/src/react/DataServiceRoleProvider.tsx
+++ b/src/react/DataServiceRoleProvider.tsx
@@ -72,11 +72,13 @@ const useS3ConfigFromAssumeRoleResult = () => {
       assumeRoleResult:
         | PromiseResult<STS.AssumeRoleWithWebIdentityResponse, AWSError>
         | undefined,
+      cacheKey?: string,
     ): S3Config => ({
       endpoint,
       region: DEFAULT_REGION,
       forcePathStyle: true,
       features,
+      cacheKey,
       proxy: {
         enabled: true,
         endpoint: zenkoEndpoint,
@@ -172,11 +174,12 @@ export const useCurrentAccount = () => {
 
 export const useS3Config = (): S3Config | undefined => {
   const assumedRole = useAssumedRole();
+  const { roleArn } = useDataServiceRole();
   const { getS3Config } = useS3ConfigFromAssumeRoleResult();
   return useMemo(() => {
     if (!assumedRole) return undefined;
-    return getS3Config(assumedRole);
-  }, [assumedRole, getS3Config]);
+    return getS3Config(assumedRole, roleArn);
+  }, [assumedRole, getS3Config, roleArn]);
 };
 
 const DataServiceRoleProvider = ({
@@ -216,6 +219,9 @@ const DataServiceRoleProvider = ({
     },
   });
 
+  const { useAuth } = useShellHooks();
+  const { userData } = useAuth();
+
   useEffect(() => {
     const storedRole = getRoleArnStored();
     if (accountName) {
@@ -243,13 +249,13 @@ const DataServiceRoleProvider = ({
     if (role.roleArn) {
       assumeRoleMutation.mutate(role.roleArn);
     }
-  }, [role.roleArn]);
+  }, [role.roleArn, userData?.token]);
 
   const { getS3Config } = useS3ConfigFromAssumeRoleResult();
 
   const s3Config = useMemo(
-    () => getS3Config(assumedRole),
-    [assumedRole, getS3Config],
+    () => getS3Config(assumedRole, role.roleArn),
+    [assumedRole, getS3Config, role.roleArn],
   );
 
   const credentials: S3Credentials = useMemo(
@@ -286,7 +292,7 @@ const DataServiceRoleProvider = ({
           setRoleArnStored(role.roleArn);
           setRoleState(role);
         });
-        return getS3Config(data);
+        return getS3Config(data, role.roleArn);
       });
   };
 


### PR DESCRIPTION
## Summary

- Add explicit `cacheKey` field to `S3BrowserConfig` for stable React Query cache isolation
- When `cacheKey` is provided, use it instead of deriving from transient credentials
- Prevents unnecessary UI refresh when OIDC tokens renew but permissions remain unchanged

## Problem

When OIDC token refreshes, the app re-assumes the IAM role, generating new temporary credentials (`accessKeyId`, `sessionToken`). Previously, these credentials were used as React Query cache keys, causing all queries to invalidate and the UI to refresh unexpectedly.

## Solution

Introduce an explicit `cacheKey` field at the top level of `S3BrowserConfig`:

- **Priority**: `cacheKey` > `accessKeyId`/`sessionToken` fallback
- **Same role = same permissions = same data** → cache persists
- **Different role = different permissions** → cache invalidates
