### PR TITLE
fix(ZKUI-488): correct ISV modal navigation to bucket creation page

### DIFF
--- a/src/react/ISV/components/Modal/ISVModal.tsx
+++ b/src/react/ISV/components/Modal/ISVModal.tsx
@@ -144,14 +144,14 @@ const ISVModal = ({ isOpen, setIsOpen }) => {
   const navigate = useBasenameRelativeNavigate();
   const [selectedISV, setSelectedISV] = useState<ISVCardConfig>(null);
   const url = useLocation();
-  const match = url.pathname.match(/accounts\/([^/]+)\/buckets/);
+  const match = url.pathname.match(/accounts\/([^/]+)/);
   const accountName = match ? match[1] : null;
 
   const handleContinueClick = () => {
     if (selectedISV?.assistant) {
       navigate(`/isv/configuration?platform=${selectedISV.id}${accountName ? `&account=${accountName}` : ''}`);
     } else if (accountName) {
-      navigate(`/accounts/${accountName}/create-bucket`);
+      navigate(`/accounts/${accountName}/buckets/-/create`);
     } else {
       navigate(`/create-account`);
     }

--- a/src/react/ui-elements/Breadcrumb.tsx
+++ b/src/react/ui-elements/Breadcrumb.tsx
@@ -53,7 +53,7 @@ export const breadcrumbPathsBuckets = (
   basePath: string,
 ): JSX.IntrinsicElements['label'][] => {
   const accountsURLPrefix = `/accounts/:accountName`;
-  const matchCreateBucketRoute = matchPath(basePath + `${accountsURLPrefix}/create-bucket`, pathname);
+  const matchCreateBucketRoute = matchPath(basePath + `${accountsURLPrefix}/buckets/-/create`, pathname);
   if (matchCreateBucketRoute) {
     return [<label key="buckets">create bucket</label>];
   }


### PR DESCRIPTION
## Summary
- Fix wrong navigation URL in ISVModal: `/accounts/${accountName}/create-bucket` -> `/accounts/${accountName}/buckets/-/create`
- Broaden `accountName` extraction regex to match any account-scoped URL, not just bucket pages

## JIRA
[ZKUI-488](https://scality.atlassian.net/browse/ZKUI-488)

## Root Cause
The `handleContinueClick` in `ISVModal.tsx` navigated to a non-existent route (`/create-bucket`), causing it to fall through to the catch-all route and render the account page instead of the bucket creation form. Additionally, the regex only extracted `accountName` from URLs containing `/buckets/`, so the modal failed when opened from non-bucket pages.

## Test plan
- [ ] Open ISV modal from the Data Browser page and click "Continue to Create bucket" — verify it navigates to the bucket creation form
- [ ] Open ISV modal from a non-bucket account page — verify `accountName` is correctly extracted and navigation works

Closes https://github.com/scality/zenko-ui/issues/1142

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ZKUI-488]: https://scality.atlassian.net/browse/ZKUI-488?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ