### PR TITLE
ZKUI-494: Bump data-browser-library to 1.1.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@scality/certchain": "1.4.0",
         "@scality/core-ui": "0.202.0",
-        "@scality/data-browser-library": "1.1.16",
+        "@scality/data-browser-library": "1.1.17",
         "@scality/module-federation": "1.6.1",
         "@scality/react-chained-query": "^2.1.0",
         "@types/react-table": "^7.7.10",
@@ -5690,9 +5690,9 @@
       }
     },
     "node_modules/@scality/data-browser-library": {
-      "version": "1.1.16",
-      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.16.tgz",
-      "integrity": "sha512-hT/pT8kVIIfhmkRbmyGa2H2oUeoNzyribKVp9E3PYHw1/zvjGGDLfUYl5pfVO9iKNETGiqEQiCrvR5v7/abuRw==",
+      "version": "1.1.17",
+      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.17.tgz",
+      "integrity": "sha512-tVgVyAuAC4NknZi6epgQlru3SW4VpilJcWARiO+dtcmJekIewQddMZ/3l+KzdHJSq7UkTstCcEoOblt05OaIOg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.983.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@scality/certchain": "1.4.0",
     "@scality/core-ui": "0.202.0",
-    "@scality/data-browser-library": "1.1.16",
+    "@scality/data-browser-library": "1.1.17",
     "@scality/module-federation": "1.6.1",
     "@scality/react-chained-query": "^2.1.0",
     "@types/react-table": "^7.7.10",


### PR DESCRIPTION
## Summary
Automated bump of `@scality/data-browser-library`.

## Links
- Release: https://github.com/scality/data-browser/releases/tag/1.1.17
- Jira: https://scality.atlassian.net/browse/ZKUI-494

🤖 Generated by data-browser auto-bump