### PR TITLE
ZKUI-497: Share ISV Connector Modal via Module Federation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@scality/certchain": "1.4.0",
-        "@scality/core-ui": "0.202.0",
+        "@scality/core-ui": "0.215.0",
         "@scality/data-browser-library": "1.1.19",
         "@scality/module-federation": "1.6.1",
         "@scality/react-chained-query": "^2.1.0",
@@ -5583,9 +5583,9 @@
       "license": "MIT"
     },
     "node_modules/@scality/core-ui": {
-      "version": "0.202.0",
-      "resolved": "https://registry.npmjs.org/@scality/core-ui/-/core-ui-0.202.0.tgz",
-      "integrity": "sha512-azmGEG1xkd0+PSn4KG7k1sHDpIje5GQkUqfXOXtp1cLo1eVEWADBZas8rGZRQIETYmr1a8JPBkhs+sVzlV/kNA==",
+      "version": "0.215.0",
+      "resolved": "https://registry.npmjs.org/@scality/core-ui/-/core-ui-0.215.0.tgz",
+      "integrity": "sha512-HpcU1ZZ2s3VpLNRXzXq0s5FBvevRx2rr2OzyMaan7gS6HZSfKZAA9bZv5iclbwFfCQ/0CxE7TX5sFCZ8708tMA==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.2",
@@ -5600,7 +5600,8 @@
         "@fortawesome/react-fontawesome": "^3.1.1",
         "@js-temporal/polyfill": "^0.4.4",
         "@lezer/highlight": "^1.2.3",
-        "@storybook/preview-api": "^8.3.6",
+        "@storybook/preview-api": "^8.6.17",
+        "@typescript-eslint/parser": "^8.56.1",
         "@uiw/react-codemirror": "^4.25.5",
         "codemirror-json-schema": "^0.8.1",
         "downshift": "^7.0.5",
@@ -6646,9 +6647,9 @@
       "license": "MIT"
     },
     "node_modules/@storybook/preview-api": {
-      "version": "8.6.14",
-      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.6.14.tgz",
-      "integrity": "sha512-2GhcCd4dNMrnD7eooEfvbfL4I83qAqEyO0CO7JQAmIO6Rxb9BsOLLI/GD5HkvQB73ArTJ+PT50rfaO820IExOQ==",
+      "version": "8.6.18",
+      "resolved": "https://registry.npmjs.org/@storybook/preview-api/-/preview-api-8.6.18.tgz",
+      "integrity": "sha512-joXRXh3GdVvzhbfIgmix1xs90p8Q/nja7AhEAC2egn5Pl7SKsIYZUCYI6UdrQANb2myg9P552LKXfPect8llKg==",
       "license": "MIT",
       "funding": {
         "type": "opencollective",
@@ -7995,6 +7996,189 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@typescript-eslint/parser": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
+      "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/scope-manager": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/typescript-estree": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/project-service": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
+      "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/tsconfig-utils": "^8.59.1",
+        "@typescript-eslint/types": "^8.59.1",
+        "debug": "^4.4.3"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/scope-manager": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
+      "integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/tsconfig-utils": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
+      "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/types": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
+      "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
+      "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/project-service": "8.59.1",
+        "@typescript-eslint/tsconfig-utils": "8.59.1",
+        "@typescript-eslint/types": "8.59.1",
+        "@typescript-eslint/visitor-keys": "8.59.1",
+        "debug": "^4.4.3",
+        "minimatch": "^10.2.2",
+        "semver": "^7.7.3",
+        "tinyglobby": "^0.2.15",
+        "ts-api-utils": "^2.5.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "license": "MIT",
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@typescript-eslint/visitor-keys": {
+      "version": "8.59.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
+      "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
+      "license": "MIT",
+      "dependencies": {
+        "@typescript-eslint/types": "8.59.1",
+        "eslint-visitor-keys": "^5.0.0"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/typescript-eslint"
+      }
     },
     "node_modules/@uiw/codemirror-extensions-basic-setup": {
       "version": "4.25.5",
@@ -11285,6 +11469,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eslint-visitor-keys": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": "^20.19.0 || ^22.13.0 || >=24"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -11652,6 +11848,23 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
       }
     },
     "node_modules/figures": {
@@ -18763,6 +18976,34 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -18867,6 +19108,18 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ts-api-utils": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
+      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12"
+      },
+      "peerDependencies": {
+        "typescript": ">=4.8.4"
       }
     },
     "node_modules/ts-node": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@scality/certchain": "1.4.0",
-    "@scality/core-ui": "0.202.0",
+    "@scality/core-ui": "0.215.0",
     "@scality/data-browser-library": "1.1.19",
     "@scality/module-federation": "1.6.1",
     "@scality/react-chained-query": "^2.1.0",

--- a/rspack.config.ts
+++ b/rspack.config.ts
@@ -137,6 +137,7 @@ const config: Configuration = {
       exposes: {
         './FederableApp': './src/react/FederableApp.tsx',
         './WelcomeModal': './src/react/ISV/components/Modal/WelcomeModal.tsx',
+        './ISVConnectorModal': './src/react/ISV/components/Modal/ISVConnectorModal.tsx',
         './SelectAccountIAMRole': './src/react/ui-elements/SelectAccountIAMRole.tsx',
       },
       remotes: !isProduction

--- a/src/react/ISV/components/Modal/ISVConnectorModal.test.tsx
+++ b/src/react/ISV/components/Modal/ISVConnectorModal.test.tsx
@@ -1,5 +1,6 @@
 import { act, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import type { ShellAlerts, ShellHooks } from 'shell/compiled-types/src/hooks/useShellHooks';
 import { mockOffsetSize, mockShellAlerts, mockShellHooks } from '../../../utils/testUtil';
 import ISVConnectorModal from './ISVConnectorModal';
 
@@ -56,8 +57,8 @@ describe('ISVConnectorModal', () => {
       <ISVConnectorModal
         isOpen={true}
         setIsOpen={mockSetIsOpen}
-        shellHooks={mockShellHooks}
-        shellAlerts={mockShellAlerts}
+        shellHooks={mockShellHooks as unknown as ShellHooks}
+        shellAlerts={mockShellAlerts as unknown as ShellAlerts}
       />,
     );
 

--- a/src/react/ISV/components/Modal/ISVConnectorModal.test.tsx
+++ b/src/react/ISV/components/Modal/ISVConnectorModal.test.tsx
@@ -1,0 +1,150 @@
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { mockOffsetSize, mockShellAlerts, mockShellHooks } from '../../../utils/testUtil';
+import ISVConnectorModal from './ISVConnectorModal';
+
+// Variables prefixed with 'mock' are accessible inside hoisted jest.mock() factories
+const mockOpenLink = jest.fn();
+let mockDeployedApps: { kind: string; appHistoryBasePath: string }[] = [
+  { kind: 'zenko-ui', appHistoryBasePath: '/data' },
+];
+let mockSetSelectedISV: ((isv: unknown) => void) | null = null;
+
+// Replace Modal with a non-portal version so React's event delegation works in tests
+jest.mock('@scality/core-ui', () => {
+  const actual = jest.requireActual('@scality/core-ui');
+  return {
+    ...actual,
+    Modal: ({
+      isOpen,
+      children,
+      footer,
+    }: {
+      isOpen: boolean;
+      children: React.ReactNode;
+      footer?: React.ReactNode;
+    }) => (isOpen ? <div role="dialog">{children}{footer}</div> : null),
+  };
+});
+
+jest.mock('./ISVModal', () => ({
+  ISVModalContent: ({ setSelectedISV }: { setSelectedISV: (isv: unknown) => void }) => {
+    mockSetSelectedISV = setSelectedISV;
+    return null;
+  },
+}));
+
+describe('ISVConnectorModal', () => {
+  const mockSetIsOpen = jest.fn();
+
+  beforeAll(() => {
+    mockOffsetSize(200, 1000);
+  });
+
+  beforeEach(() => {
+    mockOpenLink.mockReset();
+    mockSetIsOpen.mockReset();
+    mockSetSelectedISV = null;
+    mockDeployedApps = [{ kind: 'zenko-ui', appHistoryBasePath: '/data' }];
+    // Configure the global mockShellHooks to use our test-local mocks
+    (mockShellHooks.useLinkOpener as jest.Mock).mockReturnValue({ openLink: mockOpenLink });
+    (mockShellHooks.useDeployedApps as jest.Mock).mockImplementation(() => mockDeployedApps);
+  });
+
+  const renderModal = () =>
+    render(
+      <ISVConnectorModal
+        isOpen={true}
+        setIsOpen={mockSetIsOpen}
+        shellHooks={mockShellHooks}
+        shellAlerts={mockShellAlerts}
+      />,
+    );
+
+  const selectISV = async (isv: unknown) => {
+    await act(async () => {
+      mockSetSelectedISV(isv);
+    });
+  };
+
+  it('calls openLink with ISV configuration path when an assistant ISV is selected', async () => {
+    renderModal();
+    await selectISV({ id: 'veeam-vbr', name: 'Veeam', assistant: true });
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('button', { name: /Continue to assistant/i }));
+    });
+
+    expect(mockOpenLink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        view: expect.objectContaining({
+          path: '/isv/configuration?platform=veeam-vbr',
+          label: { en: 'ISV Configuration', fr: 'Configuration ISV' },
+          module: './FederableApp',
+          scope: 'zenko',
+        }),
+        isFederated: true,
+      }),
+    );
+    expect(mockSetIsOpen).toHaveBeenCalledWith(false);
+  });
+
+  it('calls openLink with accounts path when a non-assistant ISV is selected', async () => {
+    renderModal();
+    await selectISV({ id: 'rubrik', name: 'Rubrik', assistant: false });
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('button', { name: /Continue to account/i }));
+    });
+
+    expect(mockOpenLink).toHaveBeenCalledWith(
+      expect.objectContaining({
+        view: expect.objectContaining({
+          path: '/accounts',
+          label: { en: 'Accounts', fr: 'Comptes' },
+          module: './FederableApp',
+          scope: 'zenko',
+        }),
+        isFederated: true,
+      }),
+    );
+    expect(mockSetIsOpen).toHaveBeenCalledWith(false);
+  });
+
+  it('dispatches HistoryPushEvent instead of openLink when already in zenko-ui context', async () => {
+    // App with appHistoryBasePath '' triggers the fallback branch → currentApp resolves to 'zenko-ui'
+    mockDeployedApps = [
+      { kind: 'zenko-ui', appHistoryBasePath: '/data' },
+      { kind: 'zenko-ui', appHistoryBasePath: '' },
+    ];
+
+    const dispatchEventSpy = jest.spyOn(window, 'dispatchEvent');
+    renderModal();
+    await selectISV({ id: 'veeam-vbr', name: 'Veeam', assistant: true });
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('button', { name: /Continue to assistant/i }));
+    });
+
+    expect(mockOpenLink).not.toHaveBeenCalled();
+    expect(dispatchEventSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'HistoryPushEvent',
+        detail: { path: '/isv/configuration?platform=veeam-vbr' },
+      }),
+    );
+
+    dispatchEventSpy.mockRestore();
+  });
+
+  it('closes the modal without navigating when Skip is clicked', async () => {
+    renderModal();
+
+    await act(async () => {
+      await userEvent.click(screen.getByRole('button', { name: /Skip/i }));
+    });
+
+    expect(mockSetIsOpen).toHaveBeenCalledWith(false);
+    expect(mockOpenLink).not.toHaveBeenCalled();
+  });
+});

--- a/src/react/ISV/components/Modal/ISVConnectorModal.tsx
+++ b/src/react/ISV/components/Modal/ISVConnectorModal.tsx
@@ -1,0 +1,105 @@
+import { Icon, Modal, Stack, Text, Wrap } from '@scality/core-ui';
+import { Button } from '@scality/core-ui/dist/next';
+import { ShellHooksProvider, useShellHooks } from '@scality/module-federation';
+import { useMemo, useState } from 'react';
+import type { ShellAlerts, ShellHooks } from 'shell/compiled-types/src/hooks/useShellHooks';
+import styled from 'styled-components';
+import type { ISVCardConfig } from '../../types';
+import { ArtescaLogo } from '../ArtescaLogo';
+import { ISVModalContent } from './ISVModal';
+
+const CustomModal = styled(Modal)`
+  background-color: ${(props) => props.theme.backgroundLevel1};
+  > div {
+    max-width: 60vw;
+    width: 60vw;
+  }
+`;
+
+type ISVConnectorModalProps = {
+  isOpen: boolean;
+  setIsOpen: (open: boolean) => void;
+  shellHooks: ShellHooks;
+  shellAlerts: ShellAlerts;
+};
+
+const ISVConnectorModalInternal = ({
+  isOpen,
+  setIsOpen,
+}: Pick<ISVConnectorModalProps, 'isOpen' | 'setIsOpen'>) => {
+  const [selectedISV, setSelectedISV] = useState<ISVCardConfig>(null);
+  const { useLinkOpener, useDeployedApps } = useShellHooks();
+  const { openLink } = useLinkOpener();
+  const deployedApps = useDeployedApps();
+  const zenkoUI = deployedApps.find((app: { kind: string }) => app.kind === 'zenko-ui');
+
+  const currentApp =
+    deployedApps.find(
+      (app) => window.location.pathname.startsWith(app.appHistoryBasePath) && app.appHistoryBasePath !== '',
+    )?.kind ?? deployedApps.find((app) => app.appHistoryBasePath === '')?.kind;
+
+  const zenkoUIView = useMemo(
+    () =>
+      selectedISV?.assistant
+        ? {
+          path: `/isv/configuration?platform=${selectedISV.id}`,
+          label: { en: 'ISV Configuration', fr: 'Configuration ISV' },
+          module: './FederableApp',
+          scope: 'zenko',
+        }
+        : {
+          path: `/accounts`,
+          label: { en: 'Accounts', fr: 'Comptes' },
+          module: './FederableApp',
+          scope: 'zenko',
+        },
+    [selectedISV],
+  );
+
+  const handleContinueClick = () => {
+    setIsOpen(false);
+    const configurationView = { view: zenkoUIView, app: zenkoUI, isFederated: true as const };
+
+    if (currentApp === 'zenko-ui') {
+      window.dispatchEvent(new CustomEvent('HistoryPushEvent', { detail: { path: zenkoUIView.path } }));
+    } else {
+      openLink(configurationView);
+    }
+  };
+
+  return (
+    <CustomModal
+      title={
+        <Stack direction="horizontal" gap="r8">
+          <Text variant="Large">Select an ISV</Text> <ArtescaLogo />
+        </Stack>
+      }
+      isOpen={isOpen}
+      footer={
+        <Wrap>
+          <p></p>
+          <Stack>
+            <Button variant="outline" label="Skip" onClick={() => setIsOpen(false)} style={{ width: '80px' }} />
+            <Button
+              disabled={!selectedISV}
+              variant="primary"
+              label={selectedISV ? (selectedISV.assistant ? 'Continue to assistant' : 'Continue to account') : 'Continue'}
+              icon={<Icon name="Arrow-right" />}
+              onClick={handleContinueClick}
+            />
+          </Stack>
+        </Wrap>
+      }
+    >
+      <ISVModalContent selectedISV={selectedISV} setSelectedISV={setSelectedISV} />
+    </CustomModal>
+  );
+};
+
+export default function ISVConnectorModal({ shellHooks, shellAlerts, ...rest }: ISVConnectorModalProps) {
+  return (
+    <ShellHooksProvider shellHooks={shellHooks} shellAlerts={shellAlerts}>
+      <ISVConnectorModalInternal {...rest} />
+    </ShellHooksProvider>
+  );
+}

--- a/src/react/ISV/components/Modal/ISVConnectorModal.tsx
+++ b/src/react/ISV/components/Modal/ISVConnectorModal.tsx
@@ -1,20 +1,13 @@
-import { Icon, Modal, Stack, Text, Wrap } from '@scality/core-ui';
+import { Icon, Stack, Text, Wrap } from '@scality/core-ui';
 import { Button } from '@scality/core-ui/dist/next';
-import { ShellHooksProvider, useShellHooks } from '@scality/module-federation';
-import { useMemo, useState } from 'react';
+import { ShellHooksProvider } from '@scality/module-federation';
+import { useState } from 'react';
 import type { ShellAlerts, ShellHooks } from 'shell/compiled-types/src/hooks/useShellHooks';
-import styled from 'styled-components';
+import { useISVNavigation } from '../../hooks/useISVNavigation';
 import type { ISVCardConfig } from '../../types';
 import { ArtescaLogo } from '../ArtescaLogo';
+import { ISVWideModal } from '../shared/StyledComponents';
 import { ISVModalContent } from './ISVModal';
-
-const CustomModal = styled(Modal)`
-  background-color: ${(props) => props.theme.backgroundLevel1};
-  > div {
-    max-width: 60vw;
-    width: 60vw;
-  }
-`;
 
 type ISVConnectorModalProps = {
   isOpen: boolean;
@@ -28,47 +21,15 @@ const ISVConnectorModalInternal = ({
   setIsOpen,
 }: Pick<ISVConnectorModalProps, 'isOpen' | 'setIsOpen'>) => {
   const [selectedISV, setSelectedISV] = useState<ISVCardConfig>(null);
-  const { useLinkOpener, useDeployedApps } = useShellHooks();
-  const { openLink } = useLinkOpener();
-  const deployedApps = useDeployedApps();
-  const zenkoUI = deployedApps.find((app: { kind: string }) => app.kind === 'zenko-ui');
-
-  const currentApp =
-    deployedApps.find(
-      (app) => window.location.pathname.startsWith(app.appHistoryBasePath) && app.appHistoryBasePath !== '',
-    )?.kind ?? deployedApps.find((app) => app.appHistoryBasePath === '')?.kind;
-
-  const zenkoUIView = useMemo(
-    () =>
-      selectedISV?.assistant
-        ? {
-          path: `/isv/configuration?platform=${selectedISV.id}`,
-          label: { en: 'ISV Configuration', fr: 'Configuration ISV' },
-          module: './FederableApp',
-          scope: 'zenko',
-        }
-        : {
-          path: `/accounts`,
-          label: { en: 'Accounts', fr: 'Comptes' },
-          module: './FederableApp',
-          scope: 'zenko',
-        },
-    [selectedISV],
-  );
+  const { navigate } = useISVNavigation(selectedISV);
 
   const handleContinueClick = () => {
     setIsOpen(false);
-    const configurationView = { view: zenkoUIView, app: zenkoUI, isFederated: true as const };
-
-    if (currentApp === 'zenko-ui') {
-      window.dispatchEvent(new CustomEvent('HistoryPushEvent', { detail: { path: zenkoUIView.path } }));
-    } else {
-      openLink(configurationView);
-    }
+    navigate();
   };
 
   return (
-    <CustomModal
+    <ISVWideModal
       title={
         <Stack direction="horizontal" gap="r8">
           <Text variant="Large">Select an ISV</Text> <ArtescaLogo />
@@ -92,7 +53,7 @@ const ISVConnectorModalInternal = ({
       }
     >
       <ISVModalContent selectedISV={selectedISV} setSelectedISV={setSelectedISV} />
-    </CustomModal>
+    </ISVWideModal>
   );
 };
 

--- a/src/react/ISV/components/Modal/ISVModal.tsx
+++ b/src/react/ISV/components/Modal/ISVModal.tsx
@@ -158,7 +158,7 @@ const ISVModal = ({ isOpen, setIsOpen }) => {
   };
 
   if (!isOpen) {
-    return <></>;
+    return null;
   }
 
   const continueLabel = !selectedISV

--- a/src/react/ISV/components/Modal/ISVModal.tsx
+++ b/src/react/ISV/components/Modal/ISVModal.tsx
@@ -1,4 +1,4 @@
-import { Banner, Icon, Link, Modal, Stack, spacing, Text, Wrap } from '@scality/core-ui';
+import { Banner, Icon, Link, Stack, spacing, Text, Wrap } from '@scality/core-ui';
 import { Box, Button } from '@scality/core-ui/dist/next';
 import { useBasenameRelativeNavigate } from '@scality/module-federation';
 import { useState } from 'react';
@@ -7,15 +7,8 @@ import styled, { useTheme } from 'styled-components';
 import { ISVList } from '../../ISVList';
 import { ISV_CATEGORIES, type ISVCardConfig } from '../../types';
 import { ArtescaLogo } from '../ArtescaLogo';
+import { ISVWideModal } from '../shared/StyledComponents';
 import { CardISV } from './CardISV';
-
-const CustomModal = styled(Modal)`
-  background-color: ${(props) => props.theme.backgroundLevel1};
-  > div {
-    max-width: 60vw;
-    width: 60vw;
-  }
-`;
 
 export const StyledGrid = styled.div`
   display: grid;
@@ -170,7 +163,7 @@ const ISVModal = ({ isOpen, setIsOpen }) => {
         : 'Continue to create account';
 
   return (
-    <CustomModal
+    <ISVWideModal
       title={
         <Stack direction="horizontal" gap="r8">
           <Text variant="Large">Select an ISV</Text> <ArtescaLogo />
@@ -194,7 +187,7 @@ const ISVModal = ({ isOpen, setIsOpen }) => {
       }
     >
       <ISVModalContent selectedISV={selectedISV} setSelectedISV={setSelectedISV}></ISVModalContent>
-    </CustomModal>
+    </ISVWideModal>
   );
 };
 

--- a/src/react/ISV/components/Modal/WelcomeModal.tsx
+++ b/src/react/ISV/components/Modal/WelcomeModal.tsx
@@ -1,31 +1,24 @@
 import { Banner, Icon, Link, Modal, Stack, Text, Wrap } from '@scality/core-ui';
 import { Button } from '@scality/core-ui/dist/components/buttonv2/Buttonv2.component';
 import { ShellHooksProvider, useShellHooks } from '@scality/module-federation';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
+import styled from 'styled-components';
 import { useLocation } from 'react-router';
 import type { ShellAlerts, ShellHooks } from 'shell/compiled-types/src/hooks/useShellHooks';
-import styled from 'styled-components';
 import AlertProvider, { useAlerts } from '../../../next-architecture/ui/AlertProvider';
 import { useAccounts, useAuthGroups } from '../../../utils/hooks';
 import { setSessionState } from '../../../utils/localStorage';
 import { useIsVeeamVBROnly } from '../../hooks/useIsVeeamVBROnly';
+import { useISVNavigation } from '../../hooks/useISVNavigation';
 import { useNextLogin } from '../../hooks/useNextLogin';
 import { ISVList } from '../../ISVList';
 import { VeeamVBRPlatform } from '../../platforms/veeam-vbr';
 import type { ISVCardConfig } from '../../types';
 import { ArtescaLogo } from '../ArtescaLogo';
 import { ArtescaPlusLogo } from '../ArtescaPLusLogo';
+import { ISVWideModal } from '../shared/StyledComponents';
 import { ISVModalContent } from './ISVModal';
 import VeeamLogo from './Logos/VeeamLogo';
-
-const CustomModal = styled(Modal)`
-  background-color: ${(props) => props.theme.backgroundLevel1};
-
-  > div {
-    max-width: 60vw;
-    width: 60vw;
-  }
-`;
 
 const SmallModal = styled(Modal)`
   > div {
@@ -71,7 +64,7 @@ export const WelcomeModalInternal = (props: Omit<NavbarUpdaterComponentProps, 's
     !isTrialLicenseModalDisplayed;
 
   if (!isWelcomeModalEnabled) {
-    return <></>;
+    return null;
   }
 
   return isVeeamVBROnly ? <VeeamOnlyModalComponent /> : <ModalComponent />;
@@ -80,60 +73,12 @@ export const WelcomeModalInternal = (props: Omit<NavbarUpdaterComponentProps, 's
 const useWelcomeModal = (defaultISV?: ISVCardConfig) => {
   const [isOpen, setIsOpen] = useState<boolean>(true);
   const [selectedISV, setSelectedISV] = useState<ISVCardConfig>(defaultISV);
-  const { useLinkOpener, useDeployedApps, useAuth } = useShellHooks();
-  const { openLink } = useLinkOpener();
-  const deployedApps = useDeployedApps();
-  const zenkoUI = deployedApps.find((app: { kind: string }) => app.kind === 'zenko-ui');
-
-  const currentApp =
-    deployedApps.find(
-      (app) => window.location.pathname.startsWith(app.appHistoryBasePath) && app.appHistoryBasePath !== '',
-    )?.kind ?? deployedApps.find((app) => app.appHistoryBasePath === '')?.kind;
-
-  const zenkoUIConfigurationView = useMemo(() => {
-    const view = selectedISV?.assistant
-      ? {
-          path: `/isv/configuration?platform=${selectedISV.id}`,
-          label: {
-            en: 'ISV Configuration',
-            fr: 'Configuration ISV',
-          },
-          module: './FederableApp',
-          scope: 'zenko',
-        }
-      : {
-          path: `/accounts`,
-          label: {
-            en: 'Accounts',
-            fr: 'Comptes',
-          },
-          module: './FederableApp',
-          scope: 'zenko',
-        };
-    return view;
-  }, [selectedISV]);
-
-  const configurationView = {
-    view: zenkoUIConfigurationView,
-    app: zenkoUI,
-    isFederated: true as const,
-  };
+  const { navigate } = useISVNavigation(selectedISV);
+  const { useAuth } = useShellHooks();
 
   const handleContinueClick = () => {
     setIsOpen(false);
-    // If we are already in zenko-ui context, we can't use the openLink function.
-    // That's why we have to create a custom event, and listen to it to change the route.
-
-    if (currentApp === 'zenko-ui') {
-      const event = new CustomEvent('HistoryPushEvent', {
-        detail: {
-          path: configurationView.view.path,
-        },
-      });
-      window.dispatchEvent(event);
-    } else {
-      openLink(configurationView);
-    }
+    navigate();
   };
 
   const user = useAuth();
@@ -214,7 +159,7 @@ const ModalComponent = () => {
   const { isOpen, selectedISV, setSelectedISV, handleContinueClick, handleSkipClick } = useWelcomeModal();
 
   return (
-    <CustomModal
+    <ISVWideModal
       title={
         <Stack direction="horizontal" gap="r8">
           <Text variant="Large">Welcome to</Text>
@@ -242,7 +187,7 @@ const ModalComponent = () => {
       }
     >
       <ISVModalContent selectedISV={selectedISV} setSelectedISV={setSelectedISV}></ISVModalContent>
-    </CustomModal>
+    </ISVWideModal>
   );
 };
 

--- a/src/react/ISV/components/shared/StyledComponents.tsx
+++ b/src/react/ISV/components/shared/StyledComponents.tsx
@@ -1,5 +1,14 @@
+import { Modal } from '@scality/core-ui';
 import styled from 'styled-components';
 
 export const ListItem = styled.li`
   padding: 0.5rem;
+`;
+
+export const ISVWideModal = styled(Modal)`
+  background-color: ${(props) => props.theme.backgroundLevel1};
+  > div {
+    max-width: 60vw;
+    width: 60vw;
+  }
 `;

--- a/src/react/ISV/hooks/useISVNavigation.ts
+++ b/src/react/ISV/hooks/useISVNavigation.ts
@@ -1,0 +1,44 @@
+import { useShellHooks } from '@scality/module-federation';
+import { useMemo } from 'react';
+import type { ISVCardConfig } from '../types';
+
+export const useISVNavigation = (selectedISV: ISVCardConfig | null) => {
+  const { useLinkOpener, useDeployedApps } = useShellHooks();
+  const { openLink } = useLinkOpener();
+  const deployedApps = useDeployedApps();
+  const zenkoUI = deployedApps.find((app: { kind: string }) => app.kind === 'zenko-ui');
+
+  const currentApp =
+    deployedApps.find(
+      (app) => window.location.pathname.startsWith(app.appHistoryBasePath) && app.appHistoryBasePath !== '',
+    )?.kind ?? deployedApps.find((app) => app.appHistoryBasePath === '')?.kind;
+
+  const zenkoUIView = useMemo(
+    () =>
+      selectedISV?.assistant
+        ? {
+            path: `/isv/configuration?platform=${selectedISV.id}`,
+            label: { en: 'ISV Configuration', fr: 'Configuration ISV' },
+            module: './FederableApp',
+            scope: 'zenko',
+          }
+        : {
+            path: `/accounts`,
+            label: { en: 'Accounts', fr: 'Comptes' },
+            module: './FederableApp',
+            scope: 'zenko',
+          },
+    [selectedISV],
+  );
+
+  const navigate = () => {
+    const configurationView = { view: zenkoUIView, app: zenkoUI, isFederated: true as const };
+    if (currentApp === 'zenko-ui') {
+      window.dispatchEvent(new CustomEvent('HistoryPushEvent', { detail: { path: zenkoUIView.path } }));
+    } else {
+      openLink(configurationView);
+    }
+  };
+
+  return { navigate };
+};

--- a/src/react/account/AccountUserAccessKeys.tsx
+++ b/src/react/account/AccountUserAccessKeys.tsx
@@ -5,6 +5,7 @@ import {
   Icon,
   Stack,
   spacing,
+  Text,
   TextBadge,
   Toggle,
   Tooltip,
@@ -247,7 +248,7 @@ const AccountUserAccessKeys = () => {
       </AppContainer.ContextContainer>
       <AppContainer.OverallSummary>
         <Stack withSeparators gap="r32">
-          <>
+          <Stack direction="horizontal" gap="r24">
             <Icon
               name="Arrow-left"
               size="2x"
@@ -257,8 +258,8 @@ const AccountUserAccessKeys = () => {
               }}
             />
             <Icon name="Key" size="2x" color={theme.infoPrimary} />
-            <>{`Access Keys for: ${IAMUserName}`}</>
-          </>
+            <Text>{`Access Keys for: ${IAMUserName}`}</Text>
+          </Stack>
           <>{accessKeysCountComponent}</>
         </Stack>
       </AppContainer.OverallSummary>

--- a/src/react/utils/hooks.ts
+++ b/src/react/utils/hooks.ts
@@ -1,5 +1,5 @@
 import { useShellHooks } from '@scality/module-federation';
-import { useEffect, useRef, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { type QueryKey, type UseQueryOptions, type UseQueryResult, useQuery } from 'react-query';
 import { useLocation } from 'react-router';
 import { getRolesForWebIdentity } from '../../js/IAMClient';
@@ -218,24 +218,26 @@ export const useAccounts = (
     (data) => data?.Accounts,
   );
 
-  const uniqueAccountsWithRoles = Object.values(
-    data?.reduce(
-      (agg, current) => ({
-        ...agg,
-        [current.Name]: {
-          Name: current.Name,
-          CreationDate: current.CreationDate,
-          Roles: [...(agg[current.Name]?.Roles || []), ...current.Roles],
-          id: regexArn.exec(current.Roles[0].Arn).groups['account_id'],
-        },
-      }),
-      {} as Record<string, Account>,
-    ) || {},
-  );
-  return {
-    accounts: uniqueAccountsWithRoles.filter((account) => account.Name !== 'scality-internal-services'),
-    status,
-  };
+  return useMemo(() => {
+    const uniqueAccountsWithRoles = Object.values(
+      data?.reduce(
+        (agg, current) => ({
+          ...agg,
+          [current.Name]: {
+            Name: current.Name,
+            CreationDate: current.CreationDate,
+            Roles: [...(agg[current.Name]?.Roles || []), ...current.Roles],
+            id: regexArn.exec(current.Roles[0].Arn).groups['account_id'],
+          },
+        }),
+        {} as Record<string, Account>,
+      ) || {},
+    );
+    return {
+      accounts: uniqueAccountsWithRoles.filter((account) => account.Name !== 'scality-internal-services'),
+      status,
+    };
+  }, [data, status]);
 };
 
 export const useRolePathName = () => {


### PR DESCRIPTION
## Context

The new Overview page (ARTESCA-14397) needs to open the ISV Connector selection dialog from outside zenko-ui. The existing `ISVModal` only works inside zenko-ui (uses local React Router navigation). This PR exposes a federated wrapper — `ISVConnectorModal` — following the same pattern as `SelectAccountIAMRole`, so any UI can import and render it with correct cross-app navigation.

## Summary of changes

- **`ISVConnectorModal.tsx`** (new): federated wrapper that accepts `{ isOpen, setIsOpen, shellHooks, shellAlerts }`. Owns `selectedISV` state, computes the target view from `selectedISV` (mirroring `WelcomeModal`'s `zenkoUIConfigurationView`), and navigates via `openLink` (cross-app) or `HistoryPushEvent` (already in zenko-ui).
- **`ISVModal.tsx`**: fix `return null` instead of `return <></>` (biome lint).
- **`rspack.config.ts`**: expose `./ISVConnectorModal` in the Module Federation config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)