### PR TITLE
fix(ZKUI-448): remove Veeam credential cache invalidation from zenko-ui

### DIFF
--- a/src/react/ISV/contexts/VeeamCredentialContext.tsx
+++ b/src/react/ISV/contexts/VeeamCredentialContext.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useMemo } from 'react';
-import { useQueryClient, type UseMutationResult } from 'react-query';
+import type { UseMutationResult } from 'react-query';
 import {
   type ArtescaLibraryHooks,
   ArtescaLibraryNotAvailable,
@@ -29,13 +29,10 @@ const VeeamCredentialProviderInternal = ({
   children: React.ReactNode;
   artescaLibrary: ArtescaLibraryHooks;
 }) => {
-  const queryClient = useQueryClient();
   const validationResult = artescaLibrary.useIsVeeamCredentialsValid();
 
   const updateResult = artescaLibrary.useChangeVeeamCredentials({
-    onNewCredentialsValid: () => {
-      queryClient.invalidateQueries(['veeam_credential_valid']);
-    },
+    onNewCredentialsValid: () => {},
   });
 
   const value = useMemo(

--- a/src/react/ISV/hooks/useVeeamCredentialManagement.test.tsx
+++ b/src/react/ISV/hooks/useVeeamCredentialManagement.test.tsx
@@ -1,7 +1,6 @@
 import { renderHook } from '@testing-library/react-hooks';
 import { ReactNode } from 'react';
 import type { UseMutationResult } from 'react-query';
-import { useQueryClient } from 'react-query';
 import {
   ArtescaLibraryNotAvailable,
   useArtescaLibrary,
@@ -12,12 +11,8 @@ import {
   useVeeamCredentialManagement,
 } from '../contexts/VeeamCredentialContext';
 
-jest.mock('react-query');
 jest.mock('../../next-architecture/ui/ArtescaLibraryProvider');
 
-const mockUseQueryClient = useQueryClient as jest.MockedFunction<
-  typeof useQueryClient
->;
 const mockUseArtescaLibrary = useArtescaLibrary as jest.MockedFunction<
   typeof useArtescaLibrary
 >;
@@ -40,9 +35,6 @@ describe('useVeeamCredentialManagement', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
-    mockUseQueryClient.mockReturnValue({
-      invalidateQueries: jest.fn(),
-    } as any);
   });
 
   const wrapper = ({ children }: { children: ReactNode }) => (
@@ -145,7 +137,8 @@ describe('useVeeamCredentialManagement', () => {
         expect(result.current.newCredentialsStatus).toBe(status);
       });
     });
-  });
+
+});
 
   describe('when Artesca library is not available', () => {
     beforeEach(() => {


### PR DESCRIPTION
## Summary

- Veeam credential cache invalidation was incorrectly handled in zenko-ui, but the Artesca library owns both the credential query and the mutation. This PR removes that responsibility from zenko-ui so cache invalidation lives where it belongs — in the Artesca library.

## What's next

- The Artesca library needs to implement the cache invalidation on its side when credentials are changed.

## Reference

[ZKUI-448](https://scality.atlassian.net/browse/ZKUI-448)

[ZKUI-448]: https://scality.atlassian.net/browse/ZKUI-448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ