### PR TITLE
ZKUI-490: Bump data-browser-library to 1.1.14

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@scality/certchain": "1.4.0",
         "@scality/core-ui": "0.202.0",
-        "@scality/data-browser-library": "1.1.13",
+        "@scality/data-browser-library": "1.1.14",
         "@scality/module-federation": "1.6.1",
         "@scality/react-chained-query": "^2.1.0",
         "@types/react-table": "^7.7.10",
@@ -5690,9 +5690,9 @@
       }
     },
     "node_modules/@scality/data-browser-library": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.13.tgz",
-      "integrity": "sha512-V6GeOb0EHds0gknu7WwCbZ8WZQk8f/PGMZZEctCpC/r2zcYnlfyg1BCdd1bLm31PB2V6+u+yRyAbTubpErFDRQ==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.14.tgz",
+      "integrity": "sha512-3Zj01u6FHCEC7sQtA6UpdJsOBka5yIvMZs6TpuTvmv8z/Np4zeWF8xD/wgPINLBqmDldb05p0RFoXSpZ4ZyPtA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.983.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@scality/certchain": "1.4.0",
     "@scality/core-ui": "0.202.0",
-    "@scality/data-browser-library": "1.1.13",
+    "@scality/data-browser-library": "1.1.14",
     "@scality/module-federation": "1.6.1",
     "@scality/react-chained-query": "^2.1.0",
     "@types/react-table": "^7.7.10",


### PR DESCRIPTION
## Summary
Automated bump of `@scality/data-browser-library`.

## Links
- Release: https://github.com/scality/data-browser/releases/tag/1.1.14
- Jira: https://scality.atlassian.net/browse/ZKUI-490

🤖 Generated by data-browser auto-bump