### PR TITLE
ZKUI-493: Bump data-browser-library to 1.1.16

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@scality/certchain": "1.4.0",
         "@scality/core-ui": "0.202.0",
-        "@scality/data-browser-library": "1.1.15",
+        "@scality/data-browser-library": "1.1.16",
         "@scality/module-federation": "1.6.1",
         "@scality/react-chained-query": "^2.1.0",
         "@types/react-table": "^7.7.10",
@@ -5690,9 +5690,9 @@
       }
     },
     "node_modules/@scality/data-browser-library": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.15.tgz",
-      "integrity": "sha512-2MnkrNjw01Ncw+yN4rvOyMReFE861dnzNsI4uemz1CtMjrebLGQ8XeZj9QIdG5CN0b18R0E05ogUgI4MZDclTA==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.16.tgz",
+      "integrity": "sha512-hT/pT8kVIIfhmkRbmyGa2H2oUeoNzyribKVp9E3PYHw1/zvjGGDLfUYl5pfVO9iKNETGiqEQiCrvR5v7/abuRw==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.983.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@scality/certchain": "1.4.0",
     "@scality/core-ui": "0.202.0",
-    "@scality/data-browser-library": "1.1.15",
+    "@scality/data-browser-library": "1.1.16",
     "@scality/module-federation": "1.6.1",
     "@scality/react-chained-query": "^2.1.0",
     "@types/react-table": "^7.7.10",


### PR DESCRIPTION
## Summary
Automated bump of `@scality/data-browser-library`.

## Links
- Release: https://github.com/scality/data-browser/releases/tag/1.1.16
- Jira: https://scality.atlassian.net/browse/ZKUI-493

🤖 Generated by data-browser auto-bump