### PR TITLE
feat: add Kasten ISV application support and bump data-browser-library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@monaco-editor/react": "^4.4.5",
         "@scality/certchain": "1.4.0",
         "@scality/core-ui": "0.197.0",
-        "@scality/data-browser-library": "1.0.6",
+        "@scality/data-browser-library": "1.0.7",
         "@scality/module-federation": "1.6.1",
         "@scality/react-chained-query": "^2.1.0",
         "@types/react-table": "^7.7.10",
@@ -317,9 +317,9 @@
       }
     },
     "node_modules/@aws-sdk/client-cognito-identity": {
-      "version": "3.990.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.990.0.tgz",
-      "integrity": "sha512-7VF6Gm7erGLdCBk7oR4pMNgbWZWkUxiomjUmgKikiMmNVpRjUY+2PODUjIINuPZug0WbNIIvbHnfapaXho0x/A==",
+      "version": "3.991.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.991.0.tgz",
+      "integrity": "sha512-U3Qh+SPWQQiK+ON6fCOC+SctNlsigATTnz1TkD28l35j6fs7+QAEjbtP07LpfZ926mx3ibBN3jMRDFsOKSXwRQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha256-browser": "5.2.0",
@@ -332,7 +332,7 @@
         "@aws-sdk/middleware-user-agent": "^3.972.10",
         "@aws-sdk/region-config-resolver": "^3.972.3",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.990.0",
+        "@aws-sdk/util-endpoints": "3.991.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
         "@aws-sdk/util-user-agent-node": "^3.972.8",
         "@smithy/config-resolver": "^4.4.6",
@@ -367,9 +367,9 @@
       }
     },
     "node_modules/@aws-sdk/client-s3": {
-      "version": "3.990.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.990.0.tgz",
-      "integrity": "sha512-XnsM8RgB35Atn2+aYSocitCybDG82x9yYf/s2D23ytpyHCupmuZN3LzK2a0WxmKO6Zf7EtEIYy0mHGY4tLp9YA==",
+      "version": "3.991.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.991.0.tgz",
+      "integrity": "sha512-zVrOyECGCtwaGP+VzhsigkTraM3mcxuUoBKcCLxWF6hSMVozfCilA1cq1nVrcHeAAcrXgKWbCVHdxx5SQXlUcQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-crypto/sha1-browser": "5.2.0",
@@ -388,9 +388,9 @@
         "@aws-sdk/middleware-ssec": "^3.972.3",
         "@aws-sdk/middleware-user-agent": "^3.972.10",
         "@aws-sdk/region-config-resolver": "^3.972.3",
-        "@aws-sdk/signature-v4-multi-region": "3.990.0",
+        "@aws-sdk/signature-v4-multi-region": "3.991.0",
         "@aws-sdk/types": "^3.973.1",
-        "@aws-sdk/util-endpoints": "3.990.0",
+        "@aws-sdk/util-endpoints": "3.991.0",
         "@aws-sdk/util-user-agent-browser": "^3.972.3",
         "@aws-sdk/util-user-agent-node": "^3.972.8",
         "@smithy/config-resolver": "^4.4.6",
@@ -475,6 +475,22 @@
         "@smithy/util-middleware": "^4.2.8",
         "@smithy/util-retry": "^4.2.8",
         "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/client-sso/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.990.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.990.0.tgz",
+      "integrity": "sha512-kVwtDc9LNI3tQZHEMNbkLIOpeDK8sRSTuT8eMnzGY+O+JImPisfSTjdh+jw9OTznu+MYZjQsv0258sazVKunYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-endpoints": "^3.2.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -759,12 +775,12 @@
       }
     },
     "node_modules/@aws-sdk/credential-providers": {
-      "version": "3.990.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.990.0.tgz",
-      "integrity": "sha512-urX4CbPkqYVHErqglluwho98ulIZhB33vdg87IK6F0Uj5pdNF7YBoHMvwOXcFbiDIbYKOeqKQDynsMYRQtp7Vg==",
+      "version": "3.991.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.991.0.tgz",
+      "integrity": "sha512-DlNG60+kVja4CtR5KPbbXFlNi2M4dGjKRnzN2aexb1ge2jqvK20vX2MGXyNj7oVNQcvwN/qUiCJ77vzS0H7miA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-cognito-identity": "3.990.0",
+        "@aws-sdk/client-cognito-identity": "3.991.0",
         "@aws-sdk/core": "^3.973.10",
         "@aws-sdk/credential-provider-cognito-identity": "^3.972.3",
         "@aws-sdk/credential-provider-env": "^3.972.8",
@@ -775,7 +791,7 @@
         "@aws-sdk/credential-provider-process": "^3.972.8",
         "@aws-sdk/credential-provider-sso": "^3.972.8",
         "@aws-sdk/credential-provider-web-identity": "^3.972.8",
-        "@aws-sdk/nested-clients": "3.990.0",
+        "@aws-sdk/nested-clients": "3.991.0",
         "@aws-sdk/types": "^3.973.1",
         "@smithy/config-resolver": "^4.4.6",
         "@smithy/core": "^3.23.0",
@@ -783,6 +799,55 @@
         "@smithy/node-config-provider": "^4.3.8",
         "@smithy/property-provider": "^4.2.8",
         "@smithy/types": "^4.12.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/credential-providers/node_modules/@aws-sdk/nested-clients": {
+      "version": "3.991.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.991.0.tgz",
+      "integrity": "sha512-vCWX2O4Kf9h0BviR46r2kc9cAv9twcxDCW9Rlszjkxg0+QN3ji0Q68OVfFZKZYx1BIPkPaWwjeMFB3iUtyyC3w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-crypto/sha256-browser": "5.2.0",
+        "@aws-crypto/sha256-js": "5.2.0",
+        "@aws-sdk/core": "^3.973.10",
+        "@aws-sdk/middleware-host-header": "^3.972.3",
+        "@aws-sdk/middleware-logger": "^3.972.3",
+        "@aws-sdk/middleware-recursion-detection": "^3.972.3",
+        "@aws-sdk/middleware-user-agent": "^3.972.10",
+        "@aws-sdk/region-config-resolver": "^3.972.3",
+        "@aws-sdk/types": "^3.973.1",
+        "@aws-sdk/util-endpoints": "3.991.0",
+        "@aws-sdk/util-user-agent-browser": "^3.972.3",
+        "@aws-sdk/util-user-agent-node": "^3.972.8",
+        "@smithy/config-resolver": "^4.4.6",
+        "@smithy/core": "^3.23.0",
+        "@smithy/fetch-http-handler": "^5.3.9",
+        "@smithy/hash-node": "^4.2.8",
+        "@smithy/invalid-dependency": "^4.2.8",
+        "@smithy/middleware-content-length": "^4.2.8",
+        "@smithy/middleware-endpoint": "^4.4.14",
+        "@smithy/middleware-retry": "^4.4.31",
+        "@smithy/middleware-serde": "^4.2.9",
+        "@smithy/middleware-stack": "^4.2.8",
+        "@smithy/node-config-provider": "^4.3.8",
+        "@smithy/node-http-handler": "^4.4.10",
+        "@smithy/protocol-http": "^5.3.8",
+        "@smithy/smithy-client": "^4.11.3",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-base64": "^4.3.0",
+        "@smithy/util-body-length-browser": "^4.2.0",
+        "@smithy/util-body-length-node": "^4.2.1",
+        "@smithy/util-defaults-mode-browser": "^4.3.30",
+        "@smithy/util-defaults-mode-node": "^4.2.33",
+        "@smithy/util-endpoints": "^3.2.8",
+        "@smithy/util-middleware": "^4.2.8",
+        "@smithy/util-retry": "^4.2.8",
+        "@smithy/util-utf8": "^4.2.0",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -963,6 +1028,22 @@
         "node": ">=20.0.0"
       }
     },
+    "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.990.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.990.0.tgz",
+      "integrity": "sha512-kVwtDc9LNI3tQZHEMNbkLIOpeDK8sRSTuT8eMnzGY+O+JImPisfSTjdh+jw9OTznu+MYZjQsv0258sazVKunYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-endpoints": "^3.2.8",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
     "node_modules/@aws-sdk/nested-clients": {
       "version": "3.990.0",
       "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.990.0.tgz",
@@ -1006,6 +1087,22 @@
         "@smithy/util-middleware": "^4.2.8",
         "@smithy/util-retry": "^4.2.8",
         "@smithy/util-utf8": "^4.2.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
+      "version": "3.990.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.990.0.tgz",
+      "integrity": "sha512-kVwtDc9LNI3tQZHEMNbkLIOpeDK8sRSTuT8eMnzGY+O+JImPisfSTjdh+jw9OTznu+MYZjQsv0258sazVKunYg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@aws-sdk/types": "^3.973.1",
+        "@smithy/types": "^4.12.0",
+        "@smithy/url-parser": "^4.2.8",
+        "@smithy/util-endpoints": "^3.2.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1067,12 +1164,12 @@
       }
     },
     "node_modules/@aws-sdk/s3-presigned-post": {
-      "version": "3.990.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-presigned-post/-/s3-presigned-post-3.990.0.tgz",
-      "integrity": "sha512-vKmZRjfdC3cWiVf0r4z73CXV+q1nXtXFJSSKOsVAHeKfQA7vmbYOCapaMrej8XVjR6EKEd447JRVNgGHZU4/7A==",
+      "version": "3.991.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-presigned-post/-/s3-presigned-post-3.991.0.tgz",
+      "integrity": "sha512-sEqffLERaEGocTett6iXQRVZ631bGEA8Em+RORINpTlhwQ9MwRGE36OXJywxx/ndaR6DZk41H89E0Jh7goHj/A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/client-s3": "3.990.0",
+        "@aws-sdk/client-s3": "3.991.0",
         "@aws-sdk/types": "^3.973.1",
         "@aws-sdk/util-format-url": "^3.972.3",
         "@smithy/middleware-endpoint": "^4.4.14",
@@ -1087,12 +1184,12 @@
       }
     },
     "node_modules/@aws-sdk/s3-request-presigner": {
-      "version": "3.990.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.990.0.tgz",
-      "integrity": "sha512-cex+QPepH6a2gPBERvOnbPxxLeAtp1P1smnCVzxZ236YBy5XeIBMGySknrG7WZoCu9CqiXv1sfI/+sJPcM7QdQ==",
+      "version": "3.991.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/s3-request-presigner/-/s3-request-presigner-3.991.0.tgz",
+      "integrity": "sha512-oceVy3lBPiJJMcuKjap0Zp3+X9rwwcStrFu23iFcoHdVYuu4jejPNnC0nUOIschi/odX9V60gX9DyYzd3GPWnQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/signature-v4-multi-region": "3.990.0",
+        "@aws-sdk/signature-v4-multi-region": "3.991.0",
         "@aws-sdk/types": "^3.973.1",
         "@aws-sdk/util-format-url": "^3.972.3",
         "@smithy/middleware-endpoint": "^4.4.14",
@@ -1106,9 +1203,9 @@
       }
     },
     "node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.990.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.990.0.tgz",
-      "integrity": "sha512-O55s1eFmKi+2Ko5T1hbdxL6tFVONGscSVe9VRxS4m91Tlbo9iG2Q2HvKWq1DuKQAuUWSUfMmjrRt07JNzizr2A==",
+      "version": "3.991.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.991.0.tgz",
+      "integrity": "sha512-sW+BcPs/RgqsdlrN3YrYr2Q1hEQjT9DY7B0edhZeaEt2WdFQoh+QfBDhlHPCvkJyxbF9BAW8CjJDhvIQYUrx3A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/middleware-sdk-s3": "^3.972.10",
@@ -1166,9 +1263,9 @@
       }
     },
     "node_modules/@aws-sdk/util-endpoints": {
-      "version": "3.990.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.990.0.tgz",
-      "integrity": "sha512-kVwtDc9LNI3tQZHEMNbkLIOpeDK8sRSTuT8eMnzGY+O+JImPisfSTjdh+jw9OTznu+MYZjQsv0258sazVKunYg==",
+      "version": "3.991.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.991.0.tgz",
+      "integrity": "sha512-m8tcZ3SbqG3NRDv0Py3iBKdb4/FlpOCP4CQ6wRtsk4vs3UypZ0nFdZwCRVnTN7j+ldj+V72xVi/JBlxFBDE7Sg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/types": "^3.973.1",
@@ -5469,9 +5566,9 @@
       }
     },
     "node_modules/@scality/data-browser-library": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.0.6.tgz",
-      "integrity": "sha512-xwyExeHewIJPiESEZiUFhGq5SvgqeICCX8H6UIC0ga6uIMFYBx2h5gph6OGRX38t41RDcWNO0I3/EdKInKDckg==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.0.7.tgz",
+      "integrity": "sha512-khpGoOUYA5zgT2Jl6hfwswn3lAMcAttmBrrXFP9IBi71G1iiagFmtFiYgfKxZvD8y5PsGmpHMSZdKjcmBQBhGg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.983.0",

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "@monaco-editor/react": "^4.4.5",
     "@scality/certchain": "1.4.0",
     "@scality/core-ui": "0.197.0",
-    "@scality/data-browser-library": "1.0.6",
+    "@scality/data-browser-library": "1.0.7",
     "@scality/module-federation": "1.6.1",
     "@scality/react-chained-query": "^2.1.0",
     "@types/react-table": "^7.7.10",

--- a/src/react/ISV/constants.ts
+++ b/src/react/ISV/constants.ts
@@ -1,13 +1,13 @@
 export const BUCKET_TAG_VEEAM_APPLICATION = 'X-Scality-Veeam-Application';
 export const BUCKET_TAG_APPLICATION = 'X-Scality-Application';
 export const VEEAM_BACKUP_REPLICATION = 'Veeam Backup & Replication';
-export const VEEAM_BACKUP_REPLICATION_XML_VALUE =
-  'Veeam Backup &#38; Replication';
+export const VEEAM_BACKUP_REPLICATION_XML_VALUE = 'Veeam Backup &#38; Replication';
 export const VEEAM_OFFICE_365 = 'Veeam Backup for Microsoft 365 (v6, v7)';
 export const VEEAM_OFFICE_365_V8 = 'Veeam Backup for Microsoft 365 (v8+)';
 export const VEEAM_VBO_APPLICATION = 'Veeam Backup for Microsoft 365';
 export const VEEAM_IMMUTABLE_POLICY_NAME = 'Scality-Veeam-Immutable-Policy';
 export const COMMVAULT_APPLICATION = 'Commvault';
+export const KASTEN_APPLICATION = 'Kasten';
 export const GET_VEEAM_IMMUTABLE_POLICY = (bucketName: string) =>
   JSON.stringify({
     Version: '2012-10-17',
@@ -30,10 +30,7 @@ export const GET_VEEAM_IMMUTABLE_POLICY = (bucketName: string) =>
           's3:PutObjectLegalHold',
           's3:DeleteObjectVersion',
         ],
-        Resource: [
-          `arn:aws:s3:::${bucketName}/*`,
-          `arn:aws:s3:::${bucketName}`,
-        ],
+        Resource: [`arn:aws:s3:::${bucketName}/*`, `arn:aws:s3:::${bucketName}`],
       },
       {
         Sid: 'VisualEditor1',
@@ -58,10 +55,7 @@ export const GET_VEEAM_NON_IMMUTABLE_POLICY = (bucketName: string) =>
           's3:GetBucketVersioning',
           's3:GetBucketObjectLockConfiguration',
         ],
-        Resource: [
-          `arn:aws:s3:::${bucketName}/*`,
-          `arn:aws:s3:::${bucketName}`,
-        ],
+        Resource: [`arn:aws:s3:::${bucketName}/*`, `arn:aws:s3:::${bucketName}`],
       },
       {
         Sid: 'SecureBucketPolicy1',

--- a/src/react/databrowser/utils/bucketApplicationDetector.ts
+++ b/src/react/databrowser/utils/bucketApplicationDetector.ts
@@ -2,9 +2,10 @@ import {
   BUCKET_TAG_APPLICATION,
   BUCKET_TAG_VEEAM_APPLICATION,
   COMMVAULT_APPLICATION,
+  KASTEN_APPLICATION,
   VEEAM_BACKUP_REPLICATION,
-  VeeamApplicationType,
   VEEAM_VBO_APPLICATION,
+  VeeamApplicationType,
 } from '../../ISV/constants';
 
 /**
@@ -30,9 +31,7 @@ export type BucketApplicationInfo = {
  * @param tags - Bucket tags as key-value pairs
  * @returns Application information including display name and feature flags
  */
-export function detectBucketApplication(
-  tags: Record<string, string>,
-): BucketApplicationInfo {
+export function detectBucketApplication(tags: Record<string, string>): BucketApplicationInfo {
   const modernTag = tags[BUCKET_TAG_APPLICATION];
   const legacyVeeamTag = tags[BUCKET_TAG_VEEAM_APPLICATION];
 
@@ -44,7 +43,15 @@ export function detectBucketApplication(
     };
   }
 
-  // Priority 2: Veeam (check both modern and legacy tags)
+  // Priority 2: Kasten
+  if (modernTag === KASTEN_APPLICATION) {
+    return {
+      displayName: KASTEN_APPLICATION,
+      shouldShowVeeamCapacity: false,
+    };
+  }
+
+  // Priority 3: Veeam (check both modern and legacy tags)
   if (isVeeamApplication(modernTag) || isVeeamApplication(legacyVeeamTag)) {
     return {
       displayName: modernTag || legacyVeeamTag,
@@ -52,7 +59,7 @@ export function detectBucketApplication(
     };
   }
 
-  // Priority 3: Generic S3 or other modern ISV applications
+  // Priority 4: Generic S3 or other modern ISV applications
   return {
     displayName: modernTag || 'S3 Generic',
     shouldShowVeeamCapacity: false,


### PR DESCRIPTION
## Summary

- Add `KASTEN_APPLICATION` constant and integrate Kasten detection into bucket application detection logic
- Bump `@scality/data-browser-library` from 1.0.6 to 1.0.7

## Changes

### Kasten Application Support
- Introduced `KASTEN_APPLICATION` constant in `src/react/ISV/constants.ts`
- Updated `detectBucketApplication()` in `bucketApplicationDetector.ts` to recognize Kasten-tagged buckets (via `X-Scality-Application: Kasten`) as a distinct ISV application
- Kasten is detected at priority 2, between Commvault (priority 1) and Veeam (priority 3)
- Kasten buckets do not show Veeam capacity indicators (`shouldShowVeeamCapacity: false`)

### Dependency Update
- Bumped `@scality/data-browser-library` to 1.0.7

## Files Changed

| File | Change |
|------|--------|
| `src/react/ISV/constants.ts` | Added `KASTEN_APPLICATION` constant, minor formatting cleanup |
| `src/react/databrowser/utils/bucketApplicationDetector.ts` | Added Kasten detection logic, updated priority comments |
| `package.json` | Bumped `@scality/data-browser-library` to 1.0.7 |
| `package-lock.json` | Lock file update |

## Test Plan

- [x] Verify buckets tagged with `X-Scality-Application: Kasten` are correctly identified as Kasten application
- [x] Verify Kasten buckets do not display Veeam capacity indicators
- [x] Verify existing Commvault and Veeam detection still works correctly
- [x] Verify data-browser-library upgrade introduces no regressions