### PR TITLE
feat(ISV): mark Veeam repository creation as optional mutation step

### DIFF
--- a/src/react/ISV/components/__tests__/ISVApplyActions.test.tsx
+++ b/src/react/ISV/components/__tests__/ISVApplyActions.test.tsx
@@ -1,11 +1,8 @@
-import { render, screen, fireEvent } from '@testing-library/react';
-import ISVApplyActions from '../ISVApplyActions';
+import { type ChainedMutationsResult, useChainedMutations } from '@scality/react-chained-query';
+import { fireEvent, render, screen } from '@testing-library/react';
 import { Wrapper } from '../../../utils/testUtil';
 import { VeeamVBRPlatform } from '../../platforms/veeam-vbr';
-import {
-  useChainedMutations,
-  ChainedMutationsResult,
-} from '@scality/react-chained-query';
+import ISVApplyActions from '../ISVApplyActions';
 
 jest.mock('@scality/core-ui/dist/components/steppers/Stepper.component', () => ({
   useStepper: () => ({ next: jest.fn() }),
@@ -77,9 +74,7 @@ const mockGetResult = (id: string) => {
   return undefined;
 };
 
-const createMockChainedMutations = (
-  overrides = {},
-): ChainedMutationsResult => ({
+const createMockChainedMutations = (overrides = {}): ChainedMutationsResult => ({
   Slots: null,
   steps: [
     { id: 'step1', label: 'Create bucket', step: 1, status: 'success' as const, retry: mockRetry },
@@ -116,27 +111,41 @@ describe('ISVApplyActions', () => {
   });
 
   it('renders the configuration title correctly', () => {
-    render(<Wrapper><ISVApplyActions {...mockProps} /></Wrapper>);
+    render(
+      <Wrapper>
+        <ISVApplyActions {...mockProps} />
+      </Wrapper>,
+    );
     expect(screen.getByText(`Configure ARTESCA for ${mockProps.platform.name}`)).toBeInTheDocument();
   });
 
   it('shows success state when all steps complete successfully', () => {
-    render(<Wrapper><ISVApplyActions {...mockProps} /></Wrapper>);
+    render(
+      <Wrapper>
+        <ISVApplyActions {...mockProps} />
+      </Wrapper>,
+    );
     expect(screen.getAllByText('Success')).toHaveLength(2);
     expect(screen.getByRole('button', { name: 'Continue' })).not.toBeDisabled();
   });
 
   it('shows error state and retry option when a step fails', () => {
-    mockUseChainedMutations.mockReturnValue(createMockChainedMutations({
-      steps: [
-        { id: 'step1', label: 'Create bucket', step: 1, status: 'success', retry: mockRetry },
-        { id: 'step2', label: 'Add tags', step: 2, status: 'error', retry: mockRetry },
-      ],
-      isComplete: false,
-      hasError: true,
-    }));
+    mockUseChainedMutations.mockReturnValue(
+      createMockChainedMutations({
+        steps: [
+          { id: 'step1', label: 'Create bucket', step: 1, status: 'success', retry: mockRetry },
+          { id: 'step2', label: 'Add tags', step: 2, status: 'error', retry: mockRetry },
+        ],
+        isComplete: false,
+        hasError: true,
+      }),
+    );
 
-    render(<Wrapper><ISVApplyActions {...mockProps} /></Wrapper>);
+    render(
+      <Wrapper>
+        <ISVApplyActions {...mockProps} />
+      </Wrapper>,
+    );
 
     expect(screen.getByText('Success')).toBeInTheDocument();
     expect(screen.getByText('Failed')).toBeInTheDocument();
@@ -147,13 +156,19 @@ describe('ISVApplyActions', () => {
   });
 
   it('disables continue button when there are required failures', () => {
-    mockUseChainedMutations.mockReturnValue(createMockChainedMutations({
-      isComplete: false,
-      hasError: true,
-      allRequiredStepsComplete: false,
-    }));
+    mockUseChainedMutations.mockReturnValue(
+      createMockChainedMutations({
+        isComplete: false,
+        hasError: true,
+        allRequiredStepsComplete: false,
+      }),
+    );
 
-    render(<Wrapper><ISVApplyActions {...mockProps} /></Wrapper>);
+    render(
+      <Wrapper>
+        <ISVApplyActions {...mockProps} />
+      </Wrapper>,
+    );
     expect(screen.getByRole('button', { name: 'Continue' })).toBeDisabled();
   });
 
@@ -217,7 +232,9 @@ describe('ISVApplyActions', () => {
       );
 
       expect(
-        screen.getByText('Some optional configuration steps were unsuccessful. You may continue with manual configuration.'),
+        screen.getByText(
+          'Some optional configuration steps were unsuccessful. You may continue with manual configuration.',
+        ),
       ).toBeInTheDocument();
     });
 
@@ -247,9 +264,7 @@ describe('ISVApplyActions', () => {
         </Wrapper>,
       );
 
-      expect(
-        screen.queryByText('Some optional steps failed. You may configure manually.'),
-      ).not.toBeInTheDocument();
+      expect(screen.queryByText('Some optional steps failed. You may configure manually.')).not.toBeInTheDocument();
     });
   });
 });

--- a/src/react/ISV/components/__tests__/ISVApplyActions.test.tsx
+++ b/src/react/ISV/components/__tests__/ISVApplyActions.test.tsx
@@ -207,6 +207,7 @@ describe('ISVApplyActions', () => {
       const platformWithoutMessage = {
         ...VeeamVBRPlatform,
         continueWithOptionalFailuresLabel: 'Continue anyway',
+        defaultOptionalFailureMessage: undefined,
       };
 
       render(
@@ -223,9 +224,14 @@ describe('ISVApplyActions', () => {
     it('keeps "Continue" label when platform has no continueWithOptionalFailuresLabel', () => {
       mockUseChainedMutations.mockReturnValue(createMockChainedMutations(optionalFailureMockOverrides));
 
+      const platformWithoutLabel = {
+        ...VeeamVBRPlatform,
+        continueWithOptionalFailuresLabel: undefined,
+      };
+
       render(
         <Wrapper>
-          <ISVApplyActions {...mockProps} />
+          <ISVApplyActions {...mockProps} platform={platformWithoutLabel} />
         </Wrapper>,
       );
 

--- a/src/react/ISV/engine/builders/buildMutations.ts
+++ b/src/react/ISV/engine/builders/buildMutations.ts
@@ -6,26 +6,21 @@
  */
 
 import type {
-  PlatformConfig,
-  MutationDef,
-  SingleMutationDef,
-  LoopMutationDef,
-  PerBucketStep,
+  BucketItem,
   FormData,
   FullContext,
+  LoopMutationDef,
+  MutationDef,
+  PerBucketStep,
+  PlatformConfig,
   PreviousResults,
-  BucketItem,
+  SingleMutationDef,
 } from '../types';
 
 type AccountResponse = { id: string };
 
 function isAccountResponse(data: unknown): data is AccountResponse {
-  return (
-    typeof data === 'object' &&
-    data !== null &&
-    'id' in data &&
-    typeof (data as AccountResponse).id === 'string'
-  );
+  return typeof data === 'object' && data !== null && 'id' in data && typeof (data as AccountResponse).id === 'string';
 }
 
 function getAccountId(prev: PreviousResults, ctx: FullContext): string {
@@ -50,11 +45,7 @@ export const STANDARD_BUCKET_STEPS: PerBucketStep[] = [
     id: 'createBucket',
     label: 'Create Bucket: {{name}}',
     action: 'createBucket',
-    variables: (
-      form: FormData,
-      bucket: BucketItem,
-      _prev: PreviousResults
-    ) => ({
+    variables: (form: FormData, bucket: BucketItem, _prev: PreviousResults) => ({
       Bucket: bucket.name,
       ObjectLockEnabledForBucket: form.enableImmutableBackup,
     }),
@@ -63,12 +54,7 @@ export const STANDARD_BUCKET_STEPS: PerBucketStep[] = [
     id: 'tagBucket',
     label: 'Tag Bucket: {{name}}',
     action: 'tagBucket',
-    variables: (
-      _form: FormData,
-      bucket: BucketItem,
-      _prev: PreviousResults,
-      ctx: FullContext
-    ) => ({
+    variables: (_form: FormData, bucket: BucketItem, _prev: PreviousResults, ctx: FullContext) => ({
       Bucket: bucket.name,
       Tagging: {
         TagSet: [{ Key: 'X-Scality-Application', Value: ctx._bucketTag }],
@@ -87,8 +73,7 @@ export function buildSOSAPIMutation(config: PlatformConfig): SingleMutationDef |
     id: 'enableSOSAPI',
     label: `Enable ${config.name} Smart Object Storage API`,
     action: 'enableSOSAPI',
-    when: (_form: FormData, ctx: FullContext) =>
-      ctx._sosApiStatus === 'available',
+    when: (_form: FormData, ctx: FullContext) => ctx._sosApiStatus === 'available',
     variables: () => ({}),
   };
 }
@@ -122,11 +107,7 @@ export function buildAccountMutations(config: PlatformConfig): SingleMutationDef
       id: 'assumeRole',
       label: 'Assume Account Role',
       action: 'assumeRole',
-      variables: (
-        _form: FormData,
-        prev: PreviousResults,
-        ctx: FullContext
-      ) => ({
+      variables: (_form: FormData, prev: PreviousResults, ctx: FullContext) => ({
         roleArn: ctx.isNewAccount
           ? `arn:aws:iam::${getAccountId(prev, ctx)}:role/scality-internal/storage-manager-role`
           : ctx._existingAccount!.roleArn,
@@ -139,10 +120,7 @@ export function buildAccountMutations(config: PlatformConfig): SingleMutationDef
  * Build the bucket loop mutation
  */
 export function buildBucketLoopMutation(config: PlatformConfig): LoopMutationDef {
-  const steps: PerBucketStep[] = [
-    ...STANDARD_BUCKET_STEPS,
-    ...(config.perBucketSteps ?? []),
-  ];
+  const steps: PerBucketStep[] = [...STANDARD_BUCKET_STEPS, ...(config.perBucketSteps ?? [])];
 
   return {
     each: 'buckets',
@@ -178,11 +156,7 @@ export function buildIAMMutations(config: PlatformConfig): SingleMutationDef[] {
       label: (_form: FormData, ctx: FullContext) =>
         ctx.isNewAccount || ctx.needsIAMUser ? 'Create Policy' : 'Update Policy',
       action: 'createPolicy',
-      variables: (
-        form: FormData,
-        prev: PreviousResults,
-        ctx: FullContext
-      ) => {
+      variables: (form: FormData, prev: PreviousResults, ctx: FullContext) => {
         const policyName = `${form.IAMUserName || form.accountName}-${ctx._platformId}-${
           form.enableImmutableBackup ? 'immutable' : 'non-immutable'
         }`;
@@ -200,11 +174,7 @@ export function buildIAMMutations(config: PlatformConfig): SingleMutationDef[] {
       id: 'attachPolicy',
       label: 'Attach Policy to User',
       action: 'attachPolicy',
-      variables: (
-        form: FormData,
-        prev: PreviousResults,
-        ctx: FullContext
-      ) => {
+      variables: (form: FormData, prev: PreviousResults, ctx: FullContext) => {
         const userName = form.IAMUserName || form.accountName;
         const accountId = getAccountId(prev, ctx);
         return {
@@ -268,9 +238,7 @@ export function buildMutations(config: PlatformConfig): MutationDef[] {
 /**
  * Check if a mutation definition is a loop mutation
  */
-export function isLoopMutation(
-  mutation: MutationDef
-): mutation is LoopMutationDef {
+export function isLoopMutation(mutation: MutationDef): mutation is LoopMutationDef {
   return 'each' in mutation;
 }
 
@@ -288,11 +256,7 @@ export function isLoopMutation(
  *   { id: 'setup-1', ... },
  * ]
  */
-export function expandLoopMutation(
-  mutation: LoopMutationDef,
-  form: FormData,
-  ctx: FullContext
-): SingleMutationDef[] {
+export function expandLoopMutation(mutation: LoopMutationDef, form: FormData, ctx: FullContext): SingleMutationDef[] {
   const items = form[mutation.each];
   if (!Array.isArray(items)) return [];
 
@@ -306,22 +270,19 @@ export function expandLoopMutation(
       }
 
       // Replace {{field}} placeholders in label
-      const label = step.label.replace(
-        /\{\{(\w+)\}\}/g,
-        (_, field) => String(item[field as keyof BucketItem] ?? '')
-      );
+      const label = step.label.replace(/\{\{(\w+)\}\}/g, (_, field) => String(item[field as keyof BucketItem] ?? ''));
 
       expanded.push({
         id: `${step.id}-${index}`,
         label,
         action: step.action,
-        variables: (f: FormData, prev: PreviousResults, c: FullContext) =>
-          step.variables(f, item, prev, c),
+        variables: (f: FormData, prev: PreviousResults, c: FullContext) => step.variables(f, item, prev, c),
         ...(step.optional && { optional: true }),
         ...(step.failureMessage && {
           failureMessage:
             typeof step.failureMessage === 'function'
-              ? (f: FormData, c: FullContext) => (step.failureMessage as (form: FormData, bucket: BucketItem, ctx: FullContext) => string)(f, item, c)
+              ? (f: FormData, c: FullContext) =>
+                  (step.failureMessage as (form: FormData, bucket: BucketItem, ctx: FullContext) => string)(f, item, c)
               : step.failureMessage,
         }),
       });
@@ -330,4 +291,3 @@ export function expandLoopMutation(
 
   return expanded;
 }
-

--- a/src/react/ISV/engine/builders/buildMutations.ts
+++ b/src/react/ISV/engine/builders/buildMutations.ts
@@ -5,6 +5,7 @@
  * Handles the standard ISV flow with optional platform-specific steps.
  */
 
+import type { ReactNode } from 'react';
 import type {
   BucketItem,
   FormData,
@@ -282,7 +283,11 @@ export function expandLoopMutation(mutation: LoopMutationDef, form: FormData, ct
           failureMessage:
             typeof step.failureMessage === 'function'
               ? (f: FormData, c: FullContext) =>
-                  (step.failureMessage as (form: FormData, bucket: BucketItem, ctx: FullContext) => string)(f, item, c)
+                  (step.failureMessage as (form: FormData, bucket: BucketItem, ctx: FullContext) => ReactNode)(
+                    f,
+                    item,
+                    c,
+                  )
               : step.failureMessage,
         }),
       });

--- a/src/react/ISV/engine/types.ts
+++ b/src/react/ISV/engine/types.ts
@@ -218,7 +218,7 @@ export type SingleMutationDef = {
   when?: (form: FormData, ctx: FullContext) => boolean;
   variables: (form: FormData, prev: PreviousResults, ctx: FullContext) => Record<string, unknown>;
   optional?: boolean;
-  failureMessage?: string | ((form: FormData, ctx: FullContext) => string);
+  failureMessage?: ReactNode | ((form: FormData, ctx: FullContext) => ReactNode);
 };
 
 export type PerBucketStep = {
@@ -228,7 +228,7 @@ export type PerBucketStep = {
   when?: (form: FormData, bucket: BucketItem, ctx: FullContext) => boolean;
   variables: (form: FormData, bucket: BucketItem, prev: PreviousResults, ctx: FullContext) => Record<string, unknown>;
   optional?: boolean;
-  failureMessage?: string | ((form: FormData, bucket: BucketItem, ctx: FullContext) => string);
+  failureMessage?: ReactNode | ((form: FormData, bucket: BucketItem, ctx: FullContext) => ReactNode);
 };
 
 export type LoopMutationDef = {

--- a/src/react/ISV/engine/types.ts
+++ b/src/react/ISV/engine/types.ts
@@ -245,7 +245,7 @@ export type MutationDef = SingleMutationDef | LoopMutationDef;
 export type OptionalFailure = {
   id: string;
   label: string;
-  message: string;
+  message: ReactNode;
 };
 
 // ============================================================================
@@ -320,7 +320,7 @@ export type ISVPlatform = {
   skipModalContent?: ReactNode;
 
   bucketTag: string;
-  defaultOptionalFailureMessage?: string;
+  defaultOptionalFailureMessage?: ReactNode;
   continueWithOptionalFailuresLabel?: string;
 
   fields: FieldDef[];
@@ -357,7 +357,7 @@ export type PlatformConfig = {
   bucketTag?: string;
 
   // Optional step failure handling
-  defaultOptionalFailureMessage?: string;
+  defaultOptionalFailureMessage?: ReactNode;
   continueWithOptionalFailuresLabel?: string;
 
   // Feature switches

--- a/src/react/ISV/hooks/useMutationExecutor.ts
+++ b/src/react/ISV/hooks/useMutationExecutor.ts
@@ -5,6 +5,7 @@
  * by useChainedMutations (MutationConfig[] + VariablesResolvers).
  */
 
+import type { ReactNode } from 'react';
 import { useMemo } from 'react';
 import { useMutation } from 'react-query';
 import {
@@ -81,7 +82,7 @@ type UseMutationExecutorOptions = {
 type UseMutationExecutorResult = {
   mutations: MutationConfig[];
   variables: VariablesResolvers;
-  failureMessages: Record<string, string>;
+  failureMessages: Record<string, ReactNode>;
 };
 
 /**
@@ -165,7 +166,7 @@ export function useMutationExecutor({
   const { mutations, variables, failureMessages } = useMemo(() => {
     const mutationConfigs: MutationConfig[] = [];
     const variableResolvers: VariablesResolvers = {};
-    const resolvedFailureMessages: Record<string, string> = {};
+    const resolvedFailureMessages: Record<string, ReactNode> = {};
 
     for (const def of expandedMutations) {
       // Check `when` condition

--- a/src/react/ISV/platforms/__tests__/veeam-vbr.test.tsx
+++ b/src/react/ISV/platforms/__tests__/veeam-vbr.test.tsx
@@ -1,5 +1,6 @@
-import { VeeamVBRPlatform } from '../veeam-vbr';
 import { VEEAM_BACKUP_REPLICATION } from '../../constants';
+import type { FormData, SummaryRenderProps } from '../../engine/types';
+import { VeeamVBRPlatform } from '../veeam-vbr';
 
 describe('VeeamVBRPlatform', () => {
   describe('basic properties', () => {
@@ -27,48 +28,36 @@ describe('VeeamVBRPlatform', () => {
 
   describe('generated fields', () => {
     it('should generate accountName field', () => {
-      const accountField = VeeamVBRPlatform.fields.find(
-        (f) => f.name === 'accountName',
-      );
+      const accountField = VeeamVBRPlatform.fields.find((f) => f.name === 'accountName');
       expect(accountField).toBeDefined();
       expect(accountField?.type).toBe('accountSelector');
       expect(accountField?.label).toBe('Account');
     });
 
     it('should generate buckets field with capacity itemFields', () => {
-      const bucketsField = VeeamVBRPlatform.fields.find(
-        (f) => f.name === 'buckets',
-      );
+      const bucketsField = VeeamVBRPlatform.fields.find((f) => f.name === 'buckets');
       expect(bucketsField).toBeDefined();
       expect(bucketsField?.type).toBe('bucketArray');
 
       if (bucketsField && 'itemFields' in bucketsField) {
-        const capacityField = bucketsField.itemFields.find(
-          (f) => f.name === 'capacity',
-        );
+        const capacityField = bucketsField.itemFields.find((f) => f.name === 'capacity');
         expect(capacityField).toBeDefined();
         expect(capacityField?.type).toBe('number');
 
-        const capacityUnitField = bucketsField.itemFields.find(
-          (f) => f.name === 'capacityUnit',
-        );
+        const capacityUnitField = bucketsField.itemFields.find((f) => f.name === 'capacityUnit');
         expect(capacityUnitField).toBeDefined();
         expect(capacityUnitField?.type).toBe('select');
       }
     });
 
     it('should generate IAMUserName field', () => {
-      const iamField = VeeamVBRPlatform.fields.find(
-        (f) => f.name === 'IAMUserName',
-      );
+      const iamField = VeeamVBRPlatform.fields.find((f) => f.name === 'IAMUserName');
       expect(iamField).toBeDefined();
       expect(iamField?.type).toBe('iamUserSelector');
     });
 
     it('should generate enableImmutableBackup field', () => {
-      const immutableField = VeeamVBRPlatform.fields.find(
-        (f) => f.name === 'enableImmutableBackup',
-      );
+      const immutableField = VeeamVBRPlatform.fields.find((f) => f.name === 'enableImmutableBackup');
       expect(immutableField).toBeDefined();
       expect(immutableField?.type).toBe('toggle');
       expect(immutableField?.label).toBe('Immutable Backup');
@@ -198,9 +187,7 @@ describe('VeeamVBRPlatform', () => {
     });
 
     it('should include enableSOSAPI mutation (sosAPI: true)', () => {
-      const sosMutation = VeeamVBRPlatform.mutations.find(
-        (m) => 'action' in m && m.action === 'enableSOSAPI',
-      );
+      const sosMutation = VeeamVBRPlatform.mutations.find((m) => 'action' in m && m.action === 'enableSOSAPI');
       expect(sosMutation).toBeDefined();
     });
 
@@ -212,9 +199,7 @@ describe('VeeamVBRPlatform', () => {
     });
 
     it('should include bucket loop mutation with perBucketSteps', () => {
-      const loopMutation = VeeamVBRPlatform.mutations.find(
-        (m) => 'each' in m && m.each === 'buckets',
-      );
+      const loopMutation = VeeamVBRPlatform.mutations.find((m) => 'each' in m && m.each === 'buckets');
       expect(loopMutation).toBeDefined();
 
       if (loopMutation && 'steps' in loopMutation) {
@@ -229,20 +214,14 @@ describe('VeeamVBRPlatform', () => {
     });
 
     it('should have perBucketSteps with putObject action', () => {
-      const loopMutation = VeeamVBRPlatform.mutations.find(
-        (m) => 'each' in m && m.each === 'buckets',
-      );
+      const loopMutation = VeeamVBRPlatform.mutations.find((m) => 'each' in m && m.each === 'buckets');
 
       if (loopMutation && 'steps' in loopMutation) {
-        const veeamSystemStep = loopMutation.steps.find(
-          (s) => s.id === 'veeamSystem',
-        );
+        const veeamSystemStep = loopMutation.steps.find((s) => s.id === 'veeamSystem');
         expect(veeamSystemStep).toBeDefined();
         expect(veeamSystemStep?.action).toBe('putObject');
 
-        const veeamCapacityStep = loopMutation.steps.find(
-          (s) => s.id === 'veeamCapacity',
-        );
+        const veeamCapacityStep = loopMutation.steps.find((s) => s.id === 'veeamCapacity');
         expect(veeamCapacityStep).toBeDefined();
         expect(veeamCapacityStep?.action).toBe('putObject');
       }
@@ -250,14 +229,7 @@ describe('VeeamVBRPlatform', () => {
 
     it('should include IAM mutations', () => {
       const iamMutations = VeeamVBRPlatform.mutations.filter(
-        (m) =>
-          'action' in m &&
-          [
-            'createIAMUser',
-            'createAccessKey',
-            'createPolicy',
-            'attachPolicy',
-          ].includes(m.action),
+        (m) => 'action' in m && ['createIAMUser', 'createAccessKey', 'createPolicy', 'attachPolicy'].includes(m.action),
       );
       expect(iamMutations.length).toBeGreaterThan(0);
     });
@@ -265,14 +237,10 @@ describe('VeeamVBRPlatform', () => {
 
   describe('perBucketSteps variables', () => {
     it('veeamSystem step should include correct variables', () => {
-      const loopMutation = VeeamVBRPlatform.mutations.find(
-        (m) => 'each' in m && m.each === 'buckets',
-      );
+      const loopMutation = VeeamVBRPlatform.mutations.find((m) => 'each' in m && m.each === 'buckets');
 
       if (loopMutation && 'steps' in loopMutation) {
-        const veeamSystemStep = loopMutation.steps.find(
-          (s) => s.id === 'veeamSystem',
-        );
+        const veeamSystemStep = loopMutation.steps.find((s) => s.id === 'veeamSystem');
 
         const mockForm = {
           accountName: 'test',
@@ -294,12 +262,7 @@ describe('VeeamVBRPlatform', () => {
           _s3ServicePoint: 'test-s3-service-point',
         };
 
-        const variables = veeamSystemStep?.variables(
-          mockForm,
-          mockBucket,
-          mockPrev,
-          mockCtx,
-        );
+        const variables = veeamSystemStep?.variables(mockForm, mockBucket, mockPrev, mockCtx);
 
         // data-browser-library hooks get s3Client from context, not from variables
         expect(variables).not.toHaveProperty('s3Client');
@@ -309,14 +272,10 @@ describe('VeeamVBRPlatform', () => {
     });
 
     it('veeamCapacity step should use bucket.capacityBytes', () => {
-      const loopMutation = VeeamVBRPlatform.mutations.find(
-        (m) => 'each' in m && m.each === 'buckets',
-      );
+      const loopMutation = VeeamVBRPlatform.mutations.find((m) => 'each' in m && m.each === 'buckets');
 
       if (loopMutation && 'steps' in loopMutation) {
-        const veeamCapacityStep = loopMutation.steps.find(
-          (s) => s.id === 'veeamCapacity',
-        );
+        const veeamCapacityStep = loopMutation.steps.find((s) => s.id === 'veeamCapacity');
 
         const mockForm = {
           accountName: 'test',
@@ -341,12 +300,7 @@ describe('VeeamVBRPlatform', () => {
           _s3ServicePoint: 'test-s3-service-point',
         };
 
-        const variables = veeamCapacityStep?.variables(
-          mockForm,
-          mockBucket,
-          mockPrev,
-          mockCtx,
-        );
+        const variables = veeamCapacityStep?.variables(mockForm, mockBucket, mockPrev, mockCtx);
 
         expect(variables).toHaveProperty('Bucket', 'capacity-bucket');
         expect(variables?.Body).toContain('1099511627776');
@@ -361,9 +315,7 @@ describe('VeeamVBRPlatform', () => {
 
     it('should have immutabilityHelpText function', () => {
       expect(VeeamVBRPlatform.summary.immutabilityHelpText).toBeDefined();
-      expect(typeof VeeamVBRPlatform.summary.immutabilityHelpText).toBe(
-        'function',
-      );
+      expect(typeof VeeamVBRPlatform.summary.immutabilityHelpText).toBe('function');
     });
 
     it('should return help text when immutable is true', () => {
@@ -374,6 +326,68 @@ describe('VeeamVBRPlatform', () => {
     it('should return undefined when immutable is false', () => {
       const helpText = VeeamVBRPlatform.summary.immutabilityHelpText?.(false);
       expect(helpText).toBeUndefined();
+    });
+
+    describe('customRender', () => {
+      const { customRender } = VeeamVBRPlatform.summary;
+
+      if (!customRender) {
+        throw new Error('customRender should be defined on VeeamVBRPlatform');
+      }
+
+      const baseFormData: FormData = {
+        accountName: 'test',
+        accountNameType: 'create',
+        enableImmutableBackup: false,
+        buckets: [{ name: 'bucket-1' }],
+      };
+
+      const mockOnFinish = jest.fn();
+      const mockRenderDefault = jest.fn(() => <div>default summary</div>);
+
+      const buildProps = (overrides: Partial<SummaryRenderProps> = {}): SummaryRenderProps => ({
+        formData: baseFormData,
+        accessKey: 'ak',
+        secretKey: 'sk',
+        onFinish: mockOnFinish,
+        renderDefault: mockRenderDefault,
+        ...overrides,
+      });
+
+      beforeEach(() => {
+        jest.clearAllMocks();
+      });
+
+      it('should call renderDefault when autoCreateRepository is false', () => {
+        customRender(buildProps({ formData: { ...baseFormData, autoCreateRepository: false } }));
+        expect(mockRenderDefault).toHaveBeenCalled();
+      });
+
+      it('should call renderDefault when autoCreateRepository is undefined', () => {
+        customRender(buildProps());
+        expect(mockRenderDefault).toHaveBeenCalled();
+      });
+
+      it('should call renderDefault when optionalFailures has items', () => {
+        customRender(
+          buildProps({
+            formData: { ...baseFormData, autoCreateRepository: true },
+            optionalFailures: [{ id: 'createVeeamRepo-0', label: 'Create Veeam Repository', message: 'Failed' }],
+          }),
+        );
+        expect(mockRenderDefault).toHaveBeenCalled();
+      });
+
+      it('should return VeeamRepositorySummary when autoCreateRepository is true and no optional failures', () => {
+        const result = customRender(
+          buildProps({
+            formData: { ...baseFormData, autoCreateRepository: true },
+            optionalFailures: [],
+          }),
+        );
+        expect(mockRenderDefault).not.toHaveBeenCalled();
+        expect(result).toBeDefined();
+      });
     });
   });
 

--- a/src/react/ISV/platforms/veeam-vbr.tsx
+++ b/src/react/ISV/platforms/veeam-vbr.tsx
@@ -1,41 +1,33 @@
-import { useEffect } from 'react';
 import { Banner, Stack, Text } from '@scality/core-ui';
-import { definePlatform, VeeamVBRValidator } from '../engine';
-import type {
-  BucketItem,
-  FormData,
-  PreviousResults,
-  FullContext,
-  DisabledMessageProps,
-} from '../engine';
-import { GET_VEEAM_POLICY } from '../utils/ISVPolicy';
-import { VeeamLogo } from '../components/logos/VeeamLogo';
-import { VeeamMultipleBucketCapture } from '../components/veeam/VeeamMultipleBucketCapture';
+import { useEffect } from 'react';
 import { IAMUSerTooltip } from '../components/IAMUserTooltip';
-import { VeeamRepositoryFields } from '../components/VeeamRepositoryFields';
-import { useCheckSOSAPIStatus } from '../hooks/useCheckSOSAPIStatus';
+import { VeeamLogo } from '../components/logos/VeeamLogo';
 import {
   AccountTooltip,
   BucketNameTooltip,
-  VeeamImmutableBackupTooltip,
   CapacityTooltip,
+  VeeamImmutableBackupTooltip,
 } from '../components/shared/PlatformTooltips';
+import { VeeamRepositoryFields } from '../components/VeeamRepositoryFields';
+import { VeeamRepositorySummary } from '../components/VeeamRepositorySummary';
+import { VeeamMultipleBucketCapture } from '../components/veeam/VeeamMultipleBucketCapture';
 import {
-  VEEAM_BACKUP_REPLICATION,
-  VEEAM_XML_PREFIX,
-  SYSTEM_XML_CONTENT,
   GET_CAPACITY_XML_CONTENT,
+  SYSTEM_XML_CONTENT,
   VEEAM_ARCHIVE_FOLDER_PATH,
   VEEAM_BACKUP_CLIENTS_FOLDER_PATH,
   VEEAM_BACKUP_CONFIG_FOLDER_PATH,
+  VEEAM_BACKUP_REPLICATION,
+  VEEAM_XML_PREFIX,
 } from '../constants';
+import type { BucketItem, DisabledMessageProps, FormData, FullContext, PreviousResults } from '../engine';
+import { definePlatform, VeeamVBRValidator } from '../engine';
+import { useCheckSOSAPIStatus } from '../hooks/useCheckSOSAPIStatus';
 import { calculateStorageConsumptionLimit } from '../utils/capacityCalculations';
-import { VeeamRepositorySummary } from '../components/VeeamRepositorySummary';
 import { ensureHttpsPrefix } from '../utils/ensureHttpsPrefix';
+import { GET_VEEAM_POLICY } from '../utils/ISVPolicy';
 
-const VeeamVBRDisabledMessage = ({
-  onDisabledChange,
-}: DisabledMessageProps) => {
+const VeeamVBRDisabledMessage = ({ onDisabledChange }: DisabledMessageProps) => {
   const status = useCheckSOSAPIStatus();
 
   useEffect(() => {
@@ -53,9 +45,8 @@ const VeeamVBRDisabledMessage = ({
   } else if (status === 'unauthorized') {
     return (
       <Text>
-        As Smart Object Storage API is not available, you need to be a platform
-        admin to configure Veeam Backup and Replication. You can also contact
-        your platform admin to enable the Smart Object Storage API.
+        As Smart Object Storage API is not available, you need to be a platform admin to configure Veeam Backup and
+        Replication. You can also contact your platform admin to enable the Smart Object Storage API.
       </Text>
     );
   }
@@ -64,15 +55,12 @@ const VeeamVBRDisabledMessage = ({
 
 const VeeamBucketBanner = () => (
   <Banner variant="warning" title="Configuration warning">
-    When configuring Veeam Backup and Replication (VBR) application, the option
-    "Automatic bucket creation" must be disabled to ensure Veeam connects
-    properly.
+    When configuring Veeam Backup and Replication (VBR) application, the option "Automatic bucket creation" must be
+    disabled to ensure Veeam connects properly.
     <br />
-    In VBR v12.3.1.1139 and above, Automatic Bucket Creation is enabled by
-    default.
+    In VBR v12.3.1.1139 and above, Automatic Bucket Creation is enabled by default.
     <br />
-    You'll find the option next to the Bucket name in the S3 compatible
-    repository wizard.
+    You'll find the option next to the Bucket name in the S3 compatible repository wizard.
     <VeeamMultipleBucketCapture />
   </Banner>
 );
@@ -82,8 +70,7 @@ export const VeeamVBRPlatform = definePlatform({
   name: 'Veeam',
   logo: <VeeamLogo />,
   policy: GET_VEEAM_POLICY,
-  documentationLink:
-    '/artesca/docs/partner_applications/backup_and_archives/veeam/index.html',
+  documentationLink: '/artesca/docs/partner_applications/backup_and_archives/veeam/index.html',
   disabledMessage: VeeamVBRDisabledMessage,
   bucketTag: VEEAM_BACKUP_REPLICATION,
   application: VEEAM_BACKUP_REPLICATION,
@@ -91,6 +78,14 @@ export const VeeamVBRPlatform = definePlatform({
   sosAPI: true,
   bucketCapacity: true,
   customValidator: VeeamVBRValidator,
+  continueWithOptionalFailuresLabel: 'Continue to manual configuration',
+  defaultOptionalFailureMessage: (
+    <>
+      The automatic Veeam Repository creation was unsuccessful.
+      <br />
+      You may continue to configure it manually.
+    </>
+  ),
 
   fieldOverrides: {
     accountName: {
@@ -123,12 +118,7 @@ export const VeeamVBRPlatform = definePlatform({
       id: 'veeamFolder',
       label: 'Create Veeam folder: {{name}}',
       action: 'putObject',
-      variables: (
-        _form: FormData,
-        bucket: BucketItem,
-        prev: PreviousResults,
-        _ctx: FullContext,
-      ) => ({
+      variables: (_form: FormData, bucket: BucketItem, prev: PreviousResults, _ctx: FullContext) => ({
         Bucket: bucket.name,
         Key: `${VEEAM_XML_PREFIX}/`,
         Body: '',
@@ -139,14 +129,8 @@ export const VeeamVBRPlatform = definePlatform({
       id: 'veeamArchiveFolder',
       label: `Create Archive folder: ${VEEAM_ARCHIVE_FOLDER_PATH}`,
       action: 'putObject',
-      when: (form: FormData, _bucket: BucketItem, _ctx: FullContext) =>
-        form.autoCreateRepository === true,
-      variables: (
-        _form: FormData,
-        bucket: BucketItem,
-        prev: PreviousResults,
-        _ctx: FullContext,
-      ) => ({
+      when: (form: FormData, _bucket: BucketItem, _ctx: FullContext) => form.autoCreateRepository === true,
+      variables: (_form: FormData, bucket: BucketItem, prev: PreviousResults, _ctx: FullContext) => ({
         s3Client: prev.assumeRole?.data,
         Bucket: bucket.name,
         Key: VEEAM_ARCHIVE_FOLDER_PATH,
@@ -157,14 +141,8 @@ export const VeeamVBRPlatform = definePlatform({
       id: 'veeamBackupClientsFolder',
       label: `Create Backup Clients folder: ${VEEAM_BACKUP_CLIENTS_FOLDER_PATH}`,
       action: 'putObject',
-      when: (form: FormData, _bucket: BucketItem, _ctx: FullContext) =>
-        form.autoCreateRepository === true,
-      variables: (
-        _form: FormData,
-        bucket: BucketItem,
-        prev: PreviousResults,
-        _ctx: FullContext,
-      ) => ({
+      when: (form: FormData, _bucket: BucketItem, _ctx: FullContext) => form.autoCreateRepository === true,
+      variables: (_form: FormData, bucket: BucketItem, prev: PreviousResults, _ctx: FullContext) => ({
         s3Client: prev.assumeRole?.data,
         Bucket: bucket.name,
         Key: VEEAM_BACKUP_CLIENTS_FOLDER_PATH,
@@ -178,12 +156,7 @@ export const VeeamVBRPlatform = definePlatform({
       when: (form: FormData, _bucket: BucketItem, _ctx: FullContext) => {
         return form.autoCreateRepository === true;
       },
-      variables: (
-        _form: FormData,
-        bucket: BucketItem,
-        prev: PreviousResults,
-        _ctx: FullContext,
-      ) => ({
+      variables: (_form: FormData, bucket: BucketItem, prev: PreviousResults, _ctx: FullContext) => ({
         s3Client: prev.assumeRole?.data,
         Bucket: bucket.name,
         Key: VEEAM_BACKUP_CONFIG_FOLDER_PATH,
@@ -194,12 +167,7 @@ export const VeeamVBRPlatform = definePlatform({
       id: 'veeamSystem',
       label: 'Setup repository: {{name}}',
       action: 'putObject',
-      variables: (
-        _form: FormData,
-        bucket: BucketItem,
-        prev: PreviousResults,
-        _ctx: FullContext,
-      ) => ({
+      variables: (_form: FormData, bucket: BucketItem, prev: PreviousResults, _ctx: FullContext) => ({
         Bucket: bucket.name,
         Key: `${VEEAM_XML_PREFIX}/system.xml`,
         Body: SYSTEM_XML_CONTENT,
@@ -210,12 +178,7 @@ export const VeeamVBRPlatform = definePlatform({
       id: 'veeamCapacity',
       label: 'Set capacity: {{name}}',
       action: 'putObject',
-      variables: (
-        _form: FormData,
-        bucket: BucketItem,
-        prev: PreviousResults,
-        _ctx: FullContext,
-      ) => ({
+      variables: (_form: FormData, bucket: BucketItem, prev: PreviousResults, _ctx: FullContext) => ({
         Bucket: bucket.name,
         Key: `${VEEAM_XML_PREFIX}/capacity.xml`,
         Body: GET_CAPACITY_XML_CONTENT(String(bucket.capacityBytes ?? 0)),
@@ -231,17 +194,14 @@ export const VeeamVBRPlatform = definePlatform({
           id: 'createVeeamRepo',
           label: 'Create Veeam Repository: {{name}}',
           action: 'createVeeamRepository',
+          optional: true,
+          failureMessage: (_form: FormData, bucket: BucketItem, _ctx: FullContext) =>
+            `The automatic Veeam Repository creation for "${bucket.name}" was unsuccessful. You may continue to configure it manually.`,
           when: (form: FormData, _bucket: BucketItem, _ctx: FullContext) =>
             form.autoCreateRepository === true && _ctx.needsAccessKey,
-          variables: (
-            form: FormData,
-            bucket: BucketItem,
-            prev: PreviousResults,
-            ctx: FullContext,
-          ) => {
+          variables: (form: FormData, bucket: BucketItem, prev: PreviousResults, ctx: FullContext) => {
             const capacityBytes = bucket.capacityBytes ?? 0;
-            const { kind, count } =
-              calculateStorageConsumptionLimit(capacityBytes);
+            const { kind, count } = calculateStorageConsumptionLimit(capacityBytes);
             const servicePoint = ensureHttpsPrefix(ctx._s3ServicePoint);
 
             const accessKeyData = prev.createAccessKey?.data as
@@ -254,9 +214,7 @@ export const VeeamVBRPlatform = definePlatform({
               | undefined;
 
             if (!accessKeyData?.AccessKey) {
-              throw new Error(
-                'Access key not available. Ensure access key creation completed successfully.',
-              );
+              throw new Error('Access key not available. Ensure access key creation completed successfully.');
             }
 
             return {
@@ -281,11 +239,9 @@ export const VeeamVBRPlatform = definePlatform({
     bucketBanner: <VeeamBucketBanner />,
     immutabilityLabel: 'Immutable Backup',
     immutabilityHelpText: (enabled: boolean) =>
-      enabled
-        ? 'Ensure "Make recent backups immutable" is checked when configuring the bucket in Veeam.'
-        : undefined,
-    customRender: ({ formData, onFinish, renderDefault }) => {
-      if (!formData.autoCreateRepository) {
+      enabled ? 'Ensure "Make recent backups immutable" is checked when configuring the bucket in Veeam.' : undefined,
+    customRender: ({ formData, onFinish, optionalFailures, renderDefault }) => {
+      if (!formData.autoCreateRepository || optionalFailures?.length) {
         return renderDefault();
       }
 
@@ -305,9 +261,8 @@ export const VeeamVBRPlatform = definePlatform({
 
   skipModalContent: (
     <Text>
-      To start Veeam assistant configuration again, you can go to the{' '}
-      <b>Accounts</b> page or <b>Data Browser</b> page. If the platform doesn't
-      have any accounts, it will also prompt you on your next login.
+      To start Veeam assistant configuration again, you can go to the <b>Accounts</b> page or <b>Data Browser</b> page.
+      If the platform doesn't have any accounts, it will also prompt you on your next login.
     </Text>
   ),
   additionalFields: {


### PR DESCRIPTION
## Summary

This PR makes the Veeam Repository auto-creation step a **graceful, optional mutation** in the ISV assistant. When the `createVeeamRepository` API call fails (e.g. Veeam server unreachable, timeout), the assistant no longer blocks the user — instead it shows a warning banner and lets them continue to manual configuration.

- **Veeam `createVeeamRepo` marked as `optional: true`** — failure no longer prevents the user from completing the wizard
- **Warning banner on optional failure** — displays "The automatic Veeam Repository creation was unsuccessful. You may continue to configure it manually."
- **"Continue to manual configuration" button** — replaces the standard "Continue" label when optional steps fail, making the fallback path explicit
- **Per-bucket failure messages** — each failed repository creation shows which bucket failed specifically
- **Summary fallback** — when auto-create fails, the summary shows the standard credentials view (access key, endpoint, etc.) instead of the success-only `VeeamRepositorySummary`

### How

The optional mutation infrastructure was wired in previous work (Tasks 1–4). This PR applies it to the Veeam VBR platform config:

- `veeam-vbr.tsx`: adds `optional`, `failureMessage`, `continueWithOptionalFailuresLabel`, and `defaultOptionalFailureMessage` to the platform definition; updates `customRender` to fall back to the default summary on optional failures
- `ISVApplyActions.test.tsx`: adjusts tests to account for VeeamVBRPlatform now carrying optional failure config

### Deviations from plan

The `defaultOptionalFailureMessage` type was changed from `string` to `ReactNode` (not in the original plan) to have more support.