### PR TITLE
fix(isv): correct 3 dead ISV documentation links

### DIFF
--- a/src/react/ISV/ISVList.tsx
+++ b/src/react/ISV/ISVList.tsx
@@ -21,14 +21,14 @@ export const ISVList: ISVCardConfig[] = [
     id: 'zerto',
     name: 'Zerto',
     logo: <ZertoLogo />,
-    documentationLink: '/artesca/docs/partner_applications/backup_and_archives/zerto/zerto.html',
+    documentationLink: '/artesca/docs/partner_applications/backup_and_archives/zerto.html',
     category: 'backup-and-archive',
   },
   {
     id: 'splunk',
     name: 'Splunk',
     logo: <SplunkLogo />,
-    documentationLink: '/artesca/docs/partner_applications/backup_and_archives/splunk.html',
+    documentationLink: '/artesca/docs/partner_applications/big_data_storage/splunk.html',
     category: 'big-data-storage',
   },
   {

--- a/src/react/ISV/platforms/veeam-vbr.tsx
+++ b/src/react/ISV/platforms/veeam-vbr.tsx
@@ -73,7 +73,7 @@ export const VeeamVBRPlatform = definePlatform({
   name: 'Veeam',
   logo: <VeeamLogo />,
   policy: GET_VEEAM_POLICY,
-  documentationLink: '/artesca/docs/partner_applications/backup_and_archives/veeam/index.html',
+  documentationLink: '/artesca/docs/partner_applications/backup_and_archives/veeam_backup_and_replication/index.html',
   disabledMessage: VeeamVBRDisabledMessage,
   bucketTag: VEEAM_BACKUP_REPLICATION,
   application: VEEAM_BACKUP_REPLICATION,


### PR DESCRIPTION
## Summary
- **Splunk**: documentation link pointed to `backup_and_archives/splunk.html` but Splunk lives under `big_data_storage/splunk.html`
- **Zerto**: documentation link pointed to `backup_and_archives/zerto/zerto.html` instead of `backup_and_archives/zerto.html`
- **Veeam VBR**: documentation link pointed to `backup_and_archives/veeam/index.html` instead of `backup_and_archives/veeam_backup_and_replication/index.html`

All paths verified against the ARTESCA 4.1.2 documentation site. The remaining 9 ISV documentation links are correct.

## Test plan
- [x] Click each ISV card in the ISV modal and verify the documentation link opens the correct page without relying on redirects
