### PR TITLE
feat(ISV): add Rubrik CDM configuration assistant

### DIFF
--- a/src/react/ISV/ISVList.tsx
+++ b/src/react/ISV/ISVList.tsx
@@ -1,7 +1,6 @@
 import CohesityLogo from './components/Modal/Logos/CohesityLogo';
 import CteraLogo from './components/Modal/Logos/CteraLogo';
 import HycuLogo from './components/Modal/Logos/HycuLogo';
-import RubrikLogo from './components/Modal/Logos/RubrikLogo';
 import SplunkLogo from './components/Modal/Logos/SplunkLogo';
 import VeritasLogo from './components/Modal/Logos/VeritasLogo';
 import ZertoLogo from './components/Modal/Logos/ZertoLogo';
@@ -10,13 +9,6 @@ import type { ISVCardConfig } from './types';
 
 export const ISVList: ISVCardConfig[] = [
   ...platformRegistry,
-  {
-    id: 'rubrik',
-    name: 'Rubrik',
-    logo: <RubrikLogo />,
-    documentationLink: '/artesca/docs/partner_applications/backup_and_archives/rubrik_security_cloud.html',
-    category: 'backup-and-archive',
-  },
   {
     id: 'zerto',
     name: 'Zerto',

--- a/src/react/ISV/components/ISVConfiguration.tsx
+++ b/src/react/ISV/components/ISVConfiguration.tsx
@@ -102,10 +102,11 @@ const getDefaultFormValues = (
   paramsAccountName: string | null,
   isVeeamVBROnly: boolean,
 ): Partial<FormData> => {
+  const hasImmutableField = platform.fields.some((f) => f.name === 'enableImmutableBackup');
   const baseDefaults: Partial<FormData> = {
     accountName: paramsAccountName || '',
     accountNameType: paramsAccountName ? 'existing' : 'create',
-    enableImmutableBackup: true,
+    ...(hasImmutableField ? { enableImmutableBackup: true } : {}),
     buckets: [
       {
         name: '',

--- a/src/react/ISV/components/shared/PlatformTooltips.tsx
+++ b/src/react/ISV/components/shared/PlatformTooltips.tsx
@@ -7,7 +7,7 @@
 
 import { ListItem } from './StyledComponents';
 
-type PlatformName = 'Veeam' | 'Commvault' | 'Kasten';
+type PlatformName = 'Veeam' | 'Commvault' | 'Kasten' | 'Rubrik';
 
 /**
  * Account name tooltip - explains the purpose of the account field

--- a/src/react/ISV/engine/builders/buildFields.ts
+++ b/src/react/ISV/engine/builders/buildFields.ts
@@ -114,22 +114,24 @@ export function buildFields(config: PlatformConfig): FieldDef[] {
     itemFields: buildBucketItemFields(config),
   } as FieldDef);
 
-  // 5. Immutable toggle
-  const immutableOverride = config.fieldOverrides?.enableImmutableBackup;
-  const immutableBase = applyOverrides(
-    {
-      label: 'Immutable Backup',
-      helpText: 'It enables object-lock on the bucket which means backups will be permanent and unchangeable.',
-    },
-    immutableOverride,
-  );
+  // 5. Immutable toggle (skipped if platform disables immutability)
+  if (!config.disableImmutability) {
+    const immutableOverride = config.fieldOverrides?.enableImmutableBackup;
+    const immutableBase = applyOverrides(
+      {
+        label: 'Immutable Backup',
+        helpText: 'It enables object-lock on the bucket which means backups will be permanent and unchangeable.',
+      },
+      immutableOverride,
+    );
 
-  fields.push({
-    name: 'enableImmutableBackup',
-    type: 'toggle',
-    defaultValue: true,
-    ...immutableBase,
-  } as FieldDef);
+    fields.push({
+      name: 'enableImmutableBackup',
+      type: 'toggle',
+      defaultValue: true,
+      ...immutableBase,
+    } as FieldDef);
+  }
 
   // 6. Additional fields after immutable
   if (config.additionalFields?.afterImmutable) {

--- a/src/react/ISV/engine/definePlatform.ts
+++ b/src/react/ISV/engine/definePlatform.ts
@@ -19,7 +19,7 @@ function buildValidator(config: PlatformConfig): Joi.ObjectSchema {
     ...accountValidator,
     ...iamValidator,
     ...getBucketsValidator(config.bucketCapacity ?? false),
-    ...immutableValidator,
+    ...(config.disableImmutability ? {} : immutableValidator),
   };
 
   return Joi.object(baseSchema);

--- a/src/react/ISV/engine/index.ts
+++ b/src/react/ISV/engine/index.ts
@@ -72,6 +72,7 @@ export {
   iamValidator,
   immutableValidator,
   KastenValidator,
+  RubrikValidator,
   VeeamVBOValidator,
   VeeamVBRValidator,
 } from './validators';

--- a/src/react/ISV/engine/types.ts
+++ b/src/react/ISV/engine/types.ts
@@ -17,9 +17,9 @@ export type ISVId =
   | 'veeam-vbr'
   | 'commvault'
   | 'veeam-vbo'
-  // Platforms without assistant (documentation only)
   | 'kasten'
   | 'rubrik'
+  // Platforms without assistant (documentation only)
   | 'zerto'
   | 'splunk'
   | 'hycu'
@@ -368,6 +368,7 @@ export type PlatformConfig = {
   // Feature switches
   sosAPI?: boolean;
   bucketCapacity?: boolean;
+  disableImmutability?: boolean;
 
   // Field overrides
   fieldOverrides?: {

--- a/src/react/ISV/engine/validators.ts
+++ b/src/react/ISV/engine/validators.ts
@@ -137,6 +137,15 @@ export const CommvaultValidator = Joi.object({
 });
 
 /**
+ * Rubrik validator (basic, no capacity, no immutability)
+ */
+export const RubrikValidator = Joi.object({
+  ...accountValidator,
+  ...iamValidator,
+  ...bucketsValidator,
+});
+
+/**
  * Veeam Kasten validator (basic, no capacity)
  */
 export const KastenValidator = Joi.object({

--- a/src/react/ISV/platforms/__tests__/rubrik.test.tsx
+++ b/src/react/ISV/platforms/__tests__/rubrik.test.tsx
@@ -1,0 +1,135 @@
+import { RubrikPlatform } from '../rubrik';
+
+describe('RubrikPlatform', () => {
+  describe('validator', () => {
+    it('should validate correct data for new account', () => {
+      const validData = {
+        accountName: 'test-account',
+        accountNameType: 'create',
+        buckets: [{ name: 'test-rubrik-0' }],
+      };
+
+      const { error } = RubrikPlatform.validator.validate(validData);
+      expect(error).toBeUndefined();
+    });
+
+    it('should validate correct data for existing account with IAM user', () => {
+      const validData = {
+        accountName: 'existing-account',
+        accountNameType: 'existing',
+        IAMUserName: 'test-iam-user',
+        IAMUserNameType: 'create',
+        generateKey: true,
+        buckets: [{ name: 'my-archive-rubrik-0' }],
+      };
+
+      const { error } = RubrikPlatform.validator.validate(validData);
+      expect(error).toBeUndefined();
+    });
+
+    it('should not require enableImmutableBackup', () => {
+      const validData = {
+        accountName: 'test-account',
+        accountNameType: 'create',
+        buckets: [{ name: 'test-rubrik-0' }],
+        // enableImmutableBackup intentionally absent
+      };
+
+      const { error } = RubrikPlatform.validator.validate(validData);
+      expect(error).toBeUndefined();
+    });
+
+    it('should reject invalid bucket name', () => {
+      const invalidData = {
+        accountName: 'test-account',
+        accountNameType: 'create',
+        buckets: [{ name: 'INVALID_BUCKET' }],
+      };
+
+      const { error } = RubrikPlatform.validator.validate(invalidData);
+      expect(error).toBeDefined();
+    });
+
+    it('should reject missing account name', () => {
+      const invalidData = {
+        accountNameType: 'create',
+        buckets: [{ name: 'valid-rubrik-0' }],
+      };
+
+      const { error } = RubrikPlatform.validator.validate(invalidData);
+      expect(error).toBeDefined();
+    });
+  });
+
+  describe('policy generation', () => {
+    it('should generate valid JSON policy', () => {
+      const policy = RubrikPlatform.getPolicy(['my-archive-rubrik-0'], false);
+      const parsed = JSON.parse(policy);
+
+      expect(parsed.Version).toBe('2012-10-17');
+      expect(parsed.Statement).toHaveLength(1);
+      expect(parsed.Statement[0].Sid).toBe('RubrikPolicy');
+    });
+
+    it('should include Rubrik-specific actions', () => {
+      const policy = RubrikPlatform.getPolicy(['bucket1'], false);
+      const parsed = JSON.parse(policy);
+      const actions = parsed.Statement[0].Action;
+
+      expect(actions).toContain('s3:PutObject');
+      expect(actions).toContain('s3:GetObject');
+      expect(actions).toContain('s3:ListBucket');
+      expect(actions).toContain('s3:DeleteObject');
+      expect(actions).toContain('s3:GetBucketLocation');
+      expect(actions).toContain('s3:AbortMultipartUpload');
+      expect(actions).toContain('s3:ListMultipartUploadParts');
+      expect(actions).toContain('s3:ListBucketMultipartUploads');
+      expect(actions).toContain('s3:RestoreObject');
+      expect(actions).toContain('s3:CreateBucket');
+      expect(actions).toContain('s3:GetBucketAcl');
+    });
+
+    it('should scope resource to objects only (bucket/*), not the bucket ARN', () => {
+      const policy = RubrikPlatform.getPolicy(['my-archive-rubrik-0'], false);
+      const parsed = JSON.parse(policy);
+      const resources = parsed.Statement[0].Resource;
+
+      expect(resources).toContain('arn:aws:s3:::my-archive-rubrik-0/*');
+      expect(resources).not.toContain('arn:aws:s3:::my-archive-rubrik-0');
+    });
+
+    it('should generate the same policy regardless of isImmutable flag', () => {
+      const policyNonImmutable = RubrikPlatform.getPolicy(['bucket1'], false);
+      const policyImmutable = RubrikPlatform.getPolicy(['bucket1'], true);
+
+      expect(policyNonImmutable).toBe(policyImmutable);
+    });
+
+    it('should include resources for multiple buckets', () => {
+      const policy = RubrikPlatform.getPolicy(['bucket1', 'bucket2'], false);
+      const parsed = JSON.parse(policy);
+      const resources = parsed.Statement[0].Resource;
+
+      expect(resources).toContain('arn:aws:s3:::bucket1/*');
+      expect(resources).toContain('arn:aws:s3:::bucket2/*');
+    });
+  });
+
+  describe('platform config', () => {
+    it('should have assistant enabled', () => {
+      expect(RubrikPlatform.assistant).toBe(true);
+    });
+
+    it('should not have an immutability field', () => {
+      const hasImmutableField = RubrikPlatform.fields.some((f) => f.name === 'enableImmutableBackup');
+      expect(hasImmutableField).toBe(false);
+    });
+
+    it('should have account, IAM user, and bucket fields', () => {
+      const fieldNames = RubrikPlatform.fields.map((f) => f.name);
+      expect(fieldNames).toContain('accountName');
+      expect(fieldNames).toContain('IAMUserName');
+      expect(fieldNames).toContain('buckets');
+    });
+  });
+});

--- a/src/react/ISV/platforms/registry.ts
+++ b/src/react/ISV/platforms/registry.ts
@@ -1,13 +1,14 @@
 import type { ISVPlatform } from '../engine/types';
 import { CommvaultPlatform } from './commvault';
 import { KastenPlatform } from './kasten';
+import { RubrikPlatform } from './rubrik';
 import { VeeamVBOPlatform } from './veeam-vbo';
 import { VeeamVBRPlatform } from './veeam-vbr';
 
 /**
  * Registry of all available ISV platforms.
  */
-export const platformRegistry: ISVPlatform[] = [VeeamVBRPlatform, VeeamVBOPlatform, CommvaultPlatform, KastenPlatform];
+export const platformRegistry: ISVPlatform[] = [VeeamVBRPlatform, VeeamVBOPlatform, CommvaultPlatform, KastenPlatform, RubrikPlatform];
 
 /**
  * Find a platform by its ID.

--- a/src/react/ISV/platforms/rubrik.tsx
+++ b/src/react/ISV/platforms/rubrik.tsx
@@ -41,9 +41,8 @@ export const RubrikPlatform = definePlatform({
         render: () => (
           <Stack gap="r8" direction="vertical">
             <Text>
-              When configuring the Archive Location in Rubrik CDM, select{' '}
-              <b>Object Store (S3 Compatible)</b> then <b>Amazon S3 compatible</b> (do not select
-              "Scality").
+              When configuring the Archival Location in Rubrik CDM, select{' '}
+              <b>Object Store (S3 Compatible)</b> then <b>Amazon S3 compatible</b>.
             </Text>
             <Text>
               Use the <b>Bucket Prefix</b> field in Rubrik to enter the prefix portion of your

--- a/src/react/ISV/platforms/rubrik.tsx
+++ b/src/react/ISV/platforms/rubrik.tsx
@@ -1,0 +1,84 @@
+import { Stack, Text } from '@scality/core-ui';
+import { IAMUSerTooltip } from '../components/IAMUserTooltip';
+import RubrikLogo from '../components/Modal/Logos/RubrikLogo';
+import { AccountTooltip, BucketNameTooltip } from '../components/shared/PlatformTooltips';
+import { definePlatform, RubrikValidator } from '../engine';
+import { GET_RUBRIK_POLICY } from '../utils/ISVPolicy';
+
+export const RubrikPlatform = definePlatform({
+  id: 'rubrik',
+  name: 'Rubrik',
+  logo: <RubrikLogo />,
+  policy: GET_RUBRIK_POLICY,
+  documentationLink: '/artesca/docs/partner_applications/backup_and_archives/rubrik_security_cloud.html',
+  category: 'backup-and-archive',
+
+  disableImmutability: true,
+  customValidator: RubrikValidator,
+
+  fieldOverrides: {
+    accountName: {
+      label: 'Account',
+      placeholder: 'Enter account name',
+      tooltip: <AccountTooltip platform="Rubrik" />,
+    },
+    bucketName: {
+      label: 'Bucket name',
+      placeholder: 'Enter bucket name (e.g. my-archive-rubrik-0)',
+      tooltip: <BucketNameTooltip platform="Rubrik" />,
+    },
+    IAMUserName: {
+      label: 'IAM User Name',
+      tooltip: <IAMUSerTooltip platform="Rubrik" />,
+    },
+  },
+
+  summary: {
+    title: 'Rubrik Archive Location preparation summary',
+    sections: [
+      {
+        id: 'customInformation',
+        render: () => (
+          <Stack gap="r8" direction="vertical">
+            <Text>
+              When configuring the Archive Location in Rubrik CDM, select{' '}
+              <b>Object Store (S3 Compatible)</b> then <b>Amazon S3 compatible</b> (do not select
+              "Scality").
+            </Text>
+            <Text>
+              Use the <b>Bucket Prefix</b> field in Rubrik to enter the prefix portion of your
+              bucket name — the part before <b>-rubrik-0</b>. For example, if your bucket is named{' '}
+              <b>my-archive-rubrik-0</b>, enter <b>my-archive</b> as the Bucket Prefix.
+            </Text>
+            <Text>
+              Rubrik requires an RSA private key to encrypt archived data. Generate one on a secure
+              computer before configuring the Archive Location:
+            </Text>
+            <code>{'openssl genrsa -traditional -out rubrik_encryption_key.pem 2048'}</code>
+          </Stack>
+        ),
+      },
+      { id: 'credentials' },
+      { id: 'connectionInfo' },
+      { id: 'buckets' },
+    ],
+    serviceEndpointLabel: 'S3 Endpoint (Host Name in Rubrik)',
+    accessKeyLabel: 'Access Key',
+    secretKeyLabel: 'Secret Key',
+  },
+
+  description: (
+    <Stack gap="r8">
+      <Text variant="Large">Prepare ARTESCA for</Text>
+      <RubrikLogo />
+    </Stack>
+  ),
+
+  skipModalContent: (
+    <Text>
+      To start Rubrik assistant configuration again, you can go to the <b>Accounts</b> page or{' '}
+      <b>Data Browser</b> page. If the platform doesn't have any accounts, it will also prompt you
+      on your next login.
+    </Text>
+  ),
+});

--- a/src/react/ISV/utils/ISVPolicy.ts
+++ b/src/react/ISV/utils/ISVPolicy.ts
@@ -61,3 +61,28 @@ export const GET_COMMVAULT_POLICY = (buckets: string[], isImmutable: boolean) =>
   });
 
 export const GET_KASTEN_POLICY = GET_VEEAM_POLICY;
+
+export const GET_RUBRIK_POLICY = (buckets: string[], _isImmutable: boolean) =>
+  JSON.stringify({
+    Version: '2012-10-17',
+    Statement: [
+      {
+        Sid: 'RubrikPolicy',
+        Effect: 'Allow',
+        Action: [
+          's3:PutObject',
+          's3:GetObject',
+          's3:ListBucket',
+          's3:DeleteObject',
+          's3:GetBucketLocation',
+          's3:AbortMultipartUpload',
+          's3:ListMultipartUploadParts',
+          's3:ListBucketMultipartUploads',
+          's3:RestoreObject',
+          's3:CreateBucket',
+          's3:GetBucketAcl',
+        ],
+        Resource: buckets.flatMap((bucket) => [`arn:aws:s3:::${bucket}/*`]),
+      },
+    ],
+  });


### PR DESCRIPTION
## Summary [ARTESCA-17187](https://scality.atlassian.net/browse/ARTESCA-17187)

- Promotes Rubrik from a documentation-only ISV card to a full configuration assistant (Configure → ApplyActions → Summary)
- Adds a minimal engine enhancement: `disableImmutability` flag in `PlatformConfig` to cleanly support platforms that do not use S3 Object Lock
- Implements Rubrik-specific IAM policy based on Scality documentation (multipart upload, restore, ACL actions; resource scoped to objects only)
- Summary page includes Rubrik-specific guidance: Bucket Prefix convention (`<prefix>-rubrik-0`), RSA key generation instructions, and the note to select "Amazon S3 compatible" (not "Scality") in Rubrik CDM

## Changes

- `engine/types.ts` — `disableImmutability?: boolean` added to `PlatformConfig`; `'rubrik'` moved to assisted platforms in `ISVId`
- `engine/builders/buildFields.ts` — immutability toggle conditionally skipped
- `engine/definePlatform.ts` — `immutableValidator` conditionally excluded
- `utils/ISVPolicy.ts` — `GET_RUBRIK_POLICY` with Rubrik-specific S3 actions
- `engine/validators.ts` + `engine/index.ts` — `RubrikValidator` (no immutability)
- `components/shared/PlatformTooltips.tsx` — `'Rubrik'` added to `PlatformName` type
- `platforms/rubrik.tsx` — new platform definition
- `platforms/registry.ts` — `RubrikPlatform` registered
- `ISVList.tsx` — docs-only Rubrik entry removed
- `platforms/__tests__/rubrik.test.tsx` — 13 new tests (validator + policy)

## Test plan

<img width="1157" height="871" alt="Screenshot 2026-03-30 at 11 46 19" src="https://github.com/user-attachments/assets/4a704635-c991-4a9e-a1fc-b6a9b2c9c7ff" />

[ARTESCA-17187]: https://scality.atlassian.net/browse/ARTESCA-17187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ