### PR TITLE
ZKUI-458: Hide sidebar and breadcrumb on CORS, policy, and notification edit form pages

### DIFF
--- a/src/react/Routes.test.tsx
+++ b/src/react/Routes.test.tsx
@@ -266,6 +266,50 @@ describe('Routes component', () => {
     });
   });
 
+  describe('routeWithoutSideBars (form routes)', () => {
+    // Use empty basePath so pathname matches route as-is (test router has no basename)
+    const basePath = '';
+
+    beforeEach(() => {
+      mockUseConfig.mockReturnValue({
+        basePath,
+        features: [],
+        zenkoEndpoint: '/zenko/s3',
+        iamEndpoint: '/zenko/iam',
+        stsEndpoint: '/zenko/sts',
+        managementEndpoint: '/zenko/management',
+        s3InternalFQDN: 's3.test.local',
+        iamInternalFQDN: 'iam.test.local',
+      });
+    });
+
+    it('should hide sidebar and breadcrumb on simple form route (create-account)', async () => {
+      renderWithRouterMatch(<InternalRoutes />, {
+        path: '/*',
+        route: '/create-account',
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Create New Account')).toBeInTheDocument();
+      });
+      expect(selectors.dataServicesLink()).not.toBeInTheDocument();
+      expect(selectors.locationsLink()).not.toBeInTheDocument();
+    });
+
+    it('should hide sidebar and breadcrumb on complex form route (update-user)', async () => {
+      renderWithRouterMatch(<InternalRoutes />, {
+        path: '/*',
+        route: '/accounts/my-account/users/john/update-user',
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText('Edit a User')).toBeInTheDocument();
+      });
+      expect(selectors.dataServicesLink()).not.toBeInTheDocument();
+      expect(selectors.locationsLink()).not.toBeInTheDocument();
+    });
+  });
+
   describe('truststore routes', () => {
     it('should render Truststore route when Platform Admin and MetalK8s is enabled', async () => {
       // Mock the hook to return PlatformAdmin user

--- a/src/react/Routes.tsx
+++ b/src/react/Routes.tsx
@@ -333,6 +333,9 @@ function InternalRoutes() {
     '/accounts/:accountName/buckets/:bucketName/replication/create',
     '/accounts/:accountName/buckets/:bucketName/replication/edit/:ruleId',
     '/accounts/:accountName/buckets/:bucketName/notifications/create',
+    '/accounts/:accountName/buckets/:bucketName/notifications/edit/:ruleId',
+    '/accounts/:accountName/buckets/:bucketName/cors',
+    '/accounts/:accountName/buckets/:bucketName/policy',
   ];
 
   const hideSideBar = doesRouteMatch(routeWithoutSideBars);


### PR DESCRIPTION
## Context
Ticket: https://scality.atlassian.net/browse/ZKUI-458

## Problem
The breadcrumb component was incorrectly visible inside the CORS, bucket policy, and notification edit form pages. These form pages were missing from the `routeWithoutSideBars` list.

<img width="3024" height="1660" alt="image" src="https://github.com/user-attachments/assets/e10464f8-5d16-4d82-97fb-7a66ef5d16be" />


## Changes
Added the missing routes to `routeWithoutSideBars` in `Routes.tsx`

This hides the sidebar and breadcrumb on those pages, matching the behavior of other data-browser form pages (lifecycle, replication, notification create).