### PR TITLE
ARTESCA-17151 - Define branch naming for renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
   "enabledManagers": ["dockerfile"],
+  "branchPrefix": "improvement/renovate-",
   "packageRules": [
     {
       "matchManagers": ["dockerfile"],


### PR DESCRIPTION
The default branch created by renovate starts with renovate/* which is not recongnize by the CI. 
