### PR TITLE
Introduce renovate for docker base image

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "enabledManagers": ["dockerfile"],
+  "packageRules": [
+    {
+      "matchManagers": ["dockerfile"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "labels": ["dependencies", "docker"]
+    },
+    {
+      "matchManagers": ["dockerfile"],
+      "matchUpdateTypes": ["major"],
+      "labels": ["dependencies", "docker", "major"]
+    }
+  ]
+}


### PR DESCRIPTION
- Add Renovate config scoped to Dockerfile base image updates only (enabledManagers: ["dockerfile"])
- All Docker image update PRs (minor, patch, major) require manual review before merging
- Keep Dependabot for npm and GitHub Actions dependency updates


Ref: https://github.com/scality/artesca/issues/4978