### PR TITLE
improvement(ZKUI-495): adopt static verb+noun checkbox label pattern

### DIFF
--- a/src/react/databrowser/buckets/BucketCreateLocationEffects.tsx
+++ b/src/react/databrowser/buckets/BucketCreateLocationEffects.tsx
@@ -42,7 +42,7 @@ export function BucketCreateLocationEffects() {
       {showXDM && (
         <FormGroup
           id="isAsyncNotification"
-          label="Async Metadata updates"
+          label="Enable Async Metadata Updates"
           help={
             locationConstraint && isIngest && isAsyncNotification
               ? helpAsyncNotification
@@ -61,7 +61,6 @@ export function BucketCreateLocationEffects() {
                 <Checkbox
                   id="isAsyncNotification"
                   disabled={!isIngest}
-                  label={value ? 'Enabled' : 'Disabled'}
                   checked={!!value}
                   onChange={(e) => onChange(e.target.checked)}
                   ref={ref}

--- a/src/react/databrowser/buckets/BucketCreateVersioning.tsx
+++ b/src/react/databrowser/buckets/BucketCreateVersioning.tsx
@@ -25,7 +25,7 @@ export function BucketCreateVersioning({ isVersioning, isObjectLockEnabled }: Bu
   return (
     <FormGroup
       id="isVersioning"
-      label="Versioning"
+      label="Enable Versioning"
       disabled={isDisabled}
       labelHelpTooltip={
         <ul>
@@ -42,7 +42,6 @@ export function BucketCreateVersioning({ isVersioning, isObjectLockEnabled }: Bu
         <Checkbox
           id="isVersioning"
           disabled={isDisabled}
-          label={isVersioning ? 'Active' : 'Inactive'}
           {...register('isVersioning')}
         />
       }

--- a/src/react/locations/LocationDetails/LocationDetailsAws.tsx
+++ b/src/react/locations/LocationDetails/LocationDetailsAws.tsx
@@ -1,4 +1,4 @@
-import { Checkbox } from '@scality/core-ui/dist/components/checkbox/Checkbox.component';
+import { Checkbox } from '@scality/core-ui';
 import { FormGroup, FormSection } from '@scality/core-ui/dist/components/form/Form.component';
 import { Input } from '@scality/core-ui/dist/components/inputv2/inputv2';
 import React from 'react';
@@ -119,7 +119,7 @@ export default class LocationDetailsAws extends React.Component<LocationDetailsF
         </FormSection>
         <FormSection forceLabelWidth={LOCATION_EDITOR_FORCED_LABEL_WIDTH}>
           <FormGroup
-            label=""
+            label="Write objects without prefix"
             id="bucketMatch"
             direction="vertical"
             helpErrorPosition="bottom"
@@ -135,14 +135,13 @@ export default class LocationDetailsAws extends React.Component<LocationDetailsF
                 checked={this.state.bucketMatch}
                 disabled={this.props.editingExisting}
                 onChange={this.onChange}
-                label="Write objects without prefix"
               />
             }
             help="Store objects in the target bucket without a source-bucket prefix."
           />
 
           <FormGroup
-            label=""
+            label="Enable Server-Side Encryption"
             direction="vertical"
             id="serverSideEncryption"
             helpErrorPosition="bottom"
@@ -153,7 +152,6 @@ export default class LocationDetailsAws extends React.Component<LocationDetailsF
                 value={this.state.serverSideEncryption}
                 checked={this.state.serverSideEncryption}
                 onChange={this.onChange}
-                label="Server-Side Encryption"
               />
             }
           />

--- a/src/react/locations/LocationDetails/LocationDetailsWasabi.tsx
+++ b/src/react/locations/LocationDetails/LocationDetailsWasabi.tsx
@@ -1,4 +1,4 @@
-import { Checkbox } from '@scality/core-ui/dist/components/checkbox/Checkbox.component';
+import { Checkbox } from '@scality/core-ui';
 import { FormGroup, FormSection } from '@scality/core-ui/dist/components/form/Form.component';
 import { Input } from '@scality/core-ui/dist/components/inputv2/inputv2';
 import React from 'react';
@@ -131,7 +131,7 @@ export default class LocationDetailsWasabi extends React.Component<Props, State>
         <FormSection forceLabelWidth={LOCATION_EDITOR_FORCED_LABEL_WIDTH}>
           <FormGroup
             id="bucketMatch"
-            label=""
+            label="Write objects without prefix"
             direction="vertical"
             helpErrorPosition="bottom"
             error={
@@ -147,7 +147,6 @@ export default class LocationDetailsWasabi extends React.Component<Props, State>
                 checked={this.state.bucketMatch}
                 disabled={this.props.editingExisting}
                 onChange={this.onChange}
-                label="Write objects without prefix"
               />
             }
           />


### PR DESCRIPTION
## Summary

- `BucketCreateVersioning.tsx`: replace dynamic `isVersioning ? 'Active' : 'Inactive'` label on `Checkbox` with static `"Enable Versioning"` on `FormGroup`
- `BucketCreateLocationEffects.tsx`: replace dynamic `value ? 'Enabled' : 'Disabled'` label on `Checkbox` with static `"Enable Async Metadata Updates"` on `FormGroup`
- `LocationDetailsWasabi.tsx`: move label `"Write objects without prefix"` from `Checkbox` to `FormGroup`; migrate deep-path import to `@scality/core-ui`
- `LocationDetailsAws.tsx`: move labels from both `Checkbox` components to their wrapping `FormGroup`; update `"Server-Side Encryption"` → `"Enable Server-Side Encryption"`; migrate deep-path import to `@scality/core-ui`

Per the pattern defined in CUI-14: when a `Checkbox` is inside a `FormGroup`, the label belongs on `FormGroup` using a static verb+noun phrase.

Jira: https://scality.atlassian.net/browse/ZKUI-495
Linked to: https://scality.atlassian.net/browse/CUI-14

## Test plan

- [ ] Create bucket form: verify "Enable Versioning" and "Enable Async Metadata Updates" labels are visible and never change based on checkbox state
- [ ] AWS location form: confirm both checkbox labels are shown once (on FormGroup), not duplicated
- [ ] Wasabi location form: confirm "Write objects without prefix" label is shown correctly
- [ ] Toggle each checkbox and verify label text stays static

🤖 Generated with [Claude Code](https://claude.com/claude-code)