### PR TITLE
fix(ZKUI-475): scope storage-manager-role filter to zenko-ui only

### DIFF
--- a/src/react/ui-elements/SelectAccountIAMRole.tsx
+++ b/src/react/ui-elements/SelectAccountIAMRole.tsx
@@ -19,7 +19,7 @@ import {
 } from '../next-architecture/ui/AccessibleAccountsAdapterProvider';
 import { AccountsLocationsEndpointsAdapterProvider } from '../next-architecture/ui/AccountsLocationsEndpointsAdapterProvider';
 import { getListRolesQuery } from '../queries';
-import { regexArn, SCALITY_IAM_ROLES, STORAGE_MANAGER_ROLE } from '../utils/hooks';
+import { regexArn, SCALITY_IAM_ROLES } from '../utils/hooks';
 
 export class NoOpMetricsAdapter implements IMetricsAdapter {
   async listBucketsLatestUsedCapacity(buckets: Bucket[]): Promise<Record<string, LatestUsedCapacity>> {
@@ -164,21 +164,11 @@ const SelectAccountIAMRoleWithAccount = (props: SelectAccountIAMRoleWithAccountP
   };
   const roleQueryData = useQuery(listRolesQuery);
 
-  const unfilteredRoles = roleQueryData?.data?.Roles ?? [];
-
-  const storageManagerFiltered = unfilteredRoles.some((r) => r.RoleName === STORAGE_MANAGER_ROLE)
-    ? unfilteredRoles.filter((r) => r.RoleName === STORAGE_MANAGER_ROLE)
-    : unfilteredRoles;
-
   const roles = props.filterOutInternalRoles
-    ? storageManagerFiltered.filter((role) => {
-        return (
-          role.RoleName === STORAGE_MANAGER_ROLE ||
-          SCALITY_IAM_ROLES.includes(role.RoleName) ||
-          !role.Arn.includes('role/scality-internal')
-        );
+    ? (roleQueryData?.data?.Roles ?? []).filter((role) => {
+        return SCALITY_IAM_ROLES.includes(role.RoleName) || !role.Arn.includes('role/scality-internal');
       })
-    : storageManagerFiltered;
+    : (roleQueryData?.data?.Roles ?? []);
 
   const isDefaultAccountSelected = account?.name === defaultValue?.accountName;
   const defaultRole = isDefaultAccountSelected ? defaultValue?.roleName : null;

--- a/src/react/ui-elements/__tests__/SelectAccountIAMRole.test.tsx
+++ b/src/react/ui-elements/__tests__/SelectAccountIAMRole.test.tsx
@@ -184,6 +184,15 @@ const commonIAMHandlers = (getPayloadFn: jest.Mock, req, res, ctx) => {
                 <CreateDate>2024-04-17T16:31:36Z</CreateDate>
               </member>
               <member>
+                <AssumeRolePolicyDocument>%7B%22Statement%22%3A%5B%7B%22Action%22%3A%22sts%3AAssumeRoleWithWebIdentity%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22keycloak%3Aroles%22%3A%22StorageManager%22%7D%7D%2C%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Federated%22%3A%22https%3A%2F%2Fui.pod-choco.local%2Fauth%2Frealms%2Fartesca%22%7D%7D%2C%7B%22Action%22%3A%22sts%3AAssumeRoleWithWebIdentity%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22keycloak%3Aroles%22%3A%22StorageManager%22%7D%7D%2C%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Federated%22%3A%22https%3A%2F%2F13.48.197.10%3A8443%2Fauth%2Frealms%2Fartesca%22%7D%7D%5D%2C%22Version%22%3A%222012-10-17%22%7D</AssumeRolePolicyDocument>
+                <Description>Has all permissions and full access to the 100 account resources and manages ARTESCA users.</Description>
+                <Path>/scality-internal/</Path>
+                <RoleName>storage-manager-role</RoleName>
+                <RoleId>YRA3NTDUTWN6DRN76LSSDM6HA22RWBO9</RoleId>
+                <Arn>arn:aws:iam::232853836441:role/scality-internal/storage-manager-role</Arn>
+                <CreateDate>2024-04-17T16:31:36Z</CreateDate>
+              </member>
+              <member>
                 <AssumeRolePolicyDocument>%7B%22Statement%22%3A%5B%7B%22Action%22%3A%22sts%3AAssumeRoleWithWebIdentity%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22keycloak%3Agroups%22%3A%22100%3A%3ADataConsumer%22%7D%7D%2C%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Federated%22%3A%22https%3A%2F%2Fui.pod-choco.local%2Fauth%2Frealms%2Fartesca%22%7D%7D%2C%7B%22Action%22%3A%22sts%3AAssumeRoleWithWebIdentity%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22keycloak%3Agroups%22%3A%22100%3A%3ADataConsumer%22%7D%7D%2C%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Federated%22%3A%22https%3A%2F%2F13.48.197.10%3A8443%2Fauth%2Frealms%2Fartesca%22%7D%7D%5D%2C%22Version%22%3A%222012-10-17%22%7D</AssumeRolePolicyDocument>
                 <Description>No keycloak role</Description>
                 <Path>/</Path>
@@ -1000,146 +1009,5 @@ describe('SelectAccountIAMRole', () => {
       name: /data-consumer-role/i,
     });
     expect(compatibleOption).not.toHaveAttribute('aria-disabled', 'true');
-  });
-
-  it('should only display storage-manager-role when it is present among the roles', async () => {
-    const getPayloadFn = jest.fn();
-    server.use(
-      rest.post(`${TEST_API_BASE_URL}/`, (req, res, ctx) => {
-        //@ts-ignore
-        const params = new URLSearchParams(req.body);
-        if (params.get('Action') === 'ListRoles') {
-          return res(
-            ctx.xml(`
-              <ListRolesResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
-                <ListRolesResult>
-                  <Roles>
-                    <member>
-                      <AssumeRolePolicyDocument>%7B%22Statement%22%3A%5B%7B%22Action%22%3A%22sts%3AAssumeRoleWithWebIdentity%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22keycloak%3Aroles%22%3A%22StorageManager%22%7D%7D%2C%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Federated%22%3A%22https%3A%2F%2Fui.pod-choco.local%2Fauth%2Frealms%2Fartesca%22%7D%7D%5D%2C%22Version%22%3A%222012-10-17%22%7D</AssumeRolePolicyDocument>
-                      <Description>Storage Manager</Description>
-                      <Path>/scality-internal/</Path>
-                      <RoleName>storage-manager-role</RoleName>
-                      <RoleId>YRA3NTDUTWN6DRN76LSSDM6HA22RWBO9</RoleId>
-                      <Arn>arn:aws:iam::232853836441:role/scality-internal/storage-manager-role</Arn>
-                      <CreateDate>2024-04-17T16:31:36Z</CreateDate>
-                    </member>
-                    <member>
-                      <AssumeRolePolicyDocument>%7B%22Statement%22%3A%5B%7B%22Action%22%3A%22sts%3AAssumeRoleWithWebIdentity%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22keycloak%3Agroups%22%3A%22100%3A%3ADataConsumer%22%7D%7D%2C%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Federated%22%3A%22https%3A%2F%2Fui.pod-choco.local%2Fauth%2Frealms%2Fartesca%22%7D%7D%5D%2C%22Version%22%3A%222012-10-17%22%7D</AssumeRolePolicyDocument>
-                      <Description>Data Consumer</Description>
-                      <Path>/scality-internal/</Path>
-                      <RoleName>data-consumer-role</RoleName>
-                      <RoleId>YGEX9QWC7RI9KMBQEKS4RA9OND4JZ35U</RoleId>
-                      <Arn>arn:aws:iam::232853836441:role/scality-internal/data-consumer-role</Arn>
-                      <CreateDate>2024-04-17T16:31:36Z</CreateDate>
-                    </member>
-                    <member>
-                      <AssumeRolePolicyDocument>%7B%22Statement%22%3A%5B%7B%22Action%22%3A%22sts%3AAssumeRoleWithWebIdentity%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22keycloak%3Agroups%22%3A%22100%3A%3AStorageAccountOwner%22%7D%7D%2C%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Federated%22%3A%22https%3A%2F%2Fui.pod-choco.local%2Fauth%2Frealms%2Fartesca%22%7D%7D%5D%2C%22Version%22%3A%222012-10-17%22%7D</AssumeRolePolicyDocument>
-                      <Description>Storage Account Owner</Description>
-                      <Path>/scality-internal/</Path>
-                      <RoleName>storage-account-owner-role</RoleName>
-                      <RoleId>OYYDW5GLCETHME90KWAZCG5Z8KNZA1OT</RoleId>
-                      <Arn>arn:aws:iam::232853836441:role/scality-internal/storage-account-owner-role</Arn>
-                      <CreateDate>2024-04-17T16:31:36Z</CreateDate>
-                    </member>
-                  </Roles>
-                  <IsTruncated>false</IsTruncated>
-                </ListRolesResult>
-              </ListRolesResponse>
-            `),
-          );
-        }
-        return commonIAMHandlers(getPayloadFn, req, res, ctx);
-      }),
-    );
-    const onChange = jest.fn();
-    render(
-      <LocalWrapper>
-        <SelectAccountIAMRole onChange={onChange} />
-      </LocalWrapper>,
-    );
-
-    await waitFor(() => {
-      expect(seletors.accountSelect()).toBeInTheDocument();
-    });
-
-    await userEvent.click(seletors.accountSelect());
-    await userEvent.click(seletors.selectOption(/no-bucket/i));
-
-    await waitFor(() => {
-      expect(seletors.roleSelect()).toBeInTheDocument();
-    });
-
-    await userEvent.click(seletors.roleSelect());
-
-    // Only storage-manager-role should be visible
-    expect(screen.getByRole('option', { name: /storage-manager-role/i })).toBeInTheDocument();
-    expect(screen.queryByRole('option', { name: /data-consumer-role/i })).not.toBeInTheDocument();
-    expect(screen.queryByRole('option', { name: /storage-account-owner-role/i })).not.toBeInTheDocument();
-  });
-
-  it('should display storage-manager-role even when filterOutInternalRoles is true', async () => {
-    const getPayloadFn = jest.fn();
-    server.use(
-      rest.post(`${TEST_API_BASE_URL}/`, (req, res, ctx) => {
-        //@ts-ignore
-        const params = new URLSearchParams(req.body);
-        if (params.get('Action') === 'ListRoles') {
-          return res(
-            ctx.xml(`
-              <ListRolesResponse xmlns="https://iam.amazonaws.com/doc/2010-05-08/">
-                <ListRolesResult>
-                  <Roles>
-                    <member>
-                      <AssumeRolePolicyDocument>%7B%22Statement%22%3A%5B%7B%22Action%22%3A%22sts%3AAssumeRoleWithWebIdentity%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22keycloak%3Aroles%22%3A%22StorageManager%22%7D%7D%2C%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Federated%22%3A%22https%3A%2F%2Fui.pod-choco.local%2Fauth%2Frealms%2Fartesca%22%7D%7D%5D%2C%22Version%22%3A%222012-10-17%22%7D</AssumeRolePolicyDocument>
-                      <Description>Storage Manager</Description>
-                      <Path>/scality-internal/</Path>
-                      <RoleName>storage-manager-role</RoleName>
-                      <RoleId>YRA3NTDUTWN6DRN76LSSDM6HA22RWBO9</RoleId>
-                      <Arn>arn:aws:iam::232853836441:role/scality-internal/storage-manager-role</Arn>
-                      <CreateDate>2024-04-17T16:31:36Z</CreateDate>
-                    </member>
-                    <member>
-                      <AssumeRolePolicyDocument>%7B%22Statement%22%3A%5B%7B%22Action%22%3A%22sts%3AAssumeRoleWithWebIdentity%22%2C%22Condition%22%3A%7B%22StringEquals%22%3A%7B%22keycloak%3Agroups%22%3A%22100%3A%3ADataConsumer%22%7D%7D%2C%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Federated%22%3A%22https%3A%2F%2Fui.pod-choco.local%2Fauth%2Frealms%2Fartesca%22%7D%7D%5D%2C%22Version%22%3A%222012-10-17%22%7D</AssumeRolePolicyDocument>
-                      <Description>Data Consumer</Description>
-                      <Path>/scality-internal/</Path>
-                      <RoleName>data-consumer-role</RoleName>
-                      <RoleId>YGEX9QWC7RI9KMBQEKS4RA9OND4JZ35U</RoleId>
-                      <Arn>arn:aws:iam::232853836441:role/scality-internal/data-consumer-role</Arn>
-                      <CreateDate>2024-04-17T16:31:36Z</CreateDate>
-                    </member>
-                  </Roles>
-                  <IsTruncated>false</IsTruncated>
-                </ListRolesResult>
-              </ListRolesResponse>
-            `),
-          );
-        }
-        return commonIAMHandlers(getPayloadFn, req, res, ctx);
-      }),
-    );
-    const onChange = jest.fn();
-    render(
-      <LocalWrapper>
-        <SelectAccountIAMRole onChange={onChange} filterOutInternalRoles />
-      </LocalWrapper>,
-    );
-
-    await waitFor(() => {
-      expect(seletors.accountSelect()).toBeInTheDocument();
-    });
-
-    await userEvent.click(seletors.accountSelect());
-    await userEvent.click(seletors.selectOption(/no-bucket/i));
-
-    await waitFor(() => {
-      expect(seletors.roleSelect()).toBeInTheDocument();
-    });
-
-    await userEvent.click(seletors.roleSelect());
-
-    // storage-manager-role should still be visible even though it's under /scality-internal/
-    expect(screen.getByRole('option', { name: /storage-manager-role/i })).toBeInTheDocument();
-    // other internal roles should be filtered out
-    expect(screen.queryByRole('option', { name: /data-consumer-role/i })).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

- Remove the storage-manager-role superseding filter from `SelectAccountIAMRole` (shared component exposed via Module Federation to identity-ui)
- Keep the filter in `AccountRoleSelectButtonAndModal` (zenko-ui internal modal) as intended by ZKUI-475
- Restore `storage-manager-role` mock data in shared test fixtures and remove tests that validated the now-removed filter

## Context

PR #1112 applied the storage-manager-role filter to both role selection components. However, `SelectAccountIAMRole` is consumed by identity-ui's `AttachRoleModal` via Module Federation, where all roles need to be visible. The filter should only apply to zenko-ui's own Select Role modal (`AccountRoleSelectButtonAndModal`).

## Test plan

- [ ] Verify zenko-ui Select Role modal still only shows `storage-manager-role` when it exists for an account
- [ ] Verify identity-ui AttachRoleModal displays all available roles including `storage-manager-role`
- [ ] Existing `SelectAccountIAMRole` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)