### PR TITLE
feat(data-browser): add lifecycleTransition feature flag to S3 config

### DIFF
--- a/src/react/DataServiceRoleProvider.tsx
+++ b/src/react/DataServiceRoleProvider.tsx
@@ -75,7 +75,7 @@ const useS3ConfigFromAssumeRoleResult = () => {
       endpoint,
       region: DEFAULT_REGION,
       forcePathStyle: true,
-      features: ['ISV', 'metadatasearch', 'replicationV1'],
+      features: ['ISV', 'metadatasearch', 'replicationV1', 'lifecycleTransition'],
       cacheKey,
       proxy: {
         enabled: true,


### PR DESCRIPTION
## Summary

Add `'lifecycleTransition'` to the hardcoded features array in `DataServiceRoleProvider.tsx` so ARTESCA deployments pass the flag through to the data-browser library, which already gates lifecycle transition UI sections behind this feature flag.

This is a one-line integration change — the upstream data-browser fix (scality/data-browser PR #343) added the feature flag mechanism, and this change enables it for ARTESCA.

## Changes

- [x] **Step 1: Add 'lifecycleTransition' to S3 config features array** — Appended `'lifecycleTransition'` to the features array in `useS3ConfigFromAssumeRoleResult` (`src/react/DataServiceRoleProvider.tsx`)

```diff
- features: ['ISV', 'metadatasearch', 'replicationV1']
+ features: ['ISV', 'metadatasearch', 'replicationV1', 'lifecycleTransition']
```

## Test Strategy

Jest is the test framework; tests live in `src/react/__tests__/DataServiceRoleProvider.test.tsx`. No existing test asserts on the specific contents of the features array, so no test updates are strictly required. The key case is that `getS3Config` still returns a valid `S3BrowserConfig`-compatible object. Run `npx jest DataServiceRoleProvider` to confirm.

## Risks & Notes

- The `features` field is typed as `string[]` in `src/types/entities.ts` and `S3BrowserConfig` (from data-browser-library). If the installed version of `@scality/data-browser-library` does not yet include `'lifecycleTransition'` as a valid Feature union member, TypeScript compilation may fail — verify the data-browser dependency version includes the upstream fix before merging.
- ARTESCA/zenko-ui integration is the only scope here; RING/federation deployments are intentionally excluded since their config omits the flag, naturally hiding transitions.

## References

- **JIRA:** [RING-53647](https://scality.atlassian.net/browse/RING-53647)
- **Tracking Issue:** scality/agent-task#72

[RING-53647]: https://scality.atlassian.net/browse/RING-53647?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ