### PR TITLE
fix(ZKUI-483): restore Metadata updates column in bucket list for XDM

### DIFF
--- a/__mocks__/@scality/data-browser-library.tsx
+++ b/__mocks__/@scality/data-browser-library.tsx
@@ -66,6 +66,16 @@ export const useGetBucketTagging = jest.fn(() => ({
   refetch: jest.fn(),
 }));
 
+export const useGetBucketLocation = jest.fn(() => ({
+  data: undefined,
+  status: 'pending',
+  isLoading: true,
+  isSuccess: false,
+  isError: false,
+  error: null,
+  refetch: jest.fn(),
+}));
+
 export const useGetObject = jest.fn(() => ({
   data: undefined,
   status: 'idle',

--- a/src/react/databrowser/DataBrowser.tsx
+++ b/src/react/databrowser/DataBrowser.tsx
@@ -2,6 +2,7 @@ import { Box } from '@scality/core-ui/dist/next';
 import { type Bucket, type ColumnConfig, DataBrowserUI } from '@scality/data-browser-library';
 import { useCallback, useMemo } from 'react';
 import { Route, Routes, useLocation, useParams } from 'react-router';
+import { XDM_FEATURE } from '../../js/config';
 import { StartISVConnectorButton } from '../ISV/components/StartISVConnectorButton';
 import { useAccountsLocationsAndEndpoints } from '../next-architecture/domain/business/accounts';
 import { useAccountsLocationsEndpointsAdapter } from '../next-architecture/ui/AccountsLocationsEndpointsAdapterProvider';
@@ -15,6 +16,7 @@ import { LocationSection } from './buckets/LocationSection';
 import { LocationSelector } from './buckets/LocationSelector';
 import { ReplicationCRRDestinationFields } from './buckets/ReplicationCRRDestinationFields';
 import { StorageClassSelector } from './buckets/StorageClassSelector';
+import { MetadataUpdatesColumn } from './buckets/MetadataUpdatesColumn';
 import { StorageLocationColumn } from './buckets/StorageLocationColumn';
 import { UseCaseSection } from './buckets/UseCaseSection';
 import { useBucketCreateConfig } from './buckets/useBucketCreateConfig';
@@ -45,7 +47,7 @@ export default function DataBrowser({ hideHeader = false }: { hideHeader?: boole
   const query = useQueryParams();
   const prefixPath = query.get('prefix');
 
-  const { basePath } = useConfig();
+  const { basePath, features } = useConfig();
 
   const dataBrowserBasePath = `${basePath}/accounts/${accountName}`;
 
@@ -55,7 +57,10 @@ export default function DataBrowser({ hideHeader = false }: { hideHeader?: boole
   const { accountsLocationsAndEndpoints } = useAccountsLocationsAndEndpoints({
     accountsLocationsEndpointsAdapter: adapter,
   });
-  const locations = useMemo(() => accountsLocationsAndEndpoints?.locations ?? [], [accountsLocationsAndEndpoints?.locations]);
+  const locations = useMemo(
+    () => accountsLocationsAndEndpoints?.locations ?? [],
+    [accountsLocationsAndEndpoints?.locations],
+  );
 
   const isLocationCold = useCallback(
     (locationName: string) => locations.some((loc) => loc.name === locationName && loc.isCold),
@@ -73,6 +78,16 @@ export default function DataBrowser({ hideHeader = false }: { hideHeader?: boole
       },
     ];
 
+    if (features.includes(XDM_FEATURE)) {
+      columns.push({
+        id: 'ingestion',
+        header: 'Metadata updates',
+        render: MetadataUpdatesColumn,
+        width: '180px',
+        cellStyle: { textAlign: 'right' },
+      });
+    }
+
     if (isStorageManager) {
       columns.push({
         id: 'dataUsed',
@@ -84,7 +99,7 @@ export default function DataBrowser({ hideHeader = false }: { hideHeader?: boole
     }
 
     return columns;
-  }, [isStorageManager]);
+  }, [isStorageManager, features]);
 
   const extraBucketListActions = [
     {

--- a/src/react/databrowser/buckets/MetadataUpdatesColumn.tsx
+++ b/src/react/databrowser/buckets/MetadataUpdatesColumn.tsx
@@ -1,0 +1,37 @@
+import { Loader } from '@scality/core-ui';
+import { EmptyCell } from '@scality/core-ui/dist/components/tablev2/Tablev2.component';
+import type { Bucket } from '@scality/data-browser-library';
+import { useGetBucketLocation } from '@scality/data-browser-library';
+import { useInstanceStatusQuery } from '../../queries/instanceStatusQuery';
+import { getLocationIngestionState } from '../../utils/storageOptions';
+
+export const MetadataUpdatesColumn = ({ data }: { data: Bucket }) => {
+  const {
+    data: bucketLocation,
+    status: locationStatus,
+  } = useGetBucketLocation({ Bucket: data.Name });
+
+  const {
+    data: instanceStatus,
+    status: instanceStatusStatus,
+  } = useInstanceStatusQuery();
+
+  // 'pending' (react-query v5 via data-browser-library) vs 'loading' (react-query v3 via useInstanceStatusQuery)
+  if (locationStatus === 'pending' || instanceStatusStatus === 'loading') {
+    return <Loader size="small" />;
+  }
+
+  if (locationStatus === 'error' || instanceStatusStatus === 'error')
+    return <EmptyCell mr={0} />;
+
+  const locationConstraint = bucketLocation?.LocationConstraint || 'us-east-1';
+  const ingestionStates =
+    instanceStatus?.metrics?.['ingest-schedule']?.states;
+  const { value } = getLocationIngestionState(
+    ingestionStates,
+    locationConstraint,
+  );
+
+  if (value === '-') return <EmptyCell mr={0} />;
+  return <>{value}</>;
+};

--- a/src/react/databrowser/buckets/__tests__/MetadataUpdatesColumn.test.tsx
+++ b/src/react/databrowser/buckets/__tests__/MetadataUpdatesColumn.test.tsx
@@ -1,0 +1,147 @@
+import { type Bucket, useGetBucketLocation } from '@scality/data-browser-library';
+import { render, screen } from '@testing-library/react';
+import { ThemeProvider } from 'styled-components';
+import { theme } from '../../../utils/testUtil';
+import { MetadataUpdatesColumn } from '../MetadataUpdatesColumn';
+
+const mockUseGetBucketLocation = jest.mocked(useGetBucketLocation);
+
+const mockUseInstanceStatusQuery = jest.fn();
+jest.mock('../../../queries/instanceStatusQuery', () => ({
+  useInstanceStatusQuery: () => mockUseInstanceStatusQuery(),
+}));
+
+const renderColumn = (bucketName = 'test-bucket') =>
+  render(
+    <ThemeProvider theme={theme}>
+      <MetadataUpdatesColumn data={{ Name: bucketName } as Bucket} />
+    </ThemeProvider>,
+  );
+
+describe('MetadataUpdatesColumn', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should not render status while bucket location is loading', () => {
+    mockUseGetBucketLocation.mockReturnValue({
+      data: undefined,
+      status: 'pending',
+    } as any);
+    mockUseInstanceStatusQuery.mockReturnValue({
+      data: undefined,
+      status: 'success',
+    });
+
+    renderColumn();
+
+    expect(screen.queryByText('Active')).not.toBeInTheDocument();
+    expect(screen.queryByText('Paused')).not.toBeInTheDocument();
+  });
+
+  it('should not render status while instance status is loading', () => {
+    mockUseGetBucketLocation.mockReturnValue({
+      data: { LocationConstraint: 'test-xdm' },
+      status: 'success',
+    } as any);
+    mockUseInstanceStatusQuery.mockReturnValue({
+      data: undefined,
+      status: 'loading',
+    });
+
+    renderColumn();
+
+    expect(screen.queryByText('Active')).not.toBeInTheDocument();
+    expect(screen.queryByText('Paused')).not.toBeInTheDocument();
+  });
+
+  it('should not render status when bucket location query fails', () => {
+    mockUseGetBucketLocation.mockReturnValue({
+      data: undefined,
+      status: 'error',
+    } as any);
+    mockUseInstanceStatusQuery.mockReturnValue({
+      data: { metrics: { 'ingest-schedule': { states: {} } } },
+      status: 'success',
+    });
+
+    renderColumn();
+
+    expect(screen.queryByText('Active')).not.toBeInTheDocument();
+    expect(screen.queryByText('Paused')).not.toBeInTheDocument();
+  });
+
+  it('should not render status when instance status query fails', () => {
+    mockUseGetBucketLocation.mockReturnValue({
+      data: { LocationConstraint: 'test-xdm' },
+      status: 'success',
+    } as any);
+    mockUseInstanceStatusQuery.mockReturnValue({
+      data: undefined,
+      status: 'error',
+    });
+
+    renderColumn();
+
+    expect(screen.queryByText('Active')).not.toBeInTheDocument();
+    expect(screen.queryByText('Paused')).not.toBeInTheDocument();
+  });
+
+  it('should show "Active" when ingestion is enabled for bucket location', () => {
+    mockUseGetBucketLocation.mockReturnValue({
+      data: { LocationConstraint: 'test-xdm' },
+      status: 'success',
+    } as any);
+    mockUseInstanceStatusQuery.mockReturnValue({
+      data: {
+        metrics: {
+          'ingest-schedule': { states: { 'test-xdm': 'enabled' } },
+        },
+      },
+      status: 'success',
+    });
+
+    renderColumn();
+
+    expect(screen.getByText('Active')).toBeInTheDocument();
+  });
+
+  it('should show "Paused" when ingestion is disabled for bucket location', () => {
+    mockUseGetBucketLocation.mockReturnValue({
+      data: { LocationConstraint: 'test-xdm' },
+      status: 'success',
+    } as any);
+    mockUseInstanceStatusQuery.mockReturnValue({
+      data: {
+        metrics: {
+          'ingest-schedule': { states: { 'test-xdm': 'disabled' } },
+        },
+      },
+      status: 'success',
+    });
+
+    renderColumn();
+
+    expect(screen.getByText('Paused')).toBeInTheDocument();
+  });
+
+  it('should not show Active or Paused when bucket has no ingestion', () => {
+    mockUseGetBucketLocation.mockReturnValue({
+      data: { LocationConstraint: 'us-east-1' },
+      status: 'success',
+    } as any);
+    mockUseInstanceStatusQuery.mockReturnValue({
+      data: {
+        metrics: {
+          'ingest-schedule': { states: {} },
+        },
+      },
+      status: 'success',
+    });
+
+    renderColumn();
+
+    expect(screen.queryByText('Active')).not.toBeInTheDocument();
+    expect(screen.queryByText('Paused')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- Restores the "Metadata updates" column in the bucket list that was lost during the migration to `DataBrowserUI` in 4.2
- Column is conditionally displayed when XDM feature flag is enabled, matching 4.1 behavior
- Shows ingestion status (Active / Paused) per bucket, or a dash for non-applicable buckets

Closes #1132

## Test plan
- [ ] Verify the "Metadata updates" column appears in the bucket list when XDM is enabled
- [ ] Verify XDM buckets display "Active" or "Paused" status correctly
- [ ] Verify non-XDM buckets display a dash (—) in the column
- [ ] Verify the column does not appear when XDM feature is disabled