### PR TITLE
Add Veeam Credential Management Context

### DIFF
--- a/src/react/ISV/contexts/VeeamCredentialContext.tsx
+++ b/src/react/ISV/contexts/VeeamCredentialContext.tsx
@@ -1,0 +1,88 @@
+import { createContext, useContext, useMemo } from 'react';
+import type { UseMutationResult } from 'react-query';
+import { useQueryClient } from 'react-query';
+import {
+  type ArtescaLibraryHooks,
+  ArtescaLibraryNotAvailable,
+  type NewCredentialsStatus,
+  useArtescaLibrary,
+} from '../../next-architecture/ui/ArtescaLibraryProvider';
+
+type VeeamCredentialContextValue = {
+  isCredentialsValid: boolean;
+  isCheckingCredentials: boolean;
+  isCredentialCheckError: boolean;
+  changeCredentialsMutation: UseMutationResult<
+    unknown,
+    unknown,
+    { username: string; password: string }
+  > | null;
+  newCredentialsStatus: NewCredentialsStatus;
+};
+
+const VeeamCredentialContext =
+  createContext<VeeamCredentialContextValue | null>(null);
+
+const VeeamCredentialProviderInternal = ({
+  children,
+  artescaLibrary,
+}: {
+  children: React.ReactNode;
+  artescaLibrary: ArtescaLibraryHooks;
+}) => {
+  const queryClient = useQueryClient();
+
+  const validationResult = artescaLibrary.useIsVeeamCredentialsValid();
+
+  const updateResult = artescaLibrary.useChangeVeeamCredentials({
+    onNewCredentialsValid: () => {
+      queryClient.invalidateQueries(['veeam_credential_valid']);
+    },
+  });
+
+  const value = useMemo(
+    () => ({
+      isCredentialsValid:
+        validationResult.data?.isVeeamCredentialsValid ?? true,
+      isCheckingCredentials: validationResult.isLoading,
+      isCredentialCheckError: validationResult.isError,
+      changeCredentialsMutation: updateResult.changeCredentialsMutation,
+      newCredentialsStatus: updateResult.newCredentialsStatus,
+    }),
+    [validationResult, updateResult],
+  );
+
+  return (
+    <VeeamCredentialContext.Provider value={value}>
+      {children}
+    </VeeamCredentialContext.Provider>
+  );
+};
+
+export const VeeamCredentialProvider = ({
+  children,
+}: {
+  children: React.ReactNode;
+}) => {
+  const artescaLibrary = useArtescaLibrary();
+
+  if (artescaLibrary instanceof ArtescaLibraryNotAvailable) {
+    return <>{children}</>;
+  }
+
+  return (
+    <VeeamCredentialProviderInternal artescaLibrary={artescaLibrary}>
+      {children}
+    </VeeamCredentialProviderInternal>
+  );
+};
+
+export const useVeeamCredentialManagement = () => {
+  const context = useContext(VeeamCredentialContext);
+  if (!context) {
+    throw new Error(
+      'useVeeamCredentialManagement must be used within VeeamCredentialProvider',
+    );
+  }
+  return context;
+};

--- a/src/react/ISV/hooks/useVeeamCredentialManagement.test.tsx
+++ b/src/react/ISV/hooks/useVeeamCredentialManagement.test.tsx
@@ -1,0 +1,165 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { ReactNode } from 'react';
+import type { UseMutationResult } from 'react-query';
+import { useQueryClient } from 'react-query';
+import {
+  ArtescaLibraryNotAvailable,
+  useArtescaLibrary,
+  type ArtescaLibraryHooks,
+} from '../../next-architecture/ui/ArtescaLibraryProvider';
+import {
+  VeeamCredentialProvider,
+  useVeeamCredentialManagement,
+} from '../contexts/VeeamCredentialContext';
+
+jest.mock('react-query');
+jest.mock('../../next-architecture/ui/ArtescaLibraryProvider');
+
+const mockUseQueryClient = useQueryClient as jest.MockedFunction<
+  typeof useQueryClient
+>;
+const mockUseArtescaLibrary = useArtescaLibrary as jest.MockedFunction<
+  typeof useArtescaLibrary
+>;
+
+describe('useVeeamCredentialManagement', () => {
+  const mockChangeCredentialsMutation = {
+    mutate: jest.fn(),
+  } as unknown as UseMutationResult<
+    unknown,
+    unknown,
+    { username: string; password: string }
+  >;
+  const mockUseIsVeeamCredentialsValid = jest.fn();
+  const mockUseChangeVeeamCredentials = jest.fn();
+
+  const mockArtescaLibrary: ArtescaLibraryHooks = {
+    useIsVeeamCredentialsValid: mockUseIsVeeamCredentialsValid,
+    useChangeVeeamCredentials: mockUseChangeVeeamCredentials,
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseQueryClient.mockReturnValue({
+      invalidateQueries: jest.fn(),
+    } as any);
+  });
+
+  const wrapper = ({ children }: { children: ReactNode }) => (
+    <VeeamCredentialProvider>{children}</VeeamCredentialProvider>
+  );
+
+  describe('when Artesca library is available', () => {
+    beforeEach(() => {
+      mockUseArtescaLibrary.mockReturnValue(mockArtescaLibrary);
+    });
+
+    it('should return valid credentials status when credentials are valid', () => {
+      mockUseIsVeeamCredentialsValid.mockReturnValue({
+        data: { isVeeamCredentialsValid: true },
+        isLoading: false,
+        isError: false,
+      });
+
+      mockUseChangeVeeamCredentials.mockReturnValue({
+        changeCredentialsMutation: mockChangeCredentialsMutation,
+        newCredentialsStatus: 'IDLE',
+      });
+
+      const { result } = renderHook(() => useVeeamCredentialManagement(), {
+        wrapper,
+      });
+
+      expect(result.current.isCredentialsValid).toBe(true);
+      expect(result.current.isCheckingCredentials).toBe(false);
+      expect(result.current.isCredentialCheckError).toBe(false);
+      expect(result.current.changeCredentialsMutation).toBe(
+        mockChangeCredentialsMutation,
+      );
+    });
+
+    it('should return invalid credentials status when credentials are invalid', () => {
+      mockUseIsVeeamCredentialsValid.mockReturnValue({
+        data: { isVeeamCredentialsValid: false },
+        isLoading: false,
+        isError: false,
+      });
+
+      mockUseChangeVeeamCredentials.mockReturnValue({
+        changeCredentialsMutation: mockChangeCredentialsMutation,
+        newCredentialsStatus: 'IDLE',
+      });
+
+      const { result } = renderHook(() => useVeeamCredentialManagement(), {
+        wrapper,
+      });
+
+      expect(result.current.isCredentialsValid).toBe(false);
+      expect(result.current.changeCredentialsMutation).toBeDefined();
+    });
+
+    it('should indicate when checking credentials is in progress', () => {
+      mockUseIsVeeamCredentialsValid.mockReturnValue({
+        data: undefined,
+        isLoading: true,
+        isError: false,
+      });
+
+      mockUseChangeVeeamCredentials.mockReturnValue({
+        changeCredentialsMutation: mockChangeCredentialsMutation,
+        newCredentialsStatus: 'IDLE',
+      });
+
+      const { result } = renderHook(() => useVeeamCredentialManagement(), {
+        wrapper,
+      });
+
+      expect(result.current.isCheckingCredentials).toBe(true);
+    });
+
+    it('should provide credential update mutation with all status states', () => {
+      mockUseIsVeeamCredentialsValid.mockReturnValue({
+        data: { isVeeamCredentialsValid: false },
+        isLoading: false,
+        isError: false,
+      });
+
+      const statuses = [
+        'IDLE',
+        'WAITING',
+        'VALID',
+        'INVALID',
+        'ERROR',
+      ] as const;
+
+      statuses.forEach((status) => {
+        mockUseChangeVeeamCredentials.mockReturnValue({
+          changeCredentialsMutation: mockChangeCredentialsMutation,
+          newCredentialsStatus: status,
+        });
+
+        const { result } = renderHook(() => useVeeamCredentialManagement(), {
+          wrapper,
+        });
+
+        expect(result.current.newCredentialsStatus).toBe(status);
+      });
+    });
+  });
+
+  describe('when Artesca library is not available', () => {
+    beforeEach(() => {
+      mockUseArtescaLibrary.mockReturnValue(new ArtescaLibraryNotAvailable());
+    });
+
+    it('should render children without providing context', () => {
+      const { result } = renderHook(() => useVeeamCredentialManagement(), {
+        wrapper,
+      });
+
+      expect(() => result.current).toThrow(
+        'useVeeamCredentialManagement must be used within',
+      );
+    });
+  });
+});

--- a/src/react/next-architecture/ui/ArtescaLibraryProvider.tsx
+++ b/src/react/next-architecture/ui/ArtescaLibraryProvider.tsx
@@ -1,10 +1,34 @@
 import { ErrorPage500 } from '@scality/core-ui/dist/components/error-pages/ErrorPage500.component';
 import * as ModuleFederation from '@scality/module-federation';
 import { ErrorBoundary } from 'react-error-boundary';
+import type { UseMutationResult } from 'react-query';
+
+export type NewCredentialsStatus =
+  | 'IDLE'
+  | 'WAITING'
+  | 'VALID'
+  | 'INVALID'
+  | 'ERROR';
+
 export type ArtescaLibraryHooks = {
   useArtescaPlusVeeamDefaultOrOpenMode: () => {
     artescaPlusVeeamDefaultOrOpenMode: 'default' | 'open' | null;
     artescaPlusVeeamDefaultOrOpenModeStatus: 'loading' | 'error' | 'success';
+  };
+  useIsVeeamCredentialsValid: () => {
+    data: { isVeeamCredentialsValid: boolean } | undefined;
+    isLoading: boolean;
+    isError: boolean;
+  };
+  useChangeVeeamCredentials: (params: {
+    onNewCredentialsValid: () => void;
+  }) => {
+    changeCredentialsMutation: UseMutationResult<
+      unknown,
+      unknown,
+      { username: string; password: string }
+    >;
+    newCredentialsStatus: NewCredentialsStatus;
   };
   ARTESCA_PLUS_VEEAM_S3_ENDPOINT_NAME: string;
 };


### PR DESCRIPTION
# Add Veeam Credential Management Context

## What This Brings

This PR establishes the foundation for inline Veeam credential validation in the ISV Assistant by creating a Context-based credential management system. Users will be able to validate and update their Veeam VBR credentials directly within the ISV configuration form.

## How It Works

### Type Definitions
Extended `ArtescaLibraryHooks` to include two new federated hooks from Artesca:
- `useIsVeeamCredentialsValid` - validates current credentials
- `useChangeVeeamCredentials` - handles credential updates

These hooks are consumed via module federation, allowing Zenko-UI to use Artesca's credential management logic.

### Context Architecture
Created `VeeamCredentialContext` that provides credential state to the ISV form:
- **Two-component provider pattern**: Outer wrapper checks Artesca library availability, inner component calls hooks unconditionally (satisfies React Rules of Hooks)
- **Credential validation state**: `isCredentialsValid`, `isCheckingCredentials`, `isCredentialCheckError`
- **Update mutation**: Exposes mutation and status states (IDLE, WAITING, VALID, INVALID, ERROR)
- **Graceful degradation**: Returns children unchanged when Artesca library is unavailable


## Changes from Plan

**Initial approach**: Created a hook that took `artescaLibrary` as a parameter
- **Issue**: Conditional hook calls violated React Rules of Hooks

**Revised approach**: Implemented Context pattern
- Provides cleaner API for consuming components
- Single source of truth for credential state

## What's Next

**Step 3**: Create `VeeamCredentialFields` component
- Username/password input fields
- Real-time validation feedback
- Credential update UI

**Step 4**: Update Veeam-VBR platform configuration
- Integrate VeeamCredentialFields into ISV form
- Add VeeamCredentialProvider to component tree

Reference : https://docs.google.com/document/d/1mGuksnwOEH8PHd05jbVL-FqXY4zJsbPkXyOqjVqYUyk/edit?tab=t.0#heading=h.us6u22i3r0xl