### PR TITLE
Adding the github renovate workflow

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -1,0 +1,29 @@
+name: Renovate
+on:
+  schedule:
+    - cron: "0 8 * * 1-5" # Weekdays at 8am UTC
+  workflow_dispatch: # Allow manual trigger
+
+jobs:
+  renovate:
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ vars.ACTIONS_APP_ID }}
+          private-key: ${{ secrets.ACTIONS_APP_PRIVATE_KEY }}
+          owner: ${{ github.repository_owner }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Run Renovate
+        uses: renovatebot/github-action@v46.1.9
+        with:
+          configurationFile: renovate.json
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Adds a GitHub Actions workflow to run Renovate on a daily schedule for Dockerfile updates.


I will test it only after this PR is merged. And I will apply it across all our Pod UI owned repositories.


Ref: [ARTESCA-17151](https://scality.atlassian.net/browse/ARTESCA-17151)


[ARTESCA-17151]: https://scality.atlassian.net/browse/ARTESCA-17151?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
Agent task analysis: https://github.com/scality/artesca/issues/4978