### PR TITLE
ZKUI-466: Bump data-browser-library to 1.1.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@scality/certchain": "1.4.0",
         "@scality/core-ui": "0.202.0",
-        "@scality/data-browser-library": "1.1.3",
+        "@scality/data-browser-library": "1.1.5",
         "@scality/module-federation": "1.6.1",
         "@scality/react-chained-query": "^2.1.0",
         "@types/react-table": "^7.7.10",
@@ -5690,9 +5690,9 @@
       }
     },
     "node_modules/@scality/data-browser-library": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.3.tgz",
-      "integrity": "sha512-JrRbQGyjs98pnRErY/35C0aJbc7puVcvE4P23CRFRXkhUyfMW7B+EfWBYTHNb/AxwtXjctmCmazLjce5UZ6VCA==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.5.tgz",
+      "integrity": "sha512-yvqPZsBtBm0hkOsGMlkhTMumJCUNE6uLsGKS7kezlHcFVwdhobYMH3ktRkhP/wPKX1ti5eSMd8lEp13PTZXhHA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.983.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@scality/certchain": "1.4.0",
     "@scality/core-ui": "0.202.0",
-    "@scality/data-browser-library": "1.1.3",
+    "@scality/data-browser-library": "1.1.5",
     "@scality/module-federation": "1.6.1",
     "@scality/react-chained-query": "^2.1.0",
     "@types/react-table": "^7.7.10",


### PR DESCRIPTION
## Summary
Automated bump of `@scality/data-browser-library`.

## Links
- Release: https://github.com/scality/data-browser/releases/tag/1.1.5
- Jira: https://scality.atlassian.net/browse/ZKUI-466

🤖 Generated by data-browser auto-bump