### PR TITLE
ZKUI-474: Bump data-browser-library to 1.1.10

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@scality/certchain": "1.4.0",
         "@scality/core-ui": "0.202.0",
-        "@scality/data-browser-library": "1.1.9",
+        "@scality/data-browser-library": "1.1.10",
         "@scality/module-federation": "1.6.1",
         "@scality/react-chained-query": "^2.1.0",
         "@types/react-table": "^7.7.10",
@@ -5690,9 +5690,9 @@
       }
     },
     "node_modules/@scality/data-browser-library": {
-      "version": "1.1.9",
-      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.9.tgz",
-      "integrity": "sha512-n9jAraypNnzuUDTOuQJdZR2Dic8u5qogtY4PwlBsVVd9ieeyshNgrdxVd+5/4/WYzVdYkCHxyNRuf1emQVLwcw==",
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.10.tgz",
+      "integrity": "sha512-JzuNWwr7vMKUJUlKT7Ap/81ODL8h/tEUlYrr5d6DrPC2BfGn29stfAFr83ndldAxoANITy11Z4/89ePJpYLyGg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.983.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@scality/certchain": "1.4.0",
     "@scality/core-ui": "0.202.0",
-    "@scality/data-browser-library": "1.1.9",
+    "@scality/data-browser-library": "1.1.10",
     "@scality/module-federation": "1.6.1",
     "@scality/react-chained-query": "^2.1.0",
     "@types/react-table": "^7.7.10",


### PR DESCRIPTION
## Summary
Automated bump of `@scality/data-browser-library`.

## Links
- Release: https://github.com/scality/data-browser/releases/tag/1.1.10
- Jira: https://scality.atlassian.net/browse/ZKUI-474

🤖 Generated by data-browser auto-bump