### PR TITLE
feat(isv): show tooltip on disabled radio option for empty IAM users

### DIFF
--- a/src/react/ISV/components/CreateOrSelectNameField.tsx
+++ b/src/react/ISV/components/CreateOrSelectNameField.tsx
@@ -57,6 +57,73 @@ export function getRadioOptions(
   ];
 }
 
+const renderNameInput = (
+  fieldName: string,
+  status: string,
+  options: Option[],
+  platform: string,
+  register: ReturnType<typeof useFormContext>['register'],
+) => {
+  const showPlaceholder = status === 'success' && options.length !== 0;
+  return (
+    <Input
+      id={fieldName}
+      type="text"
+      autoComplete="off"
+      placeholder={showPlaceholder ? platform : undefined}
+      {...register(fieldName)}
+    />
+  );
+};
+
+const renderNameSelect = (
+  fieldName: string,
+  status: string,
+  options: Option[],
+  isAccount: boolean,
+  isSelectAccountDisabled: boolean,
+  onFieldNameChange: ((fieldValue: string) => void) | undefined,
+  control: ReturnType<typeof useFormContext>['control'],
+  selectRef: Ref<SelectRef<Option, false, null>> | undefined,
+) => (
+  <Controller
+    name={fieldName}
+    control={control}
+    defaultValue={options.length > 0 ? options[0].name : ''}
+    render={({ field: { onChange, value } }) => (
+      <Select
+        menuPosition="fixed"
+        ref={selectRef}
+        id={fieldName}
+        onChange={(selectedValue) => {
+          onFieldNameChange?.(selectedValue);
+          onChange(selectedValue);
+        }}
+        value={value}
+        disabled={isSelectAccountDisabled && isAccount}
+        placeholder={`Select existing ${isAccount ? 'account' : 'user'}`}
+      >
+        {status === 'loading' && (
+          <Select.Option
+            disabled
+            disabledReason="Please wait until the list is loaded"
+            key="loading"
+            value="loading"
+            icon={<Loader size="small" />}
+          >
+            Loading...
+          </Select.Option>
+        )}
+        {options.map((item) => (
+          <Select.Option key={item.name} value={item.name}>
+            {item.name}
+          </Select.Option>
+        ))}
+      </Select>
+    )}
+  />
+);
+
 export const CreateOrSelectNameField = ({
   isExist,
   status,
@@ -76,11 +143,14 @@ export const CreateOrSelectNameField = ({
     control,
     formState: { errors },
   } = useFormContext();
-  const isAccount = onFieldNameChange ? true : false;
+
+  const isAccount = !!onFieldNameChange;
   const typeFieldName = isAccount ? FORM_FIELDS.ACCOUNT_NAME_TYPE : FORM_FIELDS.IAM_USER_NAME_TYPE;
+
   const [searchParams] = useSearchParams();
   const paramsAccountName = searchParams.get('account');
   const isParamsAccountNameInOptions = options.some((option) => option.name === paramsAccountName);
+
   const isExistingDisabled = (isAccount && isParamsAccountNameInOptions && isExist) || options.length === 0;
   const isCreateDisabled = isAccount && isExist && isParamsAccountNameInOptions;
   const isSelectAccountDisabled = isAccount && isParamsAccountNameInOptions && isExist;
@@ -89,6 +159,12 @@ export const CreateOrSelectNameField = ({
     !isAccount && options.length === 0 ? 'No existing IAM Users available' : undefined;
 
   const radioOptions = getRadioOptions(isAccount, isCreateDisabled, isExistingDisabled, disabledExistingReason);
+
+  const showCreateInput = type === 'create' || options.length === 0;
+
+  const existsError = isExist && type === 'create'
+    ? `${isAccount ? 'Account' : 'IAM User'} name already exists`
+    : ((errors[fieldName]?.message as string) ?? '');
 
   return (
     <Stack gap="r8" direction="vertical">
@@ -106,11 +182,9 @@ export const CreateOrSelectNameField = ({
               <RadioGroup
                 options={radioOptions}
                 value={options.length === 0 ? radioOptions[0].value : value}
-                onChange={(value) => {
-                  onChange(value);
-                  if (onOptionChange) {
-                    onOptionChange(value);
-                  }
+                onChange={(selectedValue) => {
+                  onChange(selectedValue);
+                  onOptionChange?.(selectedValue);
                 }}
                 direction="vertical"
               />
@@ -124,63 +198,21 @@ export const CreateOrSelectNameField = ({
         label={isAccount ? 'Account Name' : 'IAM User Name'}
         required
         helpErrorPosition="bottom"
-        error={
-          isExist && type === 'create'
-            ? `${isAccount ? 'Account' : 'IAM User'} name already exists`
-            : ((errors[fieldName]?.message as string) ?? '')
-        }
+        error={existsError}
         content={
           <Stack gap="r8" direction="vertical">
-            {type === 'create' || options.length === 0 ? (
-              <Input
-                id={fieldName}
-                type="text"
-                autoComplete="off"
-                placeholder={status === 'success' && options.length !== 0 ? `${platform}` : undefined}
-                {...register(fieldName)}
-              />
-            ) : (
-              <Controller
-                name={fieldName}
-                control={control}
-                defaultValue={options.length > 0 ? options[0].name : ''}
-                render={({ field: { onChange, value } }) => {
-                  return (
-                    <Select
-                      menuPosition="fixed"
-                      ref={selectRef}
-                      id={fieldName}
-                      onChange={(value) => {
-                        if (onFieldNameChange) {
-                          onFieldNameChange(value);
-                        }
-                        onChange(value);
-                      }}
-                      value={value}
-                      disabled={isSelectAccountDisabled && isAccount}
-                      placeholder={`Select existing ${isAccount ? 'account' : 'user'}`}
-                    >
-                      {status === 'loading' && (
-                        <Select.Option
-                          disabled
-                          disabledReason="Please wait until the list is loaded"
-                          key="loading"
-                          value="loading"
-                          icon={<Loader size="small" />}
-                        >
-                          Loading...
-                        </Select.Option>
-                      )}
-                      {options.map((item) => (
-                        <Select.Option key={item.name} value={item.name}>
-                          {item.name}
-                        </Select.Option>
-                      ))}
-                    </Select>
-                  );
-                }}
-              />
-            )}
+            {showCreateInput
+              ? renderNameInput(fieldName, status, options, platform, register)
+              : renderNameSelect(
+                  fieldName,
+                  status,
+                  options,
+                  isAccount,
+                  isSelectAccountDisabled,
+                  onFieldNameChange,
+                  control,
+                  selectRef,
+                )}
             {children}
           </Stack>
         }

--- a/src/react/ISV/components/CreateOrSelectNameField.tsx
+++ b/src/react/ISV/components/CreateOrSelectNameField.tsx
@@ -36,7 +36,12 @@ const FORM_FIELDS = {
   GENERATE_KEY: 'generateKey',
 };
 
-const getRadioOptions = (isAccount: boolean, disableCreate: boolean, disableExisting: boolean) => {
+export function getRadioOptions(
+  isAccount: boolean,
+  disableCreate: boolean,
+  disableExisting: boolean,
+  disabledExistingReason?: string,
+) {
   return [
     {
       value: 'create',
@@ -47,9 +52,10 @@ const getRadioOptions = (isAccount: boolean, disableCreate: boolean, disableExis
       value: 'existing',
       label: `Use an existing ${isAccount ? 'Account' : 'IAM User'}`,
       disabled: disableExisting,
+      disabledReason: disabledExistingReason,
     },
   ];
-};
+}
 
 export const CreateOrSelectNameField = ({
   isExist,
@@ -79,7 +85,10 @@ export const CreateOrSelectNameField = ({
   const isCreateDisabled = isAccount && isExist && isParamsAccountNameInOptions;
   const isSelectAccountDisabled = isAccount && isParamsAccountNameInOptions && isExist;
 
-  const radioOptions = getRadioOptions(isAccount, isCreateDisabled, isExistingDisabled);
+  const disabledExistingReason =
+    !isAccount && options.length === 0 ? 'No existing IAM Users available' : undefined;
+
+  const radioOptions = getRadioOptions(isAccount, isCreateDisabled, isExistingDisabled, disabledExistingReason);
 
   return (
     <Stack gap="r8" direction="vertical">

--- a/src/react/ISV/components/RadioGroup.tsx
+++ b/src/react/ISV/components/RadioGroup.tsx
@@ -1,3 +1,4 @@
+import { Tooltip } from '@scality/core-ui';
 import { spacing } from '@scality/core-ui/dist/spacing';
 import { useId } from 'react';
 import styled from 'styled-components';
@@ -7,6 +8,7 @@ type RadioOption = {
   label: string;
   description?: string;
   disabled?: boolean;
+  disabledReason?: string;
 };
 
 type RadioGroupProps = {
@@ -128,8 +130,10 @@ export const RadioGroup = ({
     <RadioContainer direction={direction}>
       {options.map((option) => {
         const optionId = `${groupName}-${option.value}`;
-        return (
-          <RadioWrapper key={option.value} data-disabled={disabled || option.disabled}>
+        const isDisabled = disabled || option.disabled;
+
+        const radioWrapper = (
+          <RadioWrapper key={option.value} data-disabled={isDisabled}>
             <RadioInput
               type="radio"
               id={optionId}
@@ -137,7 +141,7 @@ export const RadioGroup = ({
               value={option.value}
               checked={value === option.value}
               onChange={(e) => onChange(e.target.value)}
-              disabled={disabled || option.disabled}
+              disabled={isDisabled}
             />
             <RadioContent>
               <RadioLabel htmlFor={optionId}>{option.label}</RadioLabel>
@@ -145,6 +149,24 @@ export const RadioGroup = ({
             </RadioContent>
           </RadioWrapper>
         );
+
+        if (isDisabled && option.disabledReason) {
+          return (
+            <Tooltip
+              key={option.value}
+              overlay={option.disabledReason}
+              overlayStyle={{
+                height: 'fit-content',
+                maxWidth: '20rem',
+                width: 'fit-content',
+              }}
+            >
+              {radioWrapper}
+            </Tooltip>
+          );
+        }
+
+        return radioWrapper;
       })}
     </RadioContainer>
   );

--- a/src/react/ISV/components/RadioGroup.tsx
+++ b/src/react/ISV/components/RadioGroup.tsx
@@ -115,6 +115,53 @@ const RadioDescription = styled.span`
   font-size: 0.875rem;
 `;
 
+const renderRadioOption = (
+  option: RadioOption,
+  groupName: string,
+  isGroupDisabled: boolean,
+  onChange: (value: string) => void,
+  checked: boolean,
+) => {
+  const optionId = `${groupName}-${option.value}`;
+  const isDisabled = isGroupDisabled || option.disabled;
+
+  const wrapper = (
+    <RadioWrapper key={option.value} data-disabled={isDisabled}>
+      <RadioInput
+        type="radio"
+        id={optionId}
+        name={groupName}
+        value={option.value}
+        checked={checked}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={isDisabled}
+      />
+      <RadioContent>
+        <RadioLabel htmlFor={optionId}>{option.label}</RadioLabel>
+        {option.description && <RadioDescription>{option.description}</RadioDescription>}
+      </RadioContent>
+    </RadioWrapper>
+  );
+
+  if (isDisabled && option.disabledReason) {
+    return (
+      <Tooltip
+        key={option.value}
+        overlay={option.disabledReason}
+        overlayStyle={{
+          height: 'fit-content',
+          maxWidth: '20rem',
+          width: 'fit-content',
+        }}
+      >
+        {wrapper}
+      </Tooltip>
+    );
+  }
+
+  return wrapper;
+};
+
 export const RadioGroup = ({
   options,
   value,
@@ -128,46 +175,9 @@ export const RadioGroup = ({
 
   return (
     <RadioContainer direction={direction}>
-      {options.map((option) => {
-        const optionId = `${groupName}-${option.value}`;
-        const isDisabled = disabled || option.disabled;
-
-        const radioWrapper = (
-          <RadioWrapper key={option.value} data-disabled={isDisabled}>
-            <RadioInput
-              type="radio"
-              id={optionId}
-              name={groupName}
-              value={option.value}
-              checked={value === option.value}
-              onChange={(e) => onChange(e.target.value)}
-              disabled={isDisabled}
-            />
-            <RadioContent>
-              <RadioLabel htmlFor={optionId}>{option.label}</RadioLabel>
-              {option.description && <RadioDescription>{option.description}</RadioDescription>}
-            </RadioContent>
-          </RadioWrapper>
-        );
-
-        if (isDisabled && option.disabledReason) {
-          return (
-            <Tooltip
-              key={option.value}
-              overlay={option.disabledReason}
-              overlayStyle={{
-                height: 'fit-content',
-                maxWidth: '20rem',
-                width: 'fit-content',
-              }}
-            >
-              {radioWrapper}
-            </Tooltip>
-          );
-        }
-
-        return radioWrapper;
-      })}
+      {options.map((option) =>
+        renderRadioOption(option, groupName, disabled, onChange, value === option.value),
+      )}
     </RadioContainer>
   );
 };

--- a/src/react/ISV/components/__tests__/CreateOrSelectNameField.test.tsx
+++ b/src/react/ISV/components/__tests__/CreateOrSelectNameField.test.tsx
@@ -8,14 +8,13 @@ jest.mock('react-hook-form', () => {
     useFormContext: jest.fn(),
     Controller: ({ name, defaultValue, render }) => {
       if (name === 'accountNameType' || name === 'IAMUserNameType') {
-        const { field } = render({
+        return render({
           field: {
             onChange: jest.fn(),
             value: defaultValue,
             name,
           },
         });
-        return <div>{field}</div>;
       }
 
       return (
@@ -46,6 +45,12 @@ jest.mock('@scality/core-ui', () => ({
       <div>{label}</div>
       {content || children}
       {error && <div>{error}</div>}
+    </div>
+  ),
+  Tooltip: ({ children, overlay }: { children: React.ReactNode; overlay: React.ReactNode }) => (
+    <div>
+      <div data-testid="tooltip-overlay">{overlay}</div>
+      {children}
     </div>
   ),
 }));
@@ -231,5 +236,29 @@ describe('CreateOrSelectNameField', () => {
     rerender(<CreateOrSelectNameField {...defaultProps} type="existing" />);
 
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('shows disabledReason tooltip for existing option in IAM-mode when options are empty', () => {
+    render(
+      <CreateOrSelectNameField
+        {...defaultProps}
+        onFieldNameChange={null}
+        options={[]}
+      />,
+    );
+
+    expect(screen.getByTestId('tooltip-overlay')).toBeInTheDocument();
+    expect(screen.getByTestId('tooltip-overlay')).toHaveTextContent('No existing IAM Users available');
+  });
+
+  it('does not show disabledReason tooltip for existing option in Account-mode when options are empty', () => {
+    render(
+      <CreateOrSelectNameField
+        {...defaultProps}
+        options={[]}
+      />,
+    );
+
+    expect(screen.queryByTestId('tooltip-overlay')).not.toBeInTheDocument();
   });
 });

--- a/src/react/ISV/components/__tests__/RadioGroup.test.tsx
+++ b/src/react/ISV/components/__tests__/RadioGroup.test.tsx
@@ -2,6 +2,16 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 import { RadioGroup } from '../RadioGroup';
 
+jest.mock('@scality/core-ui', () => ({
+  ...jest.requireActual('@scality/core-ui'),
+  Tooltip: ({ children, overlay }: { children: React.ReactNode; overlay: React.ReactNode }) => (
+    <div>
+      <div data-testid="tooltip-overlay">{overlay}</div>
+      {children}
+    </div>
+  ),
+}));
+
 describe('RadioGroup', () => {
   const options = [
     { value: 'option1', label: 'Option 1', description: 'Description 1' },
@@ -81,5 +91,28 @@ describe('RadioGroup', () => {
     radioInputs.forEach((radio) => {
       expect(radio).toBeDisabled();
     });
+  });
+
+  it('should render tooltip overlay text for disabled option with disabledReason', () => {
+    const optionsWithDisabledReason = [
+      { value: 'option1', label: 'Option 1' },
+      { value: 'option2', label: 'Option 2', disabled: true, disabledReason: 'This option is not available' },
+    ];
+
+    renderRadioGroup({ options: optionsWithDisabledReason });
+
+    expect(screen.getByTestId('tooltip-overlay')).toBeInTheDocument();
+    expect(screen.getByTestId('tooltip-overlay')).toHaveTextContent('This option is not available');
+  });
+
+  it('should not render tooltip for disabled option without disabledReason', () => {
+    const optionsWithoutDisabledReason = [
+      { value: 'option1', label: 'Option 1' },
+      { value: 'option2', label: 'Option 2', disabled: true },
+    ];
+
+    renderRadioGroup({ options: optionsWithoutDisabledReason });
+
+    expect(screen.queryByTestId('tooltip-overlay')).not.toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Extend `RadioOption` with an optional `disabledReason?: string` field and render a `Tooltip` from `@scality/core-ui` around disabled radio options when that field is set. `CreateOrSelectNameField` now passes an explanatory message for the IAM-user "existing" option when it is disabled due to an empty options list, mirroring the `Select.Option { disabledReason }` UX already in use.

## Links

- JIRA: [ARTESCA-17418](https://scality.atlassian.net/browse/ARTESCA-17418)
- Tracking issue: scality/agent-task#141

## Step Adherence

- [x] Step 1: Add `disabledReason` to `RadioOption` and render `Tooltip` (`src/react/ISV/components/RadioGroup.tsx`)
- [x] Step 2: Pass `disabledReason` from `CreateOrSelectNameField` for IAM-mode empty-options case
- [x] Step 3: Update `RadioGroup` tests (covered alongside step 1)
- [x] Step 4: Update `CreateOrSelectNameField` tests (covered alongside step 2)
- [x] Simplification pass (extracted `renderRadioOption`, `renderNameInput`, `renderNameSelect` helpers; replaced manual guards with optional chaining; hoisted derived values into named variables — all behavior-preserving, full test suite green)

## Approved Deviations

- **Step 1** (files-outside-list): Modified `RadioGroup.test.tsx` together with the implementation. The test additions were tightly coupled to the new behavior and matched step 3's plan.
- **Step 2** (files-outside-list): Modified `CreateOrSelectNameField.test.tsx` together with the implementation, including a small fix to the existing `Controller` mock so the radio-group render branch returns the rendered output directly. Added the IAM-mode (tooltip rendered) and Account-mode (no tooltip) test cases listed in step 4.
- **Disabled-reason text**: The plan suggested a longer message; the implementation uses `'No existing IAM Users available'` (matching the plan's "such as" qualifier and consistent with the existing `Select.Option { disabledReason }` style in the same file).

## Test Strategy Executed

Jest + React Testing Library, mirroring `RadioGroup.test.tsx` and `CreateOrSelectNameField.test.tsx`:

- `RadioGroup`: disabled option with `disabledReason` renders a tooltip overlay containing the reason text.
- `RadioGroup`: disabled option without `disabledReason` does not render a tooltip (backward compat).
- `CreateOrSelectNameField` (IAM mode, empty options): the `disabledReason` message is rendered.
- `CreateOrSelectNameField` (Account mode, empty options): no `disabledReason` message is rendered.

Result: 20/20 targeted tests pass; 307 ISV-suite tests pass.

## Risks / Notes

`Tooltip` wraps its child in an element that intercepts pointer events; verify with manual testing that the overlay still triggers on hover over a `cursor: not-allowed` `RadioWrapper`. The CardISV pattern this mirrors uses the same approach.

[ARTESCA-17418]: https://scality.atlassian.net/browse/ARTESCA-17418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ