### PR TITLE
Renovate workflow - Fix "No repositories found" 

### DIFF
--- a/.github/workflows/renovate.yaml
+++ b/.github/workflows/renovate.yaml
@@ -11,14 +11,14 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ vars.ACTIONS_APP_ID }}
           private-key: ${{ secrets.ACTIONS_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           token: ${{ steps.app-token.outputs.token }}
 
@@ -27,3 +27,5 @@ jobs:
         with:
           configurationFile: renovate.json
           token: ${{ steps.app-token.outputs.token }}
+        env:
+          RENOVATE_REPOSITORIES: ${{ github.repository }}


### PR DESCRIPTION
To fix the issue [No repositories found](https://github.com/scality/zenko-ui/actions/runs/24348934415/job/71097549293) found when maunally trigger the Renovate workflow. 
```
[14:29:50.324] INFO (8): Initializing tools all...
[14:29:50.479] INFO (8): Initialize tools all succeded in 155ms.
 INFO: Renovate started "renovateVersion": "43.111.3"
 WARN: No repositories found - did you want to run with flag --autodiscover?
```

