### PR TITLE
fix(metrics): handle 204 No Content from account metrics endpoint

### DIFF
--- a/src/js/managementClient/api.ts
+++ b/src/js/managementClient/api.ts
@@ -8951,6 +8951,9 @@ export const UiFacingApiFp = function (configuration?: Configuration) {
       return (fetch: FetchAPI = portableFetch, basePath: string = BASE_PATH) => {
         return fetch(basePath + localVarFetchArgs.url, localVarFetchArgs.options).then((response) => {
           if (response.status >= 200 && response.status < 300) {
+            if (response.status === 204) {
+              return {};
+            }
             return response.json();
           } else {
             throw response;

--- a/src/react/next-architecture/adapters/metrics/PensieveMetricAdapter.test.tsx
+++ b/src/react/next-architecture/adapters/metrics/PensieveMetricAdapter.test.tsx
@@ -178,4 +178,20 @@ describe('PensieveMetricsAdapter - listAccountLocationsLatestUsedCapacity', () =
     };
     expect(result).toStrictEqual(EXPECTED_LOCATIONS_METRICS);
   });
+
+  it('should return empty metrics when pensieve returns 204 No Content', async () => {
+    //S
+    const SUT = new PensieveMetricsAdapter(baseUrl, instanceId, mockGettoken);
+    server.use(
+      rest.get(`${baseUrl}/api/v1/instance/${instanceId}/account/${ACCOUNT_CANONICAL_ID}/metrics`, (req, res, ctx) =>
+        res(ctx.status(204)),
+      ),
+    );
+
+    //E
+    const result = await SUT.listAccountLocationsLatestUsedCapacity(ACCOUNT_CANONICAL_ID);
+
+    //V
+    expect(result).toStrictEqual({});
+  });
 });


### PR DESCRIPTION
## Summary

The Locations tab errors with *"An error occurred while loading the locations, please refresh the page."* when an account has no storage-consumption metrics yet.

Pensieve legitimately returns **204 No Content** from `GET /instance/{uuid}/account/{canonicalId}/metrics` in that case, but the generated management client calls `response.json()` on every 2xx response — which throws on an empty body. React Query surfaces that as an error state.

## Fix

Re-apply the original 2023 fix (`22c74488`) to `getStorageConsumptionMetricsForAccount` in `src/js/managementClient/api.ts`: a 3-line guard that short-circuits 204 before `response.json()` is called.

```ts
if (response.status === 204) {
  return {};
}
```

## Why this is a regression — a twice-bitten history

| Date | Commit | What happened |
|---|---|---|
| 2023-05-11 | `22c74488` | ✅ Original fix applied to `getStorageConsumptionMetricsForAccount` |
| 2026-03-04 17:57 | `2601c0c4` (ZKUI-447) | ⚠️ Regen of management client wiped the fix |
| 2026-03-04 18:39 | `5f4020ac` | ❌ Restore attempt landed on the wrong function (`inviteOrbitUsersByEmail`) |

The bug has silently been back on `development/4.2` since 2026-03-04.

⚠️ **Follow-up needed:** next regen of `api.ts` will wipe this fix again. Either capture it in the codegen template, or add a CI check that verifies the 204 guard is still present.

## Data flow verification

1. `useListLocationsForCurrentAccount` calls `listAccountLocationsLatestUsedCapacity(canonicalId)`
2. Backend returns 204 → **with fix**: `api.ts` returns `{}` instead of calling `response.json()`
3. Adapter: `Object.keys({}.locations || {}) → []` → returns `{}`
4. `locations.ts:221-228` hits the "0 locations" branch → `{ status: 'success', value: {} }`
5. Page renders the empty-state table, no error

## Known limitation (matches 2023 behavior)

If an account has locations configured but no metrics have been measured yet, the page will show "0 location" rather than listing the locations without used-capacity. This is identical to the 2023 fix behavior — `locations.ts` uses the metrics response as the source of truth for "which locations does this account use". Changing that would be a separate ticket.

## Files Changed

| File | Change |
|------|--------|
| `src/js/managementClient/api.ts` | +3 lines: 204 guard in `getStorageConsumptionMetricsForAccount` |
| `src/react/next-architecture/adapters/metrics/PensieveMetricAdapter.test.tsx` | +1 test: 204 → empty result (end-to-end, regen-agnostic) |

## Test plan

- [x] New test `should return empty metrics when pensieve returns 204 No Content` passes
- [x] `PensieveMetricAdapter.test.tsx` — 9/9 pass
- [x] `locations.test.tsx` — 12/12 pass
- [x] `tsc --noEmit` — no new errors (2 pre-existing errors unchanged)
- [ ] Manual: on an account with no metrics, Locations tab renders without error

## References

- **JIRA:** [ARTESCA-17362](https://scality.atlassian.net/browse/ARTESCA-17362)
- **Related PR:** #1165 (same ticket, different scenario: account missing from overlay)
- **Original 2023 fix:** `22c74488`
- **Broken restore:** `5f4020ac`

[ARTESCA-17362]: https://scality.atlassian.net/browse/ARTESCA-17362?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ