### PR TITLE
improvement(ZKUI-484): disable versioning toggle for unsupported storage locations

### DIFF
--- a/src/react/databrowser/DataBrowser.tsx
+++ b/src/react/databrowser/DataBrowser.tsx
@@ -9,6 +9,9 @@ import { useAccountsLocationsEndpointsAdapter } from '../next-architecture/ui/Ac
 import { useConfig } from '../next-architecture/ui/ConfigProvider';
 import { Breadcrumb, breadcrumbPathsBuckets } from '../ui-elements/Breadcrumb';
 import { useAuthGroups, useQueryParams } from '../utils/hooks';
+import { storageOptions } from '../locations/LocationDetails';
+import type { LocationTypeKey } from '../../types/config';
+import type { LocationInfo } from '../next-architecture/adapters/accounts-locations/ILocationsAdapter';
 import { BucketLocationsPrefetch } from './BucketLocationsPrefetch';
 import { BucketCreateVersioning } from './buckets/BucketCreateVersioning';
 import { DataUsedColumn } from './buckets/DataUsedColumn';
@@ -39,6 +42,24 @@ const EXTRA_BUCKET_OVERVIEW_GENERAL = [
   },
 ];
 
+export function getVersioningDisabledStatus(
+  locations: LocationInfo[],
+  locationConstraint: string,
+): { disabled: boolean; tooltip?: string } {
+  const location = locations.find((loc) => loc.name === locationConstraint);
+  if (!location) return { disabled: false };
+  const options = (storageOptions as Partial<Record<string, (typeof storageOptions)[LocationTypeKey]>>)[
+    location.type as unknown as string
+  ];
+  if (options && !options.supportsVersioning) {
+    return {
+      disabled: true,
+      tooltip: `Versioning is not supported on ${options.name}.`,
+    };
+  }
+  return { disabled: false };
+}
+
 export default function DataBrowser({ hideHeader = false }: { hideHeader?: boolean }) {
   const { accountName } = useParams<{ accountName: string }>();
   const { isStorageManager } = useAuthGroups();
@@ -64,6 +85,11 @@ export default function DataBrowser({ hideHeader = false }: { hideHeader?: boole
 
   const isLocationCold = useCallback(
     (locationName: string) => locations.some((loc) => loc.name === locationName && loc.isCold),
+    [locations],
+  );
+
+  const isVersioningDisabled = useCallback(
+    (locationConstraint: string) => getVersioningDisabledStatus(locations, locationConstraint),
     [locations],
   );
 
@@ -140,6 +166,7 @@ export default function DataBrowser({ hideHeader = false }: { hideHeader?: boole
         replicationRoleDefault="arn:aws:iam::root:role/s3-replication-role"
         replicationDestinationFields={ReplicationCRRDestinationFields}
         isLocationCold={isLocationCold}
+        isVersioningDisabled={isVersioningDisabled}
       />
     </>
   );

--- a/src/react/databrowser/__tests__/getVersioningDisabledStatus.test.ts
+++ b/src/react/databrowser/__tests__/getVersioningDisabledStatus.test.ts
@@ -1,0 +1,66 @@
+import { LocationType } from '../../../js/managementClient/api';
+import type { LocationInfo } from '../../next-architecture/adapters/accounts-locations/ILocationsAdapter';
+import { getVersioningDisabledStatus } from '../DataBrowser';
+
+function makeLocation(name: string, type: LocationType): LocationInfo {
+  return { id: name, name, type, details: {} };
+}
+
+const locations: LocationInfo[] = [
+  makeLocation('my-azure', LocationType.AzureV1),
+  makeLocation('my-gcp', LocationType.GcpV1),
+  makeLocation('my-azure-archive', LocationType.AzureArchiveV1),
+  makeLocation('my-do-spaces', LocationType.DoSpacesV1),
+  makeLocation('my-nfs', LocationType.NfsMountV1),
+  makeLocation('my-aws', LocationType.AwsS3V1),
+  makeLocation('my-ring', LocationType.ScalityRingS3V1),
+];
+
+describe('getVersioningDisabledStatus', () => {
+  it('disables versioning for Azure locations', () => {
+    const result = getVersioningDisabledStatus(locations, 'my-azure');
+    expect(result.disabled).toBe(true);
+    expect(result.tooltip).toContain('Microsoft Azure Blob Storage');
+  });
+
+  it('disables versioning for Google Cloud locations', () => {
+    const result = getVersioningDisabledStatus(locations, 'my-gcp');
+    expect(result.disabled).toBe(true);
+    expect(result.tooltip).toContain('Google Cloud Storage');
+  });
+
+  it('disables versioning for Azure Archive locations', () => {
+    const result = getVersioningDisabledStatus(locations, 'my-azure-archive');
+    expect(result.disabled).toBe(true);
+    expect(result.tooltip).toContain('Microsoft Azure Archive');
+  });
+
+  it('disables versioning for DigitalOcean Spaces locations', () => {
+    const result = getVersioningDisabledStatus(locations, 'my-do-spaces');
+    expect(result.disabled).toBe(true);
+    expect(result.tooltip).toContain('DigitalOcean Spaces');
+  });
+
+  it('disables versioning for NFS Mount locations', () => {
+    const result = getVersioningDisabledStatus(locations, 'my-nfs');
+    expect(result.disabled).toBe(true);
+    expect(result.tooltip).toContain('NFS Mount');
+  });
+
+  it('allows versioning for AWS S3 locations', () => {
+    const result = getVersioningDisabledStatus(locations, 'my-aws');
+    expect(result.disabled).toBe(false);
+    expect(result.tooltip).toBeUndefined();
+  });
+
+  it('allows versioning for RING S3 locations', () => {
+    const result = getVersioningDisabledStatus(locations, 'my-ring');
+    expect(result.disabled).toBe(false);
+    expect(result.tooltip).toBeUndefined();
+  });
+
+  it('allows versioning for unknown locations', () => {
+    const result = getVersioningDisabledStatus(locations, 'unknown-location');
+    expect(result.disabled).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Wires up the `isVersioningDisabled` callback from data-browser-library to disable the versioning toggle for storage locations that don't support it (Azure, GCP, Azure Archive, DigitalOcean Spaces, NFS Mount)
- Displays a tooltip explaining why versioning is unavailable, e.g. "Versioning is not supported on Microsoft Azure Blob Storage."
- Uses the existing `locations` array and `storageOptions` registry — no additional hooks or API calls needed

## What's next

This completes ZKUI-484.