### PR TITLE
ZKUI-496: Bump data-browser-library to 1.1.18

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@scality/certchain": "1.4.0",
         "@scality/core-ui": "0.202.0",
-        "@scality/data-browser-library": "1.1.17",
+        "@scality/data-browser-library": "1.1.18",
         "@scality/module-federation": "1.6.1",
         "@scality/react-chained-query": "^2.1.0",
         "@types/react-table": "^7.7.10",
@@ -5690,9 +5690,9 @@
       }
     },
     "node_modules/@scality/data-browser-library": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.17.tgz",
-      "integrity": "sha512-tVgVyAuAC4NknZi6epgQlru3SW4VpilJcWARiO+dtcmJekIewQddMZ/3l+KzdHJSq7UkTstCcEoOblt05OaIOg==",
+      "version": "1.1.18",
+      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.18.tgz",
+      "integrity": "sha512-NyC6TZmiYEDV85QVX8d7LqbxET3PhhIgF/TIl1DmYC20z8SuOnpVwwQL17kxl0UJBBifnyeq4lr6eb3KuAstXQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.983.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@scality/certchain": "1.4.0",
     "@scality/core-ui": "0.202.0",
-    "@scality/data-browser-library": "1.1.17",
+    "@scality/data-browser-library": "1.1.18",
     "@scality/module-federation": "1.6.1",
     "@scality/react-chained-query": "^2.1.0",
     "@types/react-table": "^7.7.10",


### PR DESCRIPTION
## Summary
Automated bump of `@scality/data-browser-library`.

## Links
- Release: https://github.com/scality/data-browser/releases/tag/1.1.18
- Jira: https://scality.atlassian.net/browse/ZKUI-496

🤖 Generated by data-browser auto-bump