### PR TITLE
fix(ISV): sync form state on radio switches to keep Continue enabled

### DIFF
--- a/src/react/ISV/components/ISVFormContext.tsx
+++ b/src/react/ISV/components/ISVFormContext.tsx
@@ -101,13 +101,18 @@ export const ISVFormProvider = ({ platform, formMethods, children }: ISVFormProv
   // Reset IAM fields
   const resetIAMFields = useCallback(
     (mode: 'create' | 'existing', firstAccountName?: string) => {
-      setValue('IAMUserName', '');
       setValue('IAMUserNameType', 'create');
       setSelectedAccount(null);
       if (mode === 'existing' && firstAccountName) {
         setValue('accountName', firstAccountName, { shouldValidate: true });
+        // Pre-fill IAMUserName with accountName so the form is valid even if
+        // onAccountSelected's async mutate never resolves (e.g. AssumeRole
+        // failure). onSuccess will refine this to the actual matching user or
+        // Users[0] once IAM users are fetched.
+        setValue('IAMUserName', firstAccountName, { shouldValidate: true });
       } else {
         setValue('accountName', '', { shouldValidate: true });
+        setValue('IAMUserName', '');
       }
     },
     [setValue],
@@ -128,6 +133,7 @@ export const ISVFormProvider = ({ platform, formMethods, children }: ISVFormProv
             if (user) {
               setValue('IAMUserName', user.UserName);
             } else {
+              setValue('IAMUserName', data.Users[0].UserName);
               setIsAccordionExpanded(true);
             }
           } else {

--- a/src/react/ISV/components/__tests__/ISVConfiguration.test.tsx
+++ b/src/react/ISV/components/__tests__/ISVConfiguration.test.tsx
@@ -512,6 +512,154 @@ describe('ISVConfiguration', () => {
       expect(existingRadio).toBeDisabled();
       expect(selectors.continueButton()).toBeDisabled();
     });
+
+    it('should sync IAMUserName when toggling IAM user radio from create back to existing', async () => {
+      const useIAMUserMock = require('../../hooks/useIAMUser').useIAMUser;
+      useIAMUserMock.mockReset();
+      useIAMUserMock.mockReturnValue({
+        isIAMUserExist: false,
+        IAMUsersStatus: 'success',
+        IAMUsers: [{ id: '1', name: 'iam-user-1' }],
+        getIAMUsersMutation: {
+          mutate: jest.fn().mockImplementation((_roleArn, options) => {
+            if (options?.onSuccess) {
+              options.onSuccess({
+                Users: [{ UserName: 'iam-user-1', UserId: 'id1', Arn: 'arn1' }],
+              });
+            }
+          }),
+          status: 'success',
+        },
+        accessKeys: null,
+        hasActiveKeys: false,
+      });
+
+      renderComponent(CommvaultPlatform);
+
+      // Switch to existing account; onAccountSelected auto-expands advanced settings
+      // because no IAM user matches 'test-account'. IAMUserNameType becomes 'existing'
+      // but IAMUserName stays '' (resetIAMFields cleared it).
+      await userEvent.click(selectors.existingAccountRadio());
+
+      // Fill bucket name so Continue validity only depends on IAMUserName.
+      await userEvent.type(screen.getByRole('textbox', { name: /Bucket name \*/i }), 'my-bucket');
+
+      await waitFor(() => {
+        expect(screen.getByText(/IAM User Management/i)).toBeInTheDocument();
+      });
+
+      // Toggle IAM user radio: existing -> create -> existing. On the final switch
+      // back to 'existing', IAMUserName must be synced to iamUsers[0].name so the
+      // Controller doesn't fall back to the registered '' value.
+      await userEvent.click(selectors.createUserRadio());
+      await userEvent.click(selectors.existingUserRadio());
+
+      await waitFor(() => {
+        expect(selectors.continueButton()).not.toBeDisabled();
+      });
+    });
+
+    it('should enable Continue button after only switching to existing account radio without touching advanced settings', async () => {
+      const useIAMUserMock = require('../../hooks/useIAMUser').useIAMUser;
+      useIAMUserMock.mockReset();
+      useIAMUserMock.mockReturnValue({
+        isIAMUserExist: false,
+        IAMUsersStatus: 'success',
+        IAMUsers: [],
+        getIAMUsersMutation: {
+          mutate: jest.fn().mockImplementation((_roleArn, options) => {
+            if (options && options.onSuccess) {
+              options.onSuccess({ Users: [] });
+            }
+          }),
+          status: 'success',
+        },
+        accessKeys: null,
+        hasActiveKeys: false,
+      });
+
+      renderComponent(CommvaultPlatform);
+
+      // Only switch to the existing account radio. Do NOT open Advanced settings
+      // and do NOT interact with the account Select. This mirrors what a real
+      // user does when they just click the radio and expect Continue to work.
+      await userEvent.click(selectors.existingAccountRadio());
+
+      // Fill the only other required field (bucket name) so validity hinges on
+      // IAMUserName being auto-synced by the radio switch.
+      await userEvent.type(screen.getByRole('textbox', { name: /Bucket name \*/i }), 'my-bucket');
+
+      // Radio switch should trigger onAccountSelected(accounts[0].name), which
+      // on empty Users auto-sets IAMUserName=accountName, making the form valid.
+      await waitFor(() => {
+        expect(selectors.continueButton()).not.toBeDisabled();
+      });
+    });
+
+    it('should enable Continue button after switching to existing account even if IAM users fetch never resolves', async () => {
+      // Simulate a real-world slow / failed AssumeRole where mutate is called
+      // but onSuccess is never invoked. Without a pre-fill fallback the form
+      // would stay invalid forever, making Continue freeze.
+      const useIAMUserMock = require('../../hooks/useIAMUser').useIAMUser;
+      useIAMUserMock.mockReset();
+      useIAMUserMock.mockReturnValue({
+        isIAMUserExist: false,
+        IAMUsersStatus: 'loading',
+        IAMUsers: [],
+        getIAMUsersMutation: {
+          mutate: jest.fn(),
+          status: 'loading',
+        },
+        accessKeys: null,
+        hasActiveKeys: false,
+      });
+
+      renderComponent(CommvaultPlatform);
+
+      await userEvent.click(selectors.existingAccountRadio());
+      await userEvent.type(screen.getByRole('textbox', { name: /Bucket name \*/i }), 'my-bucket');
+
+      await waitFor(() => {
+        expect(selectors.continueButton()).not.toBeDisabled();
+      });
+    });
+
+    it('should enable Continue button when account has IAM users but none matches accountName', async () => {
+      // Case C: accordion auto-expands but IAMUserName was previously left as ''
+      // so the Controller's defaultValue gets ignored -- Select displays the first
+      // user in the UI but form state stays empty, freezing the Continue button.
+      const useIAMUserMock = require('../../hooks/useIAMUser').useIAMUser;
+      useIAMUserMock.mockReset();
+      useIAMUserMock.mockReturnValue({
+        isIAMUserExist: false,
+        IAMUsersStatus: 'success',
+        IAMUsers: [{ id: '1', name: 'iam-user-1' }],
+        getIAMUsersMutation: {
+          mutate: jest.fn().mockImplementation((_roleArn, options) => {
+            if (options?.onSuccess) {
+              options.onSuccess({
+                Users: [{ UserName: 'iam-user-1', UserId: 'id1', Arn: 'arn1' }],
+              });
+            }
+          }),
+          status: 'success',
+        },
+        accessKeys: null,
+        hasActiveKeys: false,
+      });
+
+      renderComponent(CommvaultPlatform);
+
+      await userEvent.click(selectors.existingAccountRadio());
+      await userEvent.type(screen.getByRole('textbox', { name: /Bucket name \*/i }), 'my-bucket');
+
+      // onAccountSelected auto-expands the accordion (no user matches
+      // 'test-account'); IAMUserName should be defaulted to iamUsers[0].name
+      // so the form is valid without the user having to touch the Select.
+      await waitFor(() => {
+        expect(selectors.continueButton()).not.toBeDisabled();
+      });
+    });
   });
 
   describe('Advanced Settings', () => {
@@ -706,7 +854,7 @@ describe('ISVConfiguration', () => {
       // Select existing IAM user
       await userEvent.click(selectors.existingUserRadio());
       await userEvent.click(screen.queryByRole('listbox', { name: /Select existing user/ }));
-      await userEvent.click(screen.getByText('test-user'));
+      await userEvent.click(screen.getByRole('option', { name: 'test-user' }));
 
       expect(selectors.generateKey()).not.toBeChecked();
     });
@@ -725,7 +873,7 @@ describe('ISVConfiguration', () => {
       // Select existing IAM user
       await userEvent.click(selectors.existingUserRadio());
       await userEvent.click(selectors.selectExistingUser());
-      await userEvent.click(screen.getByText('test-user'));
+      await userEvent.click(screen.getByRole('option', { name: 'test-user' }));
 
       expect(selectors.generateKey()).toBeInTheDocument();
     });

--- a/src/react/ISV/components/fields/AccountSelectorField.tsx
+++ b/src/react/ISV/components/fields/AccountSelectorField.tsx
@@ -24,7 +24,13 @@ export const AccountSelectorField = ({ field, formMethods }: AccountSelectorFiel
       fieldName="accountName"
       label={field.label || 'Account'}
       tooltip={field.tooltip as React.ReactElement}
-      onOptionChange={(mode: string) => resetIAMFields(mode as 'create' | 'existing', accounts[0]?.name)}
+      onOptionChange={(mode: string) => {
+        const firstAccountName = accounts[0]?.name;
+        resetIAMFields(mode as 'create' | 'existing', firstAccountName);
+        if (mode === 'existing' && firstAccountName) {
+          onAccountSelected(firstAccountName);
+        }
+      }}
       onFieldNameChange={onAccountSelected}
     />
   );

--- a/src/react/ISV/components/fields/IAMUserSelectorField.tsx
+++ b/src/react/ISV/components/fields/IAMUserSelectorField.tsx
@@ -18,7 +18,7 @@ export const IAMUserSelectorField = ({ field, formMethods }: IAMUserSelectorFiel
     useISVFormContext();
 
   const selectRef = useRef<SelectRef<Option, false, null>>(null);
-  const { watch, control } = formMethods;
+  const { watch, control, setValue } = formMethods;
 
   const accountNameType = watch('accountNameType');
   const accountName = watch('accountName');
@@ -49,6 +49,14 @@ export const IAMUserSelectorField = ({ field, formMethods }: IAMUserSelectorFiel
             tooltip={field.tooltip as React.ReactElement}
             fieldName="IAMUserName"
             label="IAM User Management"
+            onOptionChange={(mode: string) => {
+              const firstIAMUserName = iamUsers[0]?.name;
+              if (mode === 'existing' && firstIAMUserName) {
+                setValue('IAMUserName', firstIAMUserName, { shouldValidate: true });
+              } else {
+                setValue('IAMUserName', '', { shouldValidate: true });
+              }
+            }}
           >
             {IAMUserNameType === 'existing' && (
               <Controller


### PR DESCRIPTION
## Summary

Follow-up to #1166. That PR synced `accountName` on account-radio switch, but the Continue button can still appear frozen in several paths — the Select/Input shows a value while the form state stays empty, because react-hook-form's `Controller` ignores `defaultValue` once the field is already registered. Typing anything in the field "unfreezes" it, which is the telltale sign that UI and form state are out of sync.

## Root cause

Three independent gaps conspire:

1. **Account radio switch never triggered `onAccountSelected`.** Only the Select `onChange` path fetched IAM users and auto-filled `IAMUserName`. So clicking the radio left `IAMUserName=''`, which is required when `accountNameType === 'existing'` but the Advanced-settings accordion is collapsed — validation fails silently.
2. **`onAccountSelected` is async.** Even after wiring it to the radio, if `AssumeRole` / `listUsers` hangs or fails in a real environment, `onSuccess` never runs, so `IAMUserName` stays `''`.
3. **`IAMUserSelectorField` never passed `onOptionChange`** to `CreateOrSelectNameField`. The inner IAM-user radio suffers the exact same "Controller `defaultValue` ignored for already-registered field" issue #1166 fixed for `accountName`.

## Fix (defense in depth)

- **`AccountSelectorField.tsx`** — after `resetIAMFields`, call `onAccountSelected(accounts[0].name)` when switching to `'existing'` so the radio path matches the Select path.
- **`ISVFormContext.resetIAMFields`** — pre-fill `IAMUserName` with the account name synchronously on `'existing'` switch. The form is valid *immediately*, regardless of whether the async IAM-user fetch ever resolves.
- **`ISVFormContext.onAccountSelected`** — when IAM users exist but none matches `accountName` (Case C), default `IAMUserName` to `Users[0].UserName` alongside expanding the accordion, so the form state matches what the Select displays.
- **`IAMUserSelectorField.tsx`** — add the missing `onOptionChange` that explicitly `setValue('IAMUserName', ...)` on mode switch, mirroring #1166's pattern for `accountName`.

## JIRA

[ARTESCA-17417](https://scality.atlassian.net/browse/ARTESCA-17417)

## Test Strategy

Framework: Jest + React Testing Library. Built with TDD — each added test was confirmed RED before the corresponding fix, then GREEN after.

New tests:
- `should enable Continue button after only switching to existing account radio without touching advanced settings` — the core reported scenario (empty IAM users → auto-fill with accountName).
- `should enable Continue button after switching to existing account even if IAM users fetch never resolves` — covers hanging / failed `AssumeRole`.
- `should enable Continue button when account has IAM users but none matches accountName` — covers Case C, the auto-expand branch.
- `should sync IAMUserName when toggling IAM user radio from create back to existing` — covers the inner-radio gap.

Existing tests updated (PR #1166 pattern): two IAM-select tests switched from `getByText('test-user')` to `getByRole('option', { name: 'test-user' })`, since the Select now pre-fills its value and plain `getByText` hits multiple DOM nodes.

Results:
- `ISVConfiguration` suite: **36 / 36** pass (32 original + 4 new).
- Full `src/react/ISV/` suite: **303 / 303** pass.

## Test plan

- [x] Create-account flow: fill account + bucket, verify Continue enables.
- [x] Switch to "Use an existing Account" radio **without** expanding Advanced settings — Continue stays enabled once bucket is filled.
- [x] Round-trip account radio (create → existing → create → existing) — Continue state tracks validity throughout.
- [x] Expand Advanced settings, toggle IAM user radio (existing → create → existing) — Select / Input stays in sync with form state; Continue tracks validity.
- [x] Manually verify against an account where IAM users exist but none matches the account name (Case C) — accordion auto-expands with `Users[0]` pre-selected and Continue is enabled.

[ARTESCA-17417]: https://scality.atlassian.net/browse/ARTESCA-17417?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ