### PR TITLE
1.1.8: Bump data-browser-library to 1.1.8

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@scality/certchain": "1.4.0",
         "@scality/core-ui": "0.202.0",
-        "@scality/data-browser-library": "1.1.7",
+        "@scality/data-browser-library": "1.1.8",
         "@scality/module-federation": "1.6.1",
         "@scality/react-chained-query": "^2.1.0",
         "@types/react-table": "^7.7.10",
@@ -5690,9 +5690,9 @@
       }
     },
     "node_modules/@scality/data-browser-library": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.7.tgz",
-      "integrity": "sha512-HrUzEImWqs4gFlYjPdBJ7K2an/uVzMNoZotFsBm7GB/SSZVGp732k7LZzmvYesnRVaVxJ3LAkKZvjUZ3ZICIrw==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.8.tgz",
+      "integrity": "sha512-fu1CLE/6my4TXMbUkHhU7S1xnpkUirC2Hf1sgfgN/a+fTi2KCTr7dCMoa0n3QoQEc9d2wQJc7AG4pM9cxOkoVQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.983.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@scality/certchain": "1.4.0",
     "@scality/core-ui": "0.202.0",
-    "@scality/data-browser-library": "1.1.7",
+    "@scality/data-browser-library": "1.1.8",
     "@scality/module-federation": "1.6.1",
     "@scality/react-chained-query": "^2.1.0",
     "@types/react-table": "^7.7.10",


### PR DESCRIPTION
## Summary
Automated bump of `@scality/data-browser-library`.

## Links
- Release: https://github.com/scality/data-browser/releases/tag/1.1.8
- Jira: https://scality.atlassian.net/browse/1.1.8

🤖 Generated by data-browser auto-bump