### PR TITLE
ZKUI-469: Bump data-browser-library to 1.1.7

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@scality/certchain": "1.4.0",
         "@scality/core-ui": "0.202.0",
-        "@scality/data-browser-library": "1.1.6",
+        "@scality/data-browser-library": "1.1.7",
         "@scality/module-federation": "1.6.1",
         "@scality/react-chained-query": "^2.1.0",
         "@types/react-table": "^7.7.10",
@@ -5690,9 +5690,9 @@
       }
     },
     "node_modules/@scality/data-browser-library": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.6.tgz",
-      "integrity": "sha512-NkNz5gQo715YFEpzFyyEPIjJJeuoxhwROhlimsPExvcu9CzXbz6I+RgK7J0SAaYUXg5DZFN6x1s3NTsGxVC3KA==",
+      "version": "1.1.7",
+      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.7.tgz",
+      "integrity": "sha512-HrUzEImWqs4gFlYjPdBJ7K2an/uVzMNoZotFsBm7GB/SSZVGp732k7LZzmvYesnRVaVxJ3LAkKZvjUZ3ZICIrw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.983.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@scality/certchain": "1.4.0",
     "@scality/core-ui": "0.202.0",
-    "@scality/data-browser-library": "1.1.6",
+    "@scality/data-browser-library": "1.1.7",
     "@scality/module-federation": "1.6.1",
     "@scality/react-chained-query": "^2.1.0",
     "@types/react-table": "^7.7.10",

--- a/src/react/DataServiceRoleProvider.tsx
+++ b/src/react/DataServiceRoleProvider.tsx
@@ -63,7 +63,7 @@ const useS3ConfigFromAssumeRoleResult = () => {
       endpoint,
       region: DEFAULT_REGION,
       forcePathStyle: true,
-      features: ['ISV', 'metadatasearch'],
+      features: ['ISV', 'metadatasearch', 'replicationV1'],
       cacheKey,
       proxy: {
         enabled: true,


### PR DESCRIPTION
## Summary
Automated bump of `@scality/data-browser-library`.

## Links
- Release: https://github.com/scality/data-browser/releases/tag/1.1.7
- Jira: https://scality.atlassian.net/browse/ZKUI-469

🤖 Generated by data-browser auto-bump