### PR TITLE
feat(components): add VeeamCredentialFields

### DIFF
--- a/src/react/ISV/components/ISVConfiguration.tsx
+++ b/src/react/ISV/components/ISVConfiguration.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { Fragment, useState } from 'react';
 import { useBasenameRelativeNavigate } from '@scality/module-federation';
 import { Form, FormSection, Icon, Stack } from '@scality/core-ui';
 import { Box, Button } from '@scality/core-ui/dist/next';
@@ -15,7 +15,6 @@ import { FormRenderer } from './FormRenderer';
 import { FormData, ISVPlatform } from '../engine/types';
 import { ISVFormProvider, useISVFormContext } from './ISVFormContext';
 import { useSearchParams } from 'react-router';
-import { VeeamCredentialProvider } from '../contexts/VeeamCredentialContext';
 
 type ISVConfigurationInnerProps = {
   formMethods: UseFormReturn<FormData>;
@@ -167,11 +166,13 @@ export const ISVConfiguration = () => {
     shouldUnregister: false,
   });
 
+  const ContextProvider = platform.contextProvider ?? Fragment;
+
   return (
-    <VeeamCredentialProvider>
+    <ContextProvider>
       <ISVFormProvider platform={platform} formMethods={formMethods}>
         <ISVConfigurationInner formMethods={formMethods} />
       </ISVFormProvider>
-    </VeeamCredentialProvider>
+    </ContextProvider>
   );
 };

--- a/src/react/ISV/components/ISVConfiguration.tsx
+++ b/src/react/ISV/components/ISVConfiguration.tsx
@@ -15,6 +15,7 @@ import { FormRenderer } from './FormRenderer';
 import { FormData, ISVPlatform } from '../engine/types';
 import { ISVFormProvider, useISVFormContext } from './ISVFormContext';
 import { useSearchParams } from 'react-router';
+import { VeeamCredentialProvider } from '../contexts/VeeamCredentialContext';
 
 type ISVConfigurationInnerProps = {
   formMethods: UseFormReturn<FormData>;
@@ -167,8 +168,10 @@ export const ISVConfiguration = () => {
   });
 
   return (
-    <ISVFormProvider platform={platform} formMethods={formMethods}>
-      <ISVConfigurationInner formMethods={formMethods} />
-    </ISVFormProvider>
+    <VeeamCredentialProvider>
+      <ISVFormProvider platform={platform} formMethods={formMethods}>
+        <ISVConfigurationInner formMethods={formMethods} />
+      </ISVFormProvider>
+    </VeeamCredentialProvider>
   );
 };

--- a/src/react/ISV/components/fields/VeeamCredentialFields.tsx
+++ b/src/react/ISV/components/fields/VeeamCredentialFields.tsx
@@ -10,13 +10,9 @@ import { Box, Button, Input } from '@scality/core-ui/dist/next';
 import { useState } from 'react';
 import { useVeeamCredentialManagement } from '../../contexts/VeeamCredentialContext';
 
-export const VeeamCredentialFields = () => {
-  const {
-    isCredentialsValid,
-    changeCredentialsMutation,
-    newCredentialsStatus,
-  } = useVeeamCredentialManagement();
-
+const VeeamCredentialFieldsForm = () => {
+  const { changeCredentialsMutation, newCredentialsStatus } =
+    useVeeamCredentialManagement();
   const { showToast } = useToast();
   const [username, setUsername] = useState('');
   const [password, setPassword] = useState('');
@@ -44,10 +40,6 @@ export const VeeamCredentialFields = () => {
       );
     }
   };
-
-  if (isCredentialsValid) {
-    return null;
-  }
 
   const isUpdating = newCredentialsStatus === 'WAITING';
 
@@ -121,4 +113,14 @@ export const VeeamCredentialFields = () => {
       </Box>
     </Stack>
   );
+};
+
+export const VeeamCredentialFields = () => {
+  const { isCredentialsValid } = useVeeamCredentialManagement();
+
+  if (isCredentialsValid) {
+    return null;
+  }
+
+  return <VeeamCredentialFieldsForm />;
 };

--- a/src/react/ISV/components/fields/VeeamCredentialFields.tsx
+++ b/src/react/ISV/components/fields/VeeamCredentialFields.tsx
@@ -1,0 +1,124 @@
+import {
+  Banner,
+  FormGroup,
+  Icon,
+  Stack,
+  Text,
+  useToast,
+} from '@scality/core-ui';
+import { Box, Button, Input } from '@scality/core-ui/dist/next';
+import { useState } from 'react';
+import { useVeeamCredentialManagement } from '../../contexts/VeeamCredentialContext';
+
+export const VeeamCredentialFields = () => {
+  const {
+    isCredentialsValid,
+    changeCredentialsMutation,
+    newCredentialsStatus,
+  } = useVeeamCredentialManagement();
+
+  const { showToast } = useToast();
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = () => {
+    if (changeCredentialsMutation && username && password) {
+      changeCredentialsMutation.mutate(
+        { username, password },
+        {
+          onSuccess: () => {
+            showToast({
+              open: true,
+              status: 'success',
+              message: 'Veeam credentials updated successfully',
+            });
+          },
+          onError: () => {
+            showToast({
+              open: true,
+              status: 'error',
+              message: 'Failed to update Veeam credentials. Please try again.',
+            });
+          },
+        },
+      );
+    }
+  };
+
+  if (isCredentialsValid) {
+    return null;
+  }
+
+  const isUpdating = newCredentialsStatus === 'WAITING';
+
+  return (
+    <Stack gap="r16" direction="vertical">
+      <Banner
+        variant="warning"
+        icon={<Icon name="Exclamation-circle" />}
+        title="Veeam Credentials required"
+      >
+        To automatically create the repository, ARTESCA needs credentials for a
+        Veeam Backup Administrator.
+        <br />
+        You can skip this by disabling the repository automatic creation, but
+        you will need to configure the repository in Veeam yourself.
+      </Banner>
+
+      <FormGroup
+        id="veeam-username"
+        label="Username"
+        required
+        helpErrorPosition="bottom"
+        content={
+          <Input
+            id="veeam-username"
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            disabled={isUpdating}
+          />
+        }
+      />
+
+      <FormGroup
+        id="veeam-password"
+        label="Password"
+        required
+        helpErrorPosition="bottom"
+        content={
+          <Input
+            id="veeam-password"
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            size="1"
+            disabled={isUpdating}
+          />
+        }
+      />
+
+      <Box
+        display="flex"
+        alignItems="baseline"
+        flexDirection="row"
+        gap="32"
+        justifyContent="flex-end"
+      >
+        <Stack direction="horizontal">
+          <Text variant="Smaller" color="textSecondary" isGentleEmphazed>
+            Note: Verification may take up to a minute to complete.
+          </Text>
+          <Button
+            type="button"
+            variant="primary"
+            label="Update Veeam credentials"
+            disabled={!username || !password}
+            isLoading={isUpdating}
+            onClick={handleSubmit}
+          />
+        </Stack>
+      </Box>
+    </Stack>
+  );
+};

--- a/src/react/ISV/components/fields/__tests__/VeeamCredentialFields.test.tsx
+++ b/src/react/ISV/components/fields/__tests__/VeeamCredentialFields.test.tsx
@@ -1,0 +1,192 @@
+import { Form, FormGroup, FormSection } from '@scality/core-ui';
+import { fireEvent, render, screen } from '@testing-library/react';
+import type React from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import type { UseMutationResult } from 'react-query';
+import { Wrapper } from '../../../../utils/testUtil';
+import { useVeeamCredentialManagement } from '../../../contexts/VeeamCredentialContext';
+import { VeeamCredentialFields } from '../VeeamCredentialFields';
+
+jest.mock('../../../contexts/VeeamCredentialContext');
+jest.mock('@scality/core-ui', () => ({
+  ...jest.requireActual('@scality/core-ui'),
+  useToast: jest.fn(() => ({ showToast: jest.fn() })),
+}));
+
+const mockUseVeeamCredentialManagement =
+  useVeeamCredentialManagement as jest.MockedFunction<
+    typeof useVeeamCredentialManagement
+  >;
+
+interface FormWrapperProps {
+  children: React.ReactNode;
+}
+
+const FormWrapper = ({ children }: FormWrapperProps) => {
+  const methods = useForm();
+
+  return (
+    <FormProvider {...methods}>
+      <Form
+        layout={{
+          kind: 'page',
+          title: 'Test Form',
+        }}
+      >
+        <FormSection>
+          <FormGroup id="test-wrapper" label="" content={<div>{children}</div>} />
+        </FormSection>
+      </Form>
+    </FormProvider>
+  );
+};
+
+describe('VeeamCredentialFields', () => {
+  const mockMutate = jest.fn();
+  const defaultMockValues = {
+    isCredentialsValid: false,
+    isCheckingCredentials: false,
+    isCredentialCheckError: false,
+    changeCredentialsMutation: {
+      mutate: mockMutate,
+      data: undefined,
+      error: null,
+      isError: false,
+      isIdle: true,
+      isLoading: false,
+      isSuccess: false,
+      status: 'idle' as const,
+      reset: jest.fn(),
+      mutateAsync: jest.fn(),
+    } as unknown as UseMutationResult<unknown, unknown, { username: string; password: string }>,
+    newCredentialsStatus: 'IDLE' as const,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('shows warning when credentials are invalid', () => {
+    mockUseVeeamCredentialManagement.mockReturnValue(defaultMockValues);
+
+    render(
+      <Wrapper>
+        <FormWrapper>
+          <VeeamCredentialFields />
+        </FormWrapper>
+      </Wrapper>,
+    );
+
+    expect(screen.getByText('Veeam Credentials required')).toBeInTheDocument();
+    expect(
+      screen.getByText(/To automatically create the repository/),
+    ).toBeInTheDocument();
+  });
+
+  it('renders username and password input fields', () => {
+    mockUseVeeamCredentialManagement.mockReturnValue(defaultMockValues);
+
+    const { container } = render(
+      <Wrapper>
+        <FormWrapper>
+          <VeeamCredentialFields />
+        </FormWrapper>
+      </Wrapper>,
+    );
+
+    expect(container.querySelector('#veeam-username')).toBeInTheDocument();
+    expect(container.querySelector('#veeam-password')).toBeInTheDocument();
+  });
+
+  it('submits credentials when validate button is clicked', () => {
+    mockUseVeeamCredentialManagement.mockReturnValue(defaultMockValues);
+
+    const { container } = render(
+      <Wrapper>
+        <FormWrapper>
+          <VeeamCredentialFields />
+        </FormWrapper>
+      </Wrapper>,
+    );
+
+    const usernameInput = container.querySelector('#veeam-username') as HTMLInputElement;
+    const passwordInput = container.querySelector('#veeam-password') as HTMLInputElement;
+    const submitButton = screen.getByRole('button', {
+      name: /Update Veeam credentials/,
+    });
+
+    fireEvent.change(usernameInput, { target: { value: 'testuser' } });
+    fireEvent.change(passwordInput, { target: { value: 'testpass' } });
+    fireEvent.click(submitButton);
+
+    expect(mockMutate).toHaveBeenCalledWith(
+      {
+        username: 'testuser',
+        password: 'testpass',
+      },
+      expect.objectContaining({
+        onSuccess: expect.any(Function),
+        onError: expect.any(Function),
+      }),
+    );
+  });
+
+  it('disables form during validation', () => {
+    mockUseVeeamCredentialManagement.mockReturnValue({
+      ...defaultMockValues,
+      newCredentialsStatus: 'WAITING',
+    });
+
+    render(
+      <Wrapper>
+        <FormWrapper>
+          <VeeamCredentialFields />
+        </FormWrapper>
+      </Wrapper>,
+    );
+
+    const inputs = screen.getAllByDisplayValue('');
+    expect(inputs[0]).toBeDisabled();
+    expect(inputs[1]).toBeDisabled();
+    expect(
+      screen.getByRole('button', { name: /Update Veeam credentials/ }),
+    ).toBeDisabled();
+  });
+
+  it('hides component when credentials are valid', () => {
+    mockUseVeeamCredentialManagement.mockReturnValue({
+      ...defaultMockValues,
+      isCredentialsValid: true,
+      newCredentialsStatus: 'IDLE',
+    });
+
+    render(
+      <Wrapper>
+        <FormWrapper>
+          <VeeamCredentialFields />
+        </FormWrapper>
+      </Wrapper>,
+    );
+
+    expect(screen.queryByText('Veeam Credentials required')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /Update Veeam credentials/ })).not.toBeInTheDocument();
+  });
+
+  it('disables submit button when fields are empty', () => {
+    mockUseVeeamCredentialManagement.mockReturnValue(defaultMockValues);
+
+    render(
+      <Wrapper>
+        <FormWrapper>
+          <VeeamCredentialFields />
+        </FormWrapper>
+      </Wrapper>,
+    );
+
+    const submitButton = screen.getByRole('button', {
+      name: /Update Veeam credentials/,
+    });
+
+    expect(submitButton).toBeDisabled();
+  });
+});

--- a/src/react/ISV/components/fields/index.ts
+++ b/src/react/ISV/components/fields/index.ts
@@ -1,3 +1,4 @@
-export { BucketArrayField } from './BucketArrayField';
 export { AccountSelectorField } from './AccountSelectorField';
+export { BucketArrayField } from './BucketArrayField';
 export { IAMUserSelectorField } from './IAMUserSelectorField';
+export { VeeamCredentialFields } from './VeeamCredentialFields';

--- a/src/react/ISV/contexts/VeeamCredentialContext.tsx
+++ b/src/react/ISV/contexts/VeeamCredentialContext.tsx
@@ -59,6 +59,14 @@ const VeeamCredentialProviderInternal = ({
   );
 };
 
+const defaultContextValue: VeeamCredentialContextValue = {
+  isCredentialsValid: true,
+  isCheckingCredentials: false,
+  isCredentialCheckError: false,
+  changeCredentialsMutation: null,
+  newCredentialsStatus: 'IDLE',
+};
+
 export const VeeamCredentialProvider = ({
   children,
 }: {
@@ -67,7 +75,11 @@ export const VeeamCredentialProvider = ({
   const artescaLibrary = useArtescaLibrary();
 
   if (artescaLibrary instanceof ArtescaLibraryNotAvailable) {
-    return <>{children}</>;
+    return (
+      <VeeamCredentialContext.Provider value={defaultContextValue}>
+        {children}
+      </VeeamCredentialContext.Provider>
+    );
   }
 
   return (

--- a/src/react/ISV/contexts/VeeamCredentialContext.tsx
+++ b/src/react/ISV/contexts/VeeamCredentialContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useMemo } from 'react';
-import type { UseMutationResult } from 'react-query';
+import { useQueryClient, type UseMutationResult } from 'react-query';
 import {
   type ArtescaLibraryHooks,
   ArtescaLibraryNotAvailable,
@@ -29,10 +29,13 @@ const VeeamCredentialProviderInternal = ({
   children: React.ReactNode;
   artescaLibrary: ArtescaLibraryHooks;
 }) => {
+  const queryClient = useQueryClient();
   const validationResult = artescaLibrary.useIsVeeamCredentialsValid();
 
   const updateResult = artescaLibrary.useChangeVeeamCredentials({
-    onNewCredentialsValid: () => {},
+    onNewCredentialsValid: () => {
+      queryClient.invalidateQueries(['veeam_credential_valid']);
+    },
   });
 
   const value = useMemo(

--- a/src/react/ISV/contexts/VeeamCredentialContext.tsx
+++ b/src/react/ISV/contexts/VeeamCredentialContext.tsx
@@ -1,6 +1,5 @@
 import { createContext, useContext, useMemo } from 'react';
 import type { UseMutationResult } from 'react-query';
-import { useQueryClient } from 'react-query';
 import {
   type ArtescaLibraryHooks,
   ArtescaLibraryNotAvailable,
@@ -30,14 +29,10 @@ const VeeamCredentialProviderInternal = ({
   children: React.ReactNode;
   artescaLibrary: ArtescaLibraryHooks;
 }) => {
-  const queryClient = useQueryClient();
-
   const validationResult = artescaLibrary.useIsVeeamCredentialsValid();
 
   const updateResult = artescaLibrary.useChangeVeeamCredentials({
-    onNewCredentialsValid: () => {
-      queryClient.invalidateQueries(['veeam_credential_valid']);
-    },
+    onNewCredentialsValid: () => {},
   });
 
   const value = useMemo(
@@ -60,6 +55,7 @@ const VeeamCredentialProviderInternal = ({
 };
 
 const defaultContextValue: VeeamCredentialContextValue = {
+  // When ArtescaLibrary is unavailable, credential validation doesn't apply.
   isCredentialsValid: true,
   isCheckingCredentials: false,
   isCredentialCheckError: false,

--- a/src/react/ISV/engine/definePlatform.ts
+++ b/src/react/ISV/engine/definePlatform.ts
@@ -119,5 +119,6 @@ export function definePlatform(config: PlatformConfig): ISVPlatform {
     assistant: config.assistant ?? true,
     application: config.application,
     disabledMessage: config.disabledMessage,
+    contextProvider: config.contextProvider,
   };
 }

--- a/src/react/ISV/engine/types.ts
+++ b/src/react/ISV/engine/types.ts
@@ -1,5 +1,5 @@
 import type Joi from 'joi';
-import type { ComponentType, ReactElement, ReactNode } from 'react';
+import type { ComponentType, FC, ReactElement, ReactNode } from 'react';
 import type { Control, FieldErrors } from 'react-hook-form';
 
 // ============================================================================
@@ -334,6 +334,7 @@ export type ISVPlatform = {
   assistant: boolean;
   application?: string;
   disabledMessage?: DisabledMessageComponent;
+  contextProvider?: FC<{ children: ReactNode }>;
 };
 
 // ============================================================================
@@ -396,4 +397,6 @@ export type PlatformConfig = {
   // Additional mutations to append after auto-generated mutations
   // Use this when you want the standard flow + additional steps at the end
   additionalMutations?: MutationDef[];
+
+  contextProvider?: FC<{ children: ReactNode }>;
 };

--- a/src/react/ISV/hooks/useVeeamCredentialManagement.test.tsx
+++ b/src/react/ISV/hooks/useVeeamCredentialManagement.test.tsx
@@ -152,14 +152,16 @@ describe('useVeeamCredentialManagement', () => {
       mockUseArtescaLibrary.mockReturnValue(new ArtescaLibraryNotAvailable());
     });
 
-    it('should render children without providing context', () => {
+    it('should provide default context treating credentials as valid', () => {
       const { result } = renderHook(() => useVeeamCredentialManagement(), {
         wrapper,
       });
 
-      expect(() => result.current).toThrow(
-        'useVeeamCredentialManagement must be used within',
-      );
+      expect(result.current.isCredentialsValid).toBe(true);
+      expect(result.current.isCheckingCredentials).toBe(false);
+      expect(result.current.isCredentialCheckError).toBe(false);
+      expect(result.current.changeCredentialsMutation).toBeNull();
+      expect(result.current.newCredentialsStatus).toBe('IDLE');
     });
   });
 });

--- a/src/react/ISV/platforms/veeam-vbr.tsx
+++ b/src/react/ISV/platforms/veeam-vbr.tsx
@@ -9,6 +9,7 @@ import {
   VeeamImmutableBackupTooltip,
 } from '../components/shared/PlatformTooltips';
 import { VeeamCredentialFields } from '../components/fields/VeeamCredentialFields';
+import { VeeamCredentialProvider } from '../contexts/VeeamCredentialContext';
 import { VeeamRepositoryFields } from '../components/VeeamRepositoryFields';
 import { VeeamRepositorySummary } from '../components/VeeamRepositorySummary';
 import { VeeamMultipleBucketCapture } from '../components/veeam/VeeamMultipleBucketCapture';
@@ -68,6 +69,7 @@ const VeeamBucketBanner = () => (
 
 export const VeeamVBRPlatform = definePlatform({
   id: 'veeam-vbr',
+  contextProvider: VeeamCredentialProvider,
   name: 'Veeam',
   logo: <VeeamLogo />,
   policy: GET_VEEAM_POLICY,

--- a/src/react/ISV/platforms/veeam-vbr.tsx
+++ b/src/react/ISV/platforms/veeam-vbr.tsx
@@ -8,6 +8,7 @@ import {
   CapacityTooltip,
   VeeamImmutableBackupTooltip,
 } from '../components/shared/PlatformTooltips';
+import { VeeamCredentialFields } from '../components/fields/VeeamCredentialFields';
 import { VeeamRepositoryFields } from '../components/VeeamRepositoryFields';
 import { VeeamRepositorySummary } from '../components/VeeamRepositorySummary';
 import { VeeamMultipleBucketCapture } from '../components/veeam/VeeamMultipleBucketCapture';
@@ -272,6 +273,12 @@ export const VeeamVBRPlatform = definePlatform({
         type: 'custom',
         label: '',
         render: () => <VeeamRepositoryFields />,
+      },
+      {
+        name: 'veeamCredentials',
+        type: 'custom',
+        label: '',
+        render: () => <VeeamCredentialFields />,
       },
     ],
   },


### PR DESCRIPTION
This PR adds inline credential validation to the Veeam Backup & Replication platform configuration flow. Users can now provide and validate Veeam administrator credentials directly within the configuration wizard, enabling automatic repository creation.

## What this brings

When configuring Veeam VBR in ARTESCA, users are now prompted to provide Veeam Backup Administrator credentials if they enable automatic repository creation. The system validates these credentials and provides immediate feedback, streamlining the setup process.

### Key features

- **Inline credential input**: Username and password fields appear in the configuration flow after repository settings
- **Automatic visibility**: Fields only display when credentials are required and hide once valid credentials are provided
- **Real-time feedback**: Toast notifications inform users of validation success or failure
- **Graceful degradation**: Users can skip credential entry by disabling automatic repository creation

## How it works

The credential validation integrates with the existing VeeamCredentialContext to check credential validity. When users enable automatic repository creation, they're prompted with a warning banner explaining why credentials are needed. After entering credentials and clicking "Update Veeam credentials", the system validates them against the Veeam server and provides feedback. Once validated, the fields disappear and the configuration flow continues.

## What's next

This completes the credential validation feature. No additional steps required.