### PR TITLE
Auto-scroll ISV action tracking table to latest entry

### DIFF
--- a/src/react/ISV/components/ISVApplyActions.tsx
+++ b/src/react/ISV/components/ISVApplyActions.tsx
@@ -16,6 +16,7 @@ import { useInstanceId } from '../../next-architecture/ui/AuthProvider';
 import { useMutationExecutor, buildRuntimeContext } from '../hooks/useMutationExecutor';
 import { ISVPlatform, FormData, BucketItem, OptionalFailure } from '../engine/types';
 import { useGetS3ServicePoint } from '../hooks/useGetS3ServicePoint';
+import { useAutoScrollOnce } from '../hooks/useAutoScrollOnce';
 
 const StatusBox = styled(Box)`
   display: flex;
@@ -53,6 +54,7 @@ const ChainStatusDisplay = memo(function ChainStatusDisplay({
   getResult: <T = unknown>(id: string) => T | undefined;
 }) {
   const [confirmCancel, setConfirmCancel] = useState(false);
+  const scrollContainerRef = useAutoScrollOnce();
   const theme = useTheme();
   const navigate = useBasenameRelativeNavigate();
   const queryClient = useQueryClient();
@@ -117,7 +119,7 @@ const ChainStatusDisplay = memo(function ChainStatusDisplay({
         style={{ width: '50rem' }}
       >
         <Stack gap="r16" direction="vertical">
-          <div style={{ height: '32rem', overflow: 'auto' }}>
+          <div ref={scrollContainerRef} style={{ height: '32rem', overflow: 'auto' }}>
             <Table>
               <T.Head>
                 <T.HeadRow style={{ display: 'flex' }}>

--- a/src/react/ISV/hooks/useAutoScrollOnce.test.ts
+++ b/src/react/ISV/hooks/useAutoScrollOnce.test.ts
@@ -1,0 +1,79 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { useAutoScrollOnce } from './useAutoScrollOnce';
+
+function createMockContainer(scrollHeight: number, clientHeight: number) {
+  const container = document.createElement('div');
+  Object.defineProperty(container, 'scrollHeight', { value: scrollHeight, configurable: true });
+  Object.defineProperty(container, 'clientHeight', { value: clientHeight, configurable: true });
+  return container;
+}
+
+const flushMicrotasks = () => new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+describe('useAutoScrollOnce', () => {
+  it('scrolls to the bottom immediately when content already overflows', () => {
+    const container = createMockContainer(1000, 400);
+    const { result } = renderHook(() => useAutoScrollOnce());
+
+    result.current(container);
+
+    expect(container.scrollTop).toBe(1000);
+  });
+
+  it('does not scroll when content fits without overflow', () => {
+    const container = createMockContainer(200, 400);
+    const { result } = renderHook(() => useAutoScrollOnce());
+
+    result.current(container);
+
+    expect(container.scrollTop).toBe(0);
+  });
+
+  it('scrolls once when content starts overflowing after DOM mutation', async () => {
+    const container = createMockContainer(200, 400);
+    const { result } = renderHook(() => useAutoScrollOnce());
+
+    result.current(container);
+    expect(container.scrollTop).toBe(0);
+
+    Object.defineProperty(container, 'scrollHeight', { value: 1000, configurable: true });
+    container.appendChild(document.createElement('div'));
+    await flushMicrotasks();
+
+    expect(container.scrollTop).toBe(1000);
+  });
+
+  it('does not scroll again after subsequent DOM mutations', async () => {
+    const container = createMockContainer(200, 400);
+    const { result } = renderHook(() => useAutoScrollOnce());
+
+    result.current(container);
+
+    Object.defineProperty(container, 'scrollHeight', { value: 1000, configurable: true });
+    container.appendChild(document.createElement('div'));
+    await flushMicrotasks();
+    expect(container.scrollTop).toBe(1000);
+
+    container.scrollTop = 200;
+
+    Object.defineProperty(container, 'scrollHeight', { value: 1200, configurable: true });
+    container.appendChild(document.createElement('div'));
+    await flushMicrotasks();
+
+    expect(container.scrollTop).toBe(200);
+  });
+
+  it('cleans up observer when called with null', async () => {
+    const container = createMockContainer(200, 400);
+    const { result } = renderHook(() => useAutoScrollOnce());
+
+    result.current(container);
+    result.current(null);
+
+    Object.defineProperty(container, 'scrollHeight', { value: 1000, configurable: true });
+    container.appendChild(document.createElement('div'));
+    await flushMicrotasks();
+
+    expect(container.scrollTop).toBe(0);
+  });
+});

--- a/src/react/ISV/hooks/useAutoScrollOnce.ts
+++ b/src/react/ISV/hooks/useAutoScrollOnce.ts
@@ -1,0 +1,31 @@
+import { useCallback, useRef } from 'react';
+
+export function useAutoScrollOnce() {
+  const observerRef = useRef<MutationObserver | null>(null);
+
+  const callbackRef = useCallback((node: HTMLDivElement | null) => {
+    if (observerRef.current) {
+      observerRef.current.disconnect();
+      observerRef.current = null;
+    }
+
+    if (!node) return;
+
+    if (node.scrollHeight > node.clientHeight) {
+      node.scrollTop = node.scrollHeight;
+      return;
+    }
+
+    observerRef.current = new MutationObserver(() => {
+      if (node.scrollHeight > node.clientHeight) {
+        node.scrollTop = node.scrollHeight;
+        observerRef.current?.disconnect();
+        observerRef.current = null;
+      }
+    });
+
+    observerRef.current.observe(node, { childList: true, subtree: true });
+  }, []);
+
+  return callbackRef;
+}


### PR DESCRIPTION
## Summary

- When the ISV assistant runs automatic configuration, the action tracking table now auto-scrolls to show the most recent entry as soon as the content overflows the visible area.
- The scroll happens once — after that, the user has full control over scrolling with no interference.

## Approach

A reusable `useAutoScrollOnce` hook observes the scroll container for DOM changes and scrolls to the bottom on first overflow, then stops observing. This keeps the component clean and the behavior self-contained, with no external dependency to manage.

## What changed from the initial plan

The initial ticket described auto-focus/auto-scroll behavior. During review, we chose a one-time scroll strategy instead of continuous auto-scroll, to avoid blocking the user from reviewing previous entries.

## Reference

[ZKUI-449](https://scality.atlassian.net/browse/ZKUI-449)

[ZKUI-449]: https://scality.atlassian.net/browse/ZKUI-449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ