### PR TITLE
Add optional mutation steps types

### DIFF
--- a/src/react/ISV/engine/definePlatform.ts
+++ b/src/react/ISV/engine/definePlatform.ts
@@ -105,6 +105,8 @@ export function definePlatform(config: PlatformConfig): ISVPlatform {
     skipModalContent: config.skipModalContent,
 
     bucketTag: config.bucketTag ?? config.name,
+    defaultOptionalFailureMessage: config.defaultOptionalFailureMessage,
+    continueWithOptionalFailuresLabel: config.continueWithOptionalFailuresLabel,
 
     fields,
     validator,

--- a/src/react/ISV/engine/types.ts
+++ b/src/react/ISV/engine/types.ts
@@ -325,6 +325,8 @@ export type ISVPlatform = {
   skipModalContent?: ReactNode;
 
   bucketTag: string;
+  defaultOptionalFailureMessage?: string;
+  continueWithOptionalFailuresLabel?: string;
 
   fields: FieldDef[];
   validator: Joi.ObjectSchema;

--- a/src/react/ISV/engine/types.ts
+++ b/src/react/ISV/engine/types.ts
@@ -222,6 +222,8 @@ export type SingleMutationDef = {
   action: ActionName;
   when?: (form: FormData, ctx: FullContext) => boolean;
   variables: (form: FormData, prev: PreviousResults, ctx: FullContext) => Record<string, unknown>;
+  optional?: boolean;
+  failureMessage?: string | ((form: FormData, ctx: FullContext) => string);
 };
 
 export type PerBucketStep = {
@@ -230,6 +232,8 @@ export type PerBucketStep = {
   action: ActionName;
   when?: (form: FormData, bucket: BucketItem, ctx: FullContext) => boolean;
   variables: (form: FormData, bucket: BucketItem, prev: PreviousResults, ctx: FullContext) => Record<string, unknown>;
+  optional?: boolean;
+  failureMessage?: string | ((form: FormData, bucket: BucketItem, ctx: FullContext) => string);
 };
 
 export type LoopMutationDef = {
@@ -238,6 +242,16 @@ export type LoopMutationDef = {
 };
 
 export type MutationDef = SingleMutationDef | LoopMutationDef;
+
+// ============================================================================
+// Optional Failure Tracking
+// ============================================================================
+
+export type OptionalFailure = {
+  id: string;
+  label: string;
+  message: string;
+};
 
 // ============================================================================
 // Summary Configuration
@@ -265,6 +279,7 @@ export type SummaryRenderProps = {
   accessKeys?: string[];
   onFinish: () => void;
   renderDefault: () => React.ReactNode;
+  optionalFailures?: OptionalFailure[];
 };
 
 export type SummaryConfig = {
@@ -343,6 +358,10 @@ export type PlatformConfig = {
 
   // Bucket tag for tagging buckets (defaults to name)
   bucketTag?: string;
+
+  // Optional step failure handling
+  defaultOptionalFailureMessage?: string;
+  continueWithOptionalFailuresLabel?: string;
 
   // Feature switches
   sosAPI?: boolean;


### PR DESCRIPTION
## Summary

Add type system support for optional mutation steps in the ISV wizard, enabling platforms to mark enhancement steps as optional and allow users to continue with working configurations when only optional steps fail.

## What's in this PR

This PR adds the foundational type definitions for the optional mutation steps pattern:

- **Mutation definitions**: Add `optional?: boolean` and `failureMessage?` to `SingleMutationDef` and `PerBucketStep`
- **Failure tracking**: New `OptionalFailure` type to track failed optional steps
- **Platform config**: Add `defaultOptionalFailureMessage` and `continueWithOptionalFailuresLabel` for platform-level customization
- **Summary props**: Add `optionalFailures` to `SummaryRenderProps` for downstream handling

All changes are backward compatible (optional fields only).

## What's coming next

This is **Phase 1** of the optional mutation steps implementation. Upcoming PRs will add:

1. **Chained mutations library** - Update `@scality/react-chained-query` to continue execution on optional failures
2. **Apply Actions component** - Enable Continue button when only optional steps fail, show warning banners
3. **Mutation executor** - Bridge platform config to chained mutations
4. **Summary component** - Pass optional failures metadata to platform renders
5. **Veeam platform** - Apply pattern to Veeam repo creation (first real use case)

## Related

Implementing design: https://docs.google.com/document/d/1Oex0aY2p9wCsitdbpGVbrxZGSLDwjWhTyfD9ObQHFgk/edit?tab=t.0
