### PR TITLE
ZKUI-471: Bump data-browser-library to 1.1.9

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@scality/certchain": "1.4.0",
         "@scality/core-ui": "0.202.0",
-        "@scality/data-browser-library": "1.1.8",
+        "@scality/data-browser-library": "1.1.9",
         "@scality/module-federation": "1.6.1",
         "@scality/react-chained-query": "^2.1.0",
         "@types/react-table": "^7.7.10",
@@ -5690,9 +5690,9 @@
       }
     },
     "node_modules/@scality/data-browser-library": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.8.tgz",
-      "integrity": "sha512-fu1CLE/6my4TXMbUkHhU7S1xnpkUirC2Hf1sgfgN/a+fTi2KCTr7dCMoa0n3QoQEc9d2wQJc7AG4pM9cxOkoVQ==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.9.tgz",
+      "integrity": "sha512-n9jAraypNnzuUDTOuQJdZR2Dic8u5qogtY4PwlBsVVd9ieeyshNgrdxVd+5/4/WYzVdYkCHxyNRuf1emQVLwcw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.983.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@scality/certchain": "1.4.0",
     "@scality/core-ui": "0.202.0",
-    "@scality/data-browser-library": "1.1.8",
+    "@scality/data-browser-library": "1.1.9",
     "@scality/module-federation": "1.6.1",
     "@scality/react-chained-query": "^2.1.0",
     "@types/react-table": "^7.7.10",


### PR DESCRIPTION
## Summary
Automated bump of `@scality/data-browser-library`.

## Links
- Release: https://github.com/scality/data-browser/releases/tag/1.1.9
- Jira: https://scality.atlassian.net/browse/ZKUI-471

🤖 Generated by data-browser auto-bump