### PR TITLE
fix(ZKUI-475): Only display Storage Manager role when it supersedes others

### DIFF
--- a/src/react/account/AccountRoleSelectButtonAndModal.tsx
+++ b/src/react/account/AccountRoleSelectButtonAndModal.tsx
@@ -107,23 +107,19 @@ export function AccountRoleSelectButtonAndModal({
     return (
       accounts?.flatMap((account) => {
         const accountName = account.Name;
-        const hasStorageManager = account.Roles.some(
-          (role) => regexArn.exec(role.Arn)?.groups?.['name'] === STORAGE_MANAGER_ROLE,
-        );
-        const rolesToDisplay = hasStorageManager
-          ? account.Roles.filter((role) => regexArn.exec(role.Arn)?.groups?.['name'] === STORAGE_MANAGER_ROLE)
-          : account.Roles;
-        return rolesToDisplay.map((role) => {
+        const parsedRoles = account.Roles.map((role) => {
           const parsedArn = regexArn.exec(role.Arn);
-          const rolePath = parsedArn?.groups['path'] || '';
-          const roleName = parsedArn?.groups['name'] || '';
           return {
             accountName,
-            roleName,
-            rolePath,
+            roleName: parsedArn?.groups['name'] || '',
+            rolePath: parsedArn?.groups['path'] || '',
             roleArn: role.Arn,
           };
         });
+        const storageManagerRoles = parsedRoles.filter(
+          (role) => role.roleName === STORAGE_MANAGER_ROLE,
+        );
+        return storageManagerRoles.length > 0 ? storageManagerRoles : parsedRoles;
       }) || []
     );
   }, [accountRolesHash]);

--- a/src/react/account/AccountRoleSelectButtonAndModal.tsx
+++ b/src/react/account/AccountRoleSelectButtonAndModal.tsx
@@ -6,7 +6,7 @@ import { useLocation, useNavigate, useParams } from 'react-router';
 import { useCurrentAccount, useDataServiceRole, useSetAssumedRolePromise } from '../DataServiceRoleProvider';
 import { CustomModal as Modal, ModalBody } from '../ui-elements/Modal';
 import { AccountSelectorButton } from '../ui-elements/Table';
-import { regexArn, SCALITY_INTERNAL_ROLES, useAccounts } from '../utils/hooks';
+import { regexArn, SCALITY_INTERNAL_ROLES, STORAGE_MANAGER_ROLE, useAccounts } from '../utils/hooks';
 
 function AccountRoleList({ accountsWithRoles, onRowSelected }) {
   const { roleArn } = useDataServiceRole();
@@ -107,7 +107,13 @@ export function AccountRoleSelectButtonAndModal({
     return (
       accounts?.flatMap((account) => {
         const accountName = account.Name;
-        return account.Roles.map((role) => {
+        const hasStorageManager = account.Roles.some(
+          (role) => regexArn.exec(role.Arn)?.groups?.['name'] === STORAGE_MANAGER_ROLE,
+        );
+        const rolesToDisplay = hasStorageManager
+          ? account.Roles.filter((role) => regexArn.exec(role.Arn)?.groups?.['name'] === STORAGE_MANAGER_ROLE)
+          : account.Roles;
+        return rolesToDisplay.map((role) => {
           const parsedArn = regexArn.exec(role.Arn);
           const rolePath = parsedArn?.groups['path'] || '';
           const roleName = parsedArn?.groups['name'] || '';

--- a/src/react/ui-elements/SelectAccountIAMRole.tsx
+++ b/src/react/ui-elements/SelectAccountIAMRole.tsx
@@ -162,15 +162,17 @@ const SelectAccountIAMRoleWithAccount = (props: SelectAccountIAMRoleWithAccountP
   };
   const roleQueryData = useQuery(listRolesQuery);
 
-  const allRoles = props.filterOutInternalRoles
-    ? (roleQueryData?.data?.Roles ?? []).filter((role) => {
-        return SCALITY_IAM_ROLES.includes(role.RoleName) || !role.Arn.includes('role/scality-internal');
-      })
-    : (roleQueryData?.data?.Roles ?? []);
+  const unfilteredRoles = roleQueryData?.data?.Roles ?? [];
 
-  const roles = allRoles.some((r) => r.RoleName === STORAGE_MANAGER_ROLE)
-    ? allRoles.filter((r) => r.RoleName === STORAGE_MANAGER_ROLE)
-    : allRoles;
+  const storageManagerFiltered = unfilteredRoles.some((r) => r.RoleName === STORAGE_MANAGER_ROLE)
+    ? unfilteredRoles.filter((r) => r.RoleName === STORAGE_MANAGER_ROLE)
+    : unfilteredRoles;
+
+  const roles = props.filterOutInternalRoles
+    ? storageManagerFiltered.filter((role) => {
+        return role.RoleName === STORAGE_MANAGER_ROLE || SCALITY_IAM_ROLES.includes(role.RoleName) || !role.Arn.includes('role/scality-internal');
+      })
+    : storageManagerFiltered;
 
   const isDefaultAccountSelected = account?.name === defaultValue?.accountName;
   const defaultRole = isDefaultAccountSelected ? defaultValue?.roleName : null;

--- a/src/react/ui-elements/SelectAccountIAMRole.tsx
+++ b/src/react/ui-elements/SelectAccountIAMRole.tsx
@@ -19,7 +19,7 @@ import {
 } from '../next-architecture/ui/AccessibleAccountsAdapterProvider';
 import { AccountsLocationsEndpointsAdapterProvider } from '../next-architecture/ui/AccountsLocationsEndpointsAdapterProvider';
 import { getListRolesQuery } from '../queries';
-import { regexArn, SCALITY_IAM_ROLES } from '../utils/hooks';
+import { regexArn, SCALITY_IAM_ROLES, STORAGE_MANAGER_ROLE } from '../utils/hooks';
 
 export class NoOpMetricsAdapter implements IMetricsAdapter {
   async listBucketsLatestUsedCapacity(buckets: Bucket[]): Promise<Record<string, LatestUsedCapacity>> {
@@ -162,11 +162,15 @@ const SelectAccountIAMRoleWithAccount = (props: SelectAccountIAMRoleWithAccountP
   };
   const roleQueryData = useQuery(listRolesQuery);
 
-  const roles = props.filterOutInternalRoles
+  const allRoles = props.filterOutInternalRoles
     ? (roleQueryData?.data?.Roles ?? []).filter((role) => {
         return SCALITY_IAM_ROLES.includes(role.RoleName) || !role.Arn.includes('role/scality-internal');
       })
     : (roleQueryData?.data?.Roles ?? []);
+
+  const roles = allRoles.some((r) => r.RoleName === STORAGE_MANAGER_ROLE)
+    ? allRoles.filter((r) => r.RoleName === STORAGE_MANAGER_ROLE)
+    : allRoles;
 
   const isDefaultAccountSelected = account?.name === defaultValue?.accountName;
   const defaultRole = isDefaultAccountSelected ? defaultValue?.roleName : null;

--- a/src/react/ui-elements/__tests__/SelectAccountIAMRole.test.tsx
+++ b/src/react/ui-elements/__tests__/SelectAccountIAMRole.test.tsx
@@ -1044,4 +1044,70 @@ describe('SelectAccountIAMRole', () => {
     expect(screen.queryByRole('option', { name: /data-consumer-role/i })).not.toBeInTheDocument();
     expect(screen.queryByRole('option', { name: /storage-account-owner-role/i })).not.toBeInTheDocument();
   });
+
+  it('should display storage-manager-role even when filterOutInternalRoles is true', async () => {
+    const getPayloadFn = jest.fn();
+    server.use(
+      rest.post(`${TEST_API_BASE_URL}/`, (req, res, ctx) => {
+        //@ts-ignore
+        const params = new URLSearchParams(req.body);
+        if (params.get('Action') === 'ListRoles') {
+          return res(
+            ctx.xml(`
+              <ListRolesResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+                <ListRolesResult>
+                  <Roles>
+                    <member>
+                      <AssumeRolePolicyDocument>%7B%22Statement%22%3A%5B%7B%22Action%22%3A%22sts%3AAssumeRoleWithWebIdentity%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22keycloak%3Aroles%22%3A%22StorageManager%22%7D%7D%2C%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Federated%22%3A%22https%3A%2F%2Fui.pod-choco.local%2Fauth%2Frealms%2Fartesca%22%7D%7D%5D%2C%22Version%22%3A%222012-10-17%22%7D</AssumeRolePolicyDocument>
+                      <Description>Storage Manager</Description>
+                      <Path>/scality-internal/</Path>
+                      <RoleName>storage-manager-role</RoleName>
+                      <RoleId>YRA3NTDUTWN6DRN76LSSDM6HA22RWBO9</RoleId>
+                      <Arn>arn:aws:iam::232853836441:role/scality-internal/storage-manager-role</Arn>
+                      <CreateDate>2024-04-17T16:31:36Z</CreateDate>
+                    </member>
+                    <member>
+                      <AssumeRolePolicyDocument>%7B%22Statement%22%3A%5B%7B%22Action%22%3A%22sts%3AAssumeRoleWithWebIdentity%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22keycloak%3Agroups%22%3A%22100%3A%3ADataConsumer%22%7D%7D%2C%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Federated%22%3A%22https%3A%2F%2Fui.pod-choco.local%2Fauth%2Frealms%2Fartesca%22%7D%7D%5D%2C%22Version%22%3A%222012-10-17%22%7D</AssumeRolePolicyDocument>
+                      <Description>Data Consumer</Description>
+                      <Path>/scality-internal/</Path>
+                      <RoleName>data-consumer-role</RoleName>
+                      <RoleId>YGEX9QWC7RI9KMBQEKS4RA9OND4JZ35U</RoleId>
+                      <Arn>arn:aws:iam::232853836441:role/scality-internal/data-consumer-role</Arn>
+                      <CreateDate>2024-04-17T16:31:36Z</CreateDate>
+                    </member>
+                  </Roles>
+                  <IsTruncated>false</IsTruncated>
+                </ListRolesResult>
+              </ListRolesResponse>
+            `),
+          );
+        }
+        return commonIAMHandlers(getPayloadFn, req, res, ctx);
+      }),
+    );
+    const onChange = jest.fn();
+    render(
+      <LocalWrapper>
+        <SelectAccountIAMRole onChange={onChange} filterOutInternalRoles />
+      </LocalWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(seletors.accountSelect()).toBeInTheDocument();
+    });
+
+    await userEvent.click(seletors.accountSelect());
+    await userEvent.click(seletors.selectOption(/no-bucket/i));
+
+    await waitFor(() => {
+      expect(seletors.roleSelect()).toBeInTheDocument();
+    });
+
+    await userEvent.click(seletors.roleSelect());
+
+    // storage-manager-role should still be visible even though it's under /scality-internal/
+    expect(screen.getByRole('option', { name: /storage-manager-role/i })).toBeInTheDocument();
+    // other internal roles should be filtered out
+    expect(screen.queryByRole('option', { name: /data-consumer-role/i })).not.toBeInTheDocument();
+  });
 });

--- a/src/react/ui-elements/__tests__/SelectAccountIAMRole.test.tsx
+++ b/src/react/ui-elements/__tests__/SelectAccountIAMRole.test.tsx
@@ -184,15 +184,6 @@ const commonIAMHandlers = (getPayloadFn: jest.Mock, req, res, ctx) => {
                 <CreateDate>2024-04-17T16:31:36Z</CreateDate>
               </member>
               <member>
-                <AssumeRolePolicyDocument>%7B%22Statement%22%3A%5B%7B%22Action%22%3A%22sts%3AAssumeRoleWithWebIdentity%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22keycloak%3Aroles%22%3A%22StorageManager%22%7D%7D%2C%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Federated%22%3A%22https%3A%2F%2Fui.pod-choco.local%2Fauth%2Frealms%2Fartesca%22%7D%7D%2C%7B%22Action%22%3A%22sts%3AAssumeRoleWithWebIdentity%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22keycloak%3Aroles%22%3A%22StorageManager%22%7D%7D%2C%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Federated%22%3A%22https%3A%2F%2F13.48.197.10%3A8443%2Fauth%2Frealms%2Fartesca%22%7D%7D%5D%2C%22Version%22%3A%222012-10-17%22%7D</AssumeRolePolicyDocument>
-                <Description>Has all permissions and full access to the 100 account resources and manages ARTESCA users.</Description>
-                <Path>/scality-internal/</Path>
-                <RoleName>storage-manager-role</RoleName>
-                <RoleId>YRA3NTDUTWN6DRN76LSSDM6HA22RWBO9</RoleId>
-                <Arn>arn:aws:iam::232853836441:role/scality-internal/storage-manager-role</Arn>
-                <CreateDate>2024-04-17T16:31:36Z</CreateDate>
-              </member>
-              <member>
                 <AssumeRolePolicyDocument>%7B%22Statement%22%3A%5B%7B%22Action%22%3A%22sts%3AAssumeRoleWithWebIdentity%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22keycloak%3Agroups%22%3A%22100%3A%3ADataConsumer%22%7D%7D%2C%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Federated%22%3A%22https%3A%2F%2Fui.pod-choco.local%2Fauth%2Frealms%2Fartesca%22%7D%7D%2C%7B%22Action%22%3A%22sts%3AAssumeRoleWithWebIdentity%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22keycloak%3Agroups%22%3A%22100%3A%3ADataConsumer%22%7D%7D%2C%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Federated%22%3A%22https%3A%2F%2F13.48.197.10%3A8443%2Fauth%2Frealms%2Fartesca%22%7D%7D%5D%2C%22Version%22%3A%222012-10-17%22%7D</AssumeRolePolicyDocument>
                 <Description>No keycloak role</Description>
                 <Path>/</Path>
@@ -977,5 +968,80 @@ describe('SelectAccountIAMRole', () => {
       name: /data-consumer-role/i,
     });
     expect(compatibleOption).not.toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('should only display storage-manager-role when it is present among the roles', async () => {
+    const getPayloadFn = jest.fn();
+    server.use(
+      rest.post(`${TEST_API_BASE_URL}/`, (req, res, ctx) => {
+        //@ts-ignore
+        const params = new URLSearchParams(req.body);
+        if (params.get('Action') === 'ListRoles') {
+          return res(
+            ctx.xml(`
+              <ListRolesResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
+                <ListRolesResult>
+                  <Roles>
+                    <member>
+                      <AssumeRolePolicyDocument>%7B%22Statement%22%3A%5B%7B%22Action%22%3A%22sts%3AAssumeRoleWithWebIdentity%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22keycloak%3Aroles%22%3A%22StorageManager%22%7D%7D%2C%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Federated%22%3A%22https%3A%2F%2Fui.pod-choco.local%2Fauth%2Frealms%2Fartesca%22%7D%7D%5D%2C%22Version%22%3A%222012-10-17%22%7D</AssumeRolePolicyDocument>
+                      <Description>Storage Manager</Description>
+                      <Path>/scality-internal/</Path>
+                      <RoleName>storage-manager-role</RoleName>
+                      <RoleId>YRA3NTDUTWN6DRN76LSSDM6HA22RWBO9</RoleId>
+                      <Arn>arn:aws:iam::232853836441:role/scality-internal/storage-manager-role</Arn>
+                      <CreateDate>2024-04-17T16:31:36Z</CreateDate>
+                    </member>
+                    <member>
+                      <AssumeRolePolicyDocument>%7B%22Statement%22%3A%5B%7B%22Action%22%3A%22sts%3AAssumeRoleWithWebIdentity%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22keycloak%3Agroups%22%3A%22100%3A%3ADataConsumer%22%7D%7D%2C%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Federated%22%3A%22https%3A%2F%2Fui.pod-choco.local%2Fauth%2Frealms%2Fartesca%22%7D%7D%5D%2C%22Version%22%3A%222012-10-17%22%7D</AssumeRolePolicyDocument>
+                      <Description>Data Consumer</Description>
+                      <Path>/scality-internal/</Path>
+                      <RoleName>data-consumer-role</RoleName>
+                      <RoleId>YGEX9QWC7RI9KMBQEKS4RA9OND4JZ35U</RoleId>
+                      <Arn>arn:aws:iam::232853836441:role/scality-internal/data-consumer-role</Arn>
+                      <CreateDate>2024-04-17T16:31:36Z</CreateDate>
+                    </member>
+                    <member>
+                      <AssumeRolePolicyDocument>%7B%22Statement%22%3A%5B%7B%22Action%22%3A%22sts%3AAssumeRoleWithWebIdentity%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22keycloak%3Agroups%22%3A%22100%3A%3AStorageAccountOwner%22%7D%7D%2C%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Federated%22%3A%22https%3A%2F%2Fui.pod-choco.local%2Fauth%2Frealms%2Fartesca%22%7D%7D%5D%2C%22Version%22%3A%222012-10-17%22%7D</AssumeRolePolicyDocument>
+                      <Description>Storage Account Owner</Description>
+                      <Path>/scality-internal/</Path>
+                      <RoleName>storage-account-owner-role</RoleName>
+                      <RoleId>OYYDW5GLCETHME90KWAZCG5Z8KNZA1OT</RoleId>
+                      <Arn>arn:aws:iam::232853836441:role/scality-internal/storage-account-owner-role</Arn>
+                      <CreateDate>2024-04-17T16:31:36Z</CreateDate>
+                    </member>
+                  </Roles>
+                  <IsTruncated>false</IsTruncated>
+                </ListRolesResult>
+              </ListRolesResponse>
+            `),
+          );
+        }
+        return commonIAMHandlers(getPayloadFn, req, res, ctx);
+      }),
+    );
+    const onChange = jest.fn();
+    render(
+      <LocalWrapper>
+        <SelectAccountIAMRole onChange={onChange} />
+      </LocalWrapper>,
+    );
+
+    await waitFor(() => {
+      expect(seletors.accountSelect()).toBeInTheDocument();
+    });
+
+    await userEvent.click(seletors.accountSelect());
+    await userEvent.click(seletors.selectOption(/no-bucket/i));
+
+    await waitFor(() => {
+      expect(seletors.roleSelect()).toBeInTheDocument();
+    });
+
+    await userEvent.click(seletors.roleSelect());
+
+    // Only storage-manager-role should be visible
+    expect(screen.getByRole('option', { name: /storage-manager-role/i })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /data-consumer-role/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /storage-account-owner-role/i })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- When a user has `storage-manager-role` for an account, all other IAM roles are now hidden in the Select Role modal
- Storage Manager provides a superset of permissions over every other role, so displaying lower-permission roles alongside it is redundant and confusing
- Applied filtering in both role selection components:
  - `AccountRoleSelectButtonAndModal` (table-based modal)
  - `SelectAccountIAMRole` (dropdown-based selector)

## Changes

- **`AccountRoleSelectButtonAndModal.tsx`**: Added per-account check — if `storage-manager-role` exists among the account's roles, only that role is included in the list
- **`SelectAccountIAMRole.tsx`**: Added post-filter step after the existing `filterOutInternalRoles` logic — if `storage-manager-role` is in the fetched roles, only it is kept
- **`SelectAccountIAMRole.test.tsx`**: Updated shared mock data and added a dedicated test verifying that only `storage-manager-role` is displayed when present alongside other roles

## Test plan

- [x] Existing tests pass (11 passed, 1 previously skipped)
- [x] New test: verifies `data-consumer-role` and `storage-account-owner-role` are hidden when `storage-manager-role` is present
- [x] Manual verification: open Select Role modal with a Storage Manager account and confirm only `storage-manager-role` appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)