### PR TITLE
refactor: redesign credential lifecycle with provider pattern and proactive refresh

### DIFF
--- a/src/react/DataServiceRoleProvider.tsx
+++ b/src/react/DataServiceRoleProvider.tsx
@@ -4,7 +4,7 @@ import type { AWSError, STS } from 'aws-sdk';
 import type { PromiseResult } from 'aws-sdk/lib/request';
 import { createContext, type JSX, useContext, useEffect, useMemo, useState } from 'react';
 import { flushSync } from 'react-dom';
-import { useMutation } from 'react-query';
+import { useQuery, useQueryClient } from 'react-query';
 import { useParams } from 'react-router';
 import { useTheme } from 'styled-components';
 import STSClient from '../js/STSClient';
@@ -195,7 +195,7 @@ const DataServiceRoleProvider = ({
   const accountName = params?.accountName;
   const theme = useTheme();
 
-  const { iamInternalFQDN, s3InternalFQDN, zenkoEndpoint, iamEndpoint } = useConfig();
+  const { iamInternalFQDN, s3InternalFQDN, zenkoEndpoint, iamEndpoint, stsEndpoint } = useConfig();
 
   useEffect(() => {
     initializeAWSSigner({
@@ -206,17 +206,29 @@ const DataServiceRoleProvider = ({
     });
   }, [iamInternalFQDN, s3InternalFQDN, zenkoEndpoint, iamEndpoint]);
 
-  const { getQuery } = useAssumeRoleQuery();
-  const [assumedRole, setAssumedRole] = useState<PromiseResult<STS.AssumeRoleWithWebIdentityResponse, AWSError>>();
-  const assumeRoleMutation = useMutation({
-    mutationFn: (roleArn: string) => getQuery(roleArn).queryFn(),
-    onSuccess: (data) => {
-      setAssumedRole(data);
-    },
-  });
-
   const { useAuth } = useShellHooks();
-  const { userData } = useAuth();
+  const { getToken, userData } = useAuth();
+  const roleSessionName = `ui-${userData?.id}`;
+  const stsClient = useMemo(() => new STSClient({ endpoint: stsEndpoint }), [stsEndpoint]);
+  const queryClient = useQueryClient();
+
+  const assumeRoleQuery = useQuery(
+    ['assumeRole', role.roleArn],
+    async () =>
+      stsClient.assumeRoleWithWebIdentity({
+        idToken: notFalsyTypeGuard(await getToken()),
+        roleArn: role.roleArn,
+        RoleSessionName: roleSessionName,
+      }),
+    {
+      enabled: !!role.roleArn,
+      refetchOnWindowFocus: true,
+      staleTime: 0,
+      refetchOnMount: false,
+    },
+  );
+
+  const assumedRole = assumeRoleQuery.data;
 
   useEffect(() => {
     const storedRole = getRoleArnStored();
@@ -241,12 +253,6 @@ const DataServiceRoleProvider = ({
     }
   }, [accounts.length, accountName, role.roleArn]);
 
-  useEffect(() => {
-    if (role.roleArn) {
-      assumeRoleMutation.mutate(role.roleArn);
-    }
-  }, [role.roleArn, userData?.token]);
-
   const { getS3Config } = useS3ConfigFromAssumeRoleResult();
 
   const s3Config = useMemo(() => getS3Config(assumedRole, role.roleArn), [assumedRole, getS3Config, role.roleArn]);
@@ -265,29 +271,29 @@ const DataServiceRoleProvider = ({
   const setRole = (role: { roleArn: string }) => {
     setRoleArnStored(role.roleArn);
     setRoleState(role);
-    if (role.roleArn) {
-      assumeRoleMutation.mutate(role.roleArn, {});
-    }
   };
 
-  const setRolePromise = async (role: { roleArn: string }): Promise<S3Config> => {
-    if (!role.roleArn) {
+  const setRolePromise = async (newRole: { roleArn: string }): Promise<S3Config> => {
+    if (!newRole.roleArn) {
       return Promise.reject('Invalid role arn');
     }
-    return getQuery(role.roleArn)
-      .queryFn()
-      .then((data) => {
-        // Use flushSync to force synchronous state updates
-        flushSync(() => {
-          setAssumedRole(data);
-          setRoleArnStored(role.roleArn);
-          setRoleState(role);
-        });
-        return getS3Config(data, role.roleArn);
-      });
+    const data = await queryClient.fetchQuery(
+      ['assumeRole', newRole.roleArn],
+      async () =>
+        stsClient.assumeRoleWithWebIdentity({
+          idToken: notFalsyTypeGuard(await getToken()),
+          roleArn: newRole.roleArn,
+          RoleSessionName: roleSessionName,
+        }),
+    );
+    flushSync(() => {
+      setRoleArnStored(newRole.roleArn);
+      setRoleState(newRole);
+    });
+    return getS3Config(data, newRole.roleArn);
   };
 
-  if (role.roleArn && !assumedRole) {
+  if (role.roleArn && assumeRoleQuery.isLoading) {
     //@ts-expect-error fix this when you are working on it
     return inlineLoader ? <div>loading...</div> : <Loader>Loading...</Loader>;
   }

--- a/src/react/DataServiceRoleProvider.tsx
+++ b/src/react/DataServiceRoleProvider.tsx
@@ -213,7 +213,6 @@ const DataServiceRoleProvider = ({
     {
       enabled: !!role.roleArn,
       refetchOnWindowFocus: true,
-      staleTime: 0,
       refetchOnMount: false,
     },
   );
@@ -256,12 +255,14 @@ const DataServiceRoleProvider = ({
   assumeRoleQueryRef.current = assumeRoleQuery;
 
   const refreshPromiseRef = useRef<Promise<S3Credentials> | null>(null);
+  const refreshCooldownUntilRef = useRef<number>(0);
+  const REFRESH_COOLDOWN_MS = 30 * 1000;
 
   const credentialProvider = useCallback(async (): Promise<S3Credentials> => {
     const expiration = assumeRoleQueryRef.current.data?.Credentials?.Expiration;
     const REFRESH_BUFFER_MS = 2 * 60 * 1000;
 
-    if (expiration && new Date(expiration).getTime() - Date.now() <= REFRESH_BUFFER_MS) {
+    if (expiration && new Date(expiration).getTime() - Date.now() <= REFRESH_BUFFER_MS && Date.now() >= refreshCooldownUntilRef.current) {
       if (!refreshPromiseRef.current) {
         refreshPromiseRef.current = assumeRoleQueryRef.current.refetch()
           .then((result) => {
@@ -277,9 +278,10 @@ const DataServiceRoleProvider = ({
           .catch((err) => {
             console.warn('STS credential refresh failed:', err);
             refreshPromiseRef.current = null;
+            refreshCooldownUntilRef.current = Date.now() + REFRESH_COOLDOWN_MS;
             return {
               ...(s3ConfigRef.current.credentials as S3Credentials),
-              expiration: new Date(),
+              expiration: expiration ? new Date(expiration) : undefined,
             };
           });
       }
@@ -351,4 +353,4 @@ const DataServiceRoleProvider = ({
 
 export default DataServiceRoleProvider;
 
-export { useAssumeRoleQuery, useS3ConfigFromAssumeRoleResult };
+export { useAssumeRoleQuery };

--- a/src/react/DataServiceRoleProvider.tsx
+++ b/src/react/DataServiceRoleProvider.tsx
@@ -277,11 +277,15 @@ const DataServiceRoleProvider = ({
   const getS3ConfigFn = useCallback(() => {
     const expiration = assumeRoleQueryRef.current.data?.Credentials?.Expiration;
 
-    if (expiration && new Date(expiration) <= new Date()) {
+    const REFRESH_BUFFER_MS = 2 * 60 * 1000;
+    if (expiration && new Date(expiration).getTime() - Date.now() <= REFRESH_BUFFER_MS) {
       if (!refreshPromiseRef.current) {
         refreshPromiseRef.current = assumeRoleQueryRef.current.refetch()
           .then(() => { refreshPromiseRef.current = null; })
-          .catch(() => { refreshPromiseRef.current = null; });
+          .catch((err) => {
+            console.warn('STS credential refresh failed:', err);
+            refreshPromiseRef.current = null;
+          });
       }
     }
 

--- a/src/react/DataServiceRoleProvider.tsx
+++ b/src/react/DataServiceRoleProvider.tsx
@@ -2,7 +2,7 @@ import { DataBrowserProvider, type S3BrowserConfig, type S3Credentials } from '@
 import { useShellHooks } from '@scality/module-federation';
 import type { AWSError, STS } from 'aws-sdk';
 import type { PromiseResult } from 'aws-sdk/lib/request';
-import { createContext, type JSX, useContext, useEffect, useMemo, useState } from 'react';
+import { createContext, type JSX, useCallback, useContext, useEffect, useMemo, useRef, useState } from 'react';
 import { flushSync } from 'react-dom';
 import { useQuery, useQueryClient } from 'react-query';
 import { useParams } from 'react-router';
@@ -266,7 +266,27 @@ const DataServiceRoleProvider = ({
     [s3Config.credentials],
   );
 
-  const getS3ConfigFn = useMemo(() => () => s3Config, [s3Config]);
+  const s3ConfigRef = useRef(s3Config);
+  s3ConfigRef.current = s3Config;
+
+  const assumeRoleQueryRef = useRef(assumeRoleQuery);
+  assumeRoleQueryRef.current = assumeRoleQuery;
+
+  const refreshPromiseRef = useRef<Promise<void> | null>(null);
+
+  const getS3ConfigFn = useCallback(() => {
+    const expiration = assumeRoleQueryRef.current.data?.Credentials?.Expiration;
+
+    if (expiration && new Date(expiration) <= new Date()) {
+      if (!refreshPromiseRef.current) {
+        refreshPromiseRef.current = assumeRoleQueryRef.current.refetch()
+          .then(() => { refreshPromiseRef.current = null; })
+          .catch(() => { refreshPromiseRef.current = null; });
+      }
+    }
+
+    return s3ConfigRef.current;
+  }, []);
 
   const setRole = (role: { roleArn: string }) => {
     setRoleArnStored(role.roleArn);

--- a/src/react/DataServiceRoleProvider.tsx
+++ b/src/react/DataServiceRoleProvider.tsx
@@ -170,16 +170,6 @@ export const useCurrentAccount = () => {
   };
 };
 
-export const useS3Config = (): S3Config | undefined => {
-  const assumedRole = useAssumedRole();
-  const { roleArn } = useDataServiceRole();
-  const { getS3Config } = useS3ConfigFromAssumeRoleResult();
-  return useMemo(() => {
-    if (!assumedRole) return undefined;
-    return getS3Config(assumedRole, roleArn);
-  }, [assumedRole, getS3Config, roleArn]);
-};
-
 const DataServiceRoleProvider = ({
   children,
   inlineLoader = false,
@@ -257,14 +247,7 @@ const DataServiceRoleProvider = ({
 
   const s3Config = useMemo(() => getS3Config(assumedRole, role.roleArn), [assumedRole, getS3Config, role.roleArn]);
 
-  const credentials: S3Credentials = useMemo(
-    () => ({
-      accessKeyId: s3Config.credentials.accessKeyId,
-      secretAccessKey: s3Config.credentials.secretAccessKey,
-      sessionToken: s3Config.credentials.sessionToken,
-    }),
-    [s3Config.credentials],
-  );
+  const credentials = s3Config.credentials;
 
   const s3ConfigRef = useRef(s3Config);
   s3ConfigRef.current = s3Config;
@@ -272,25 +255,49 @@ const DataServiceRoleProvider = ({
   const assumeRoleQueryRef = useRef(assumeRoleQuery);
   assumeRoleQueryRef.current = assumeRoleQuery;
 
-  const refreshPromiseRef = useRef<Promise<void> | null>(null);
+  const refreshPromiseRef = useRef<Promise<S3Credentials> | null>(null);
 
-  const getS3ConfigFn = useCallback(() => {
+  const credentialProvider = useCallback(async (): Promise<S3Credentials> => {
     const expiration = assumeRoleQueryRef.current.data?.Credentials?.Expiration;
-
     const REFRESH_BUFFER_MS = 2 * 60 * 1000;
+
     if (expiration && new Date(expiration).getTime() - Date.now() <= REFRESH_BUFFER_MS) {
       if (!refreshPromiseRef.current) {
         refreshPromiseRef.current = assumeRoleQueryRef.current.refetch()
-          .then(() => { refreshPromiseRef.current = null; })
+          .then((result) => {
+            refreshPromiseRef.current = null;
+            const exp = result.data?.Credentials?.Expiration;
+            return {
+              accessKeyId: result.data?.Credentials?.AccessKeyId || '',
+              secretAccessKey: result.data?.Credentials?.SecretAccessKey || '',
+              sessionToken: result.data?.Credentials?.SessionToken || '',
+              expiration: exp ? new Date(exp) : undefined,
+            };
+          })
           .catch((err) => {
             console.warn('STS credential refresh failed:', err);
             refreshPromiseRef.current = null;
+            return {
+              ...(s3ConfigRef.current.credentials as S3Credentials),
+              expiration: new Date(),
+            };
           });
       }
+      return await refreshPromiseRef.current;
     }
 
-    return s3ConfigRef.current;
+    return {
+      ...(s3ConfigRef.current.credentials as S3Credentials),
+      expiration: expiration ? new Date(expiration) : undefined,
+    };
   }, []);
+
+  const getS3ConfigFn = useCallback(() => {
+    return {
+      ...s3ConfigRef.current,
+      credentials: credentialProvider,
+    };
+  }, [credentialProvider]);
 
   const setRole = (role: { roleArn: string }) => {
     setRoleArnStored(role.roleArn);

--- a/src/react/__tests__/DataServiceRoleProvider.test.tsx
+++ b/src/react/__tests__/DataServiceRoleProvider.test.tsx
@@ -1,0 +1,179 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from 'react-query';
+import { MemoryRouter } from 'react-router';
+import { ThemeProvider } from 'styled-components';
+import { coreUIAvailableThemes } from '@scality/core-ui/dist/style/theme';
+import * as hooks from '../utils/hooks';
+import STSClient from '../../js/STSClient';
+
+const TEST_ROLE_ARN =
+  'arn:aws:iam::000000000000:role/scality-internal/storage-manager-role';
+
+const MOCK_STS_CREDENTIALS = {
+  Credentials: {
+    AccessKeyId: 'ASIA_TEST_ACCESS_KEY',
+    SecretAccessKey: 'test-secret-key',
+    SessionToken: 'test-session-token',
+    Expiration: new Date(Date.now() + 3600 * 1000),
+  },
+};
+
+const mockAssumeRoleWithWebIdentity = jest
+  .fn()
+  .mockResolvedValue(MOCK_STS_CREDENTIALS);
+
+// Mock STSClient prototype method since the module is already cached
+// from the global setup and jest.mock won't rebind existing imports.
+jest.spyOn(STSClient.prototype, 'assumeRoleWithWebIdentity')
+  .mockImplementation((...args) => mockAssumeRoleWithWebIdentity(...args));
+
+jest.mock('../utils/localStorage', () => ({
+  getRoleArnStored: jest.fn(() => ''),
+  setRoleArnStored: jest.fn(),
+}));
+
+jest.mock('../utils', () => ({
+  genClientEndpoint: jest.fn((endpoint: string) => endpoint),
+  initializeAWSSigner: jest.fn(),
+}));
+
+jest.mock('../ISV/components/ISVSummary', () => ({
+  DEFAULT_REGION: 'us-east-1',
+}));
+
+// Use jest.spyOn to replace useAccounts on the already-imported module.
+// jest.mock('../utils/hooks') doesn't work because jestSetupAfterEnv.tsx
+// transitively imports DataServiceRoleProvider, which imports hooks before
+// our test-level mock can take effect.
+jest.spyOn(hooks, 'useAccounts').mockReturnValue({
+  accounts: [
+    {
+      Name: 'test-account',
+      id: '000000000000',
+      Roles: [
+        {
+          Name: 'storage-manager-role',
+          Arn: TEST_ROLE_ARN,
+        },
+      ],
+    },
+  ],
+} as any);
+
+import DataServiceRoleProvider, {
+  useDataServiceRole,
+  useAssumedRole,
+} from '../DataServiceRoleProvider';
+
+const theme = coreUIAvailableThemes.darkRebrand;
+
+function createWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return function Wrapper({ children }: { children: React.ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>
+        <ThemeProvider theme={theme}>
+          <MemoryRouter>{children}</MemoryRouter>
+        </ThemeProvider>
+      </QueryClientProvider>
+    );
+  };
+}
+
+describe('DataServiceRoleProvider', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAssumeRoleWithWebIdentity.mockResolvedValue(MOCK_STS_CREDENTIALS);
+    jest.spyOn(hooks, 'useAccounts').mockReturnValue({
+      accounts: [
+        {
+          Name: 'test-account',
+          id: '000000000000',
+          Roles: [
+            {
+              Name: 'storage-manager-role',
+              Arn: TEST_ROLE_ARN,
+            },
+          ],
+        },
+      ],
+    } as any);
+  });
+
+  it('renders children after AssumeRole succeeds', async () => {
+    const Wrapper = createWrapper();
+
+    render(
+      <Wrapper>
+        <DataServiceRoleProvider>
+          <div data-testid="child-content">Hello</div>
+        </DataServiceRoleProvider>
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('child-content')).toBeInTheDocument();
+    });
+
+    expect(mockAssumeRoleWithWebIdentity).toHaveBeenCalledWith(
+      expect.objectContaining({
+        roleArn: TEST_ROLE_ARN,
+      }),
+    );
+  });
+
+  it('useDataServiceRole returns the correct roleArn', async () => {
+    const Wrapper = createWrapper();
+
+    function RoleConsumer() {
+      const role = useDataServiceRole();
+      return <div data-testid="role-arn">{role.roleArn}</div>;
+    }
+
+    render(
+      <Wrapper>
+        <DataServiceRoleProvider>
+          <RoleConsumer />
+        </DataServiceRoleProvider>
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('role-arn')).toHaveTextContent(TEST_ROLE_ARN);
+    });
+  });
+
+  it('useAssumedRole returns STS credentials after query completes', async () => {
+    const Wrapper = createWrapper();
+
+    function AssumedRoleConsumer() {
+      const assumedRole = useAssumedRole();
+      if (!assumedRole) return <div data-testid="loading">Loading</div>;
+      return (
+        <div data-testid="access-key">
+          {assumedRole.Credentials?.AccessKeyId}
+        </div>
+      );
+    }
+
+    render(
+      <Wrapper>
+        <DataServiceRoleProvider>
+          <AssumedRoleConsumer />
+        </DataServiceRoleProvider>
+      </Wrapper>,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId('access-key')).toHaveTextContent(
+        'ASIA_TEST_ACCESS_KEY',
+      );
+    });
+  });
+});

--- a/src/react/__tests__/DataServiceRoleProvider.test.tsx
+++ b/src/react/__tests__/DataServiceRoleProvider.test.tsx
@@ -1,5 +1,6 @@
 import { render, screen, waitFor } from '@testing-library/react';
-import { QueryClient, QueryClientProvider } from 'react-query';
+import { QueryClient } from 'react-query';
+import { QueryClientProvider } from '../../QueryClientProvider';
 import { MemoryRouter } from 'react-router';
 import { ThemeProvider } from 'styled-components';
 import { coreUIAvailableThemes } from '@scality/core-ui/dist/style/theme';

--- a/src/react/utils/testUtil.tsx
+++ b/src/react/utils/testUtil.tsx
@@ -1,5 +1,5 @@
 import { PropsWithChildren, ReactNode, JSX } from 'react';
-import { QueryClient, setLogger, useMutation } from 'react-query';
+import { QueryClient, setLogger } from 'react-query';
 import { MemoryRouter, Route, Routes } from 'react-router';
 import { ThemeProvider } from 'styled-components';
 import IAMClient from '../../js/IAMClient';
@@ -20,7 +20,6 @@ import { _AuthContext } from '../next-architecture/ui/AuthProvider';
 import { _ConfigContext } from '../next-architecture/ui/ConfigProvider';
 import { LocationAdapterProvider } from '../next-architecture/ui/LocationAdapterProvider';
 import MetricsAdapterProvider from '../next-architecture/ui/MetricsAdapterProvider';
-import { useAssumeRoleQuery } from '../DataServiceRoleProvider';
 import { DataBrowserProvider } from '@scality/data-browser-library';
 import { IAMProvider } from '../IAMProvider';
 import { ZenkoProvider } from '../ZenkoProvider';
@@ -596,19 +595,11 @@ export const renderWithCustomRoute = (
 };
 
 const DataServiceProvider = ({ children }) => {
-  const { getQuery } = useAssumeRoleQuery();
-  const assumeRoleMutation = useMutation({
-    mutationFn: (roleArn: string) => getQuery(roleArn).queryFn(),
-  });
   const role = {
     roleArn: TEST_ROLE_ARN,
   };
-  const setRole = (role: { roleArn: string }) => {
-    assumeRoleMutation.mutate(role.roleArn, {});
-  };
-  const setRolePromise = async (role: { roleArn: string }) => {
-    return getQuery(role.roleArn).queryFn();
-  };
+  const setRole = jest.fn();
+  const setRolePromise = jest.fn().mockResolvedValue(testS3Config);
   return (
     //@ts-expect-error fix this when you are working on it
     <_DataServiceRoleContext.Provider value={{ role, setRole, setRolePromise }}>


### PR DESCRIPTION
## Summary

- **Replace `useMutation` with `useQuery` for AssumeRole**: Leverages React Query's built-in caching, `refetchOnWindowFocus`, and `staleTime` instead of manually managing mutation state and `useEffect` triggers.
- **Introduce credential provider pattern**: Instead of passing static credentials to `DataBrowserProvider`, passes an async `credentialProvider` function. The AWS SDK calls this before each request, enabling transparent credential refresh without re-rendering the component tree.
- **Add proactive credential refresh with 2-minute buffer**: Credentials are refreshed before they expire (`REFRESH_BUFFER_MS = 2min`), preventing `ExpiredToken` errors after idle periods. A deduplication mechanism (`refreshPromiseRef`) ensures only one refresh request is in-flight at a time.
- **Simplify `setRole` / `setRolePromise`**: Role switching now leverages `queryClient.fetchQuery` instead of manual mutation + callback wiring.

## Changed Files

| File | Change |
|------|--------|
| `DataServiceRoleProvider.tsx` | Core refactor: `useMutation` → `useQuery`, static credentials → credential provider, added proactive refresh logic |
| `DataServiceRoleProvider.test.tsx` | New integration tests covering render, role context, and STS credential flow |
| `testUtil.tsx` | Simplified test wrapper to remove unused `useAssumeRoleQuery` / `useMutation` dependencies |

## Motivation

When the browser tab is idle and STS temporary credentials expire, subsequent S3 requests fail with `ExpiredToken` errors. The previous design relied on `useMutation` triggered by `useEffect`, which only refreshed credentials on role or token changes — not on expiration. The new credential provider pattern lets the AWS SDK resolve fresh credentials on demand, and the 2-minute pre-expiry buffer ensures seamless operation after idle periods.

## Test Plan

- [x] Integration tests for `DataServiceRoleProvider` added
- [x] Manual: verify S3 operations work after leaving tab idle past credential expiration
- [x] Manual: verify role switching still works correctly
- [x] Manual: verify `refetchOnWindowFocus` triggers credential refresh when returning to tab