### PR TITLE
fix(routes): gate Data Browser sidebar and routes for data-consumer-role

### DIFF
--- a/__mocks__/@scality/data-browser-library.tsx
+++ b/__mocks__/@scality/data-browser-library.tsx
@@ -87,3 +87,12 @@ export const useGetObject = jest.fn(() => ({
 }));
 
 export const DataBrowserUI = () => null;
+
+export const useBuckets = jest.fn(() => ({
+  data: undefined,
+  status: 'idle',
+  isLoading: false,
+  isSuccess: false,
+  isError: false,
+  error: null,
+}));

--- a/__mocks__/@scality/data-browser-library.tsx
+++ b/__mocks__/@scality/data-browser-library.tsx
@@ -85,3 +85,5 @@ export const useGetObject = jest.fn(() => ({
   error: null,
   refetch: jest.fn(),
 }));
+
+export const DataBrowserUI = () => null;

--- a/src/react/Routes.test.tsx
+++ b/src/react/Routes.test.tsx
@@ -462,7 +462,7 @@ describe('Routes component', () => {
         });
 
         await waitFor(() => {
-          expect(screen.getByText(/Access Denied/i)).toBeInTheDocument();
+          expect(screen.getByText(/Not authorized/i)).toBeInTheDocument();
         });
       });
 
@@ -475,7 +475,7 @@ describe('Routes component', () => {
         });
 
         await waitFor(() => {
-          expect(screen.queryByText(/Access Denied/i)).not.toBeInTheDocument();
+          expect(screen.queryByText(/Not authorized/i)).not.toBeInTheDocument();
         });
       });
     });
@@ -490,7 +490,7 @@ describe('Routes component', () => {
         });
 
         await waitFor(() => {
-          expect(screen.getByText(/Access Denied/i)).toBeInTheDocument();
+          expect(screen.getByText(/Not authorized/i)).toBeInTheDocument();
         });
       });
 
@@ -503,7 +503,7 @@ describe('Routes component', () => {
         });
 
         await waitFor(() => {
-          expect(screen.queryByText(/Access Denied/i)).not.toBeInTheDocument();
+          expect(screen.queryByText(/Not authorized/i)).not.toBeInTheDocument();
         });
       });
     });
@@ -518,7 +518,7 @@ describe('Routes component', () => {
         });
 
         await waitFor(() => {
-          expect(screen.getByText(/Access Denied/i)).toBeInTheDocument();
+          expect(screen.getByText(/Not authorized/i)).toBeInTheDocument();
         });
       });
 
@@ -531,7 +531,7 @@ describe('Routes component', () => {
         });
 
         await waitFor(() => {
-          expect(screen.queryByText(/Access Denied/i)).not.toBeInTheDocument();
+          expect(screen.queryByText(/Not authorized/i)).not.toBeInTheDocument();
         });
       });
     });

--- a/src/react/Routes.test.tsx
+++ b/src/react/Routes.test.tsx
@@ -3,6 +3,7 @@ import { useAuthLoading } from './AuthLoadingProvider';
 import { useConfig } from './next-architecture/ui/ConfigProvider';
 import InternalRoutes, { PrivateRoutes } from './Routes';
 import { FAKE_TOKEN, mockShellHooks, renderWithRouterMatch } from './utils/testUtil';
+import { setRoleArnStored, removeRoleArnStored } from './utils/localStorage';
 
 jest.mock('./next-architecture/ui/ConfigProvider', () => ({
   useConfig: jest.fn(),
@@ -438,6 +439,99 @@ describe('Routes component', () => {
       // Truststore route should not be rendered - verify Truststore content is not present
       await waitFor(() => {
         expect(screen.queryByText(/Import Certificate/i)).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Data Browser route guards', () => {
+    const DATA_CONSUMER_ARN = 'arn:aws:iam::000000000000:role/scality-internal/data-consumer-role';
+    const STORAGE_MANAGER_ARN = 'arn:aws:iam::000000000000:role/scality-internal/storage-manager-role';
+
+    afterEach(() => {
+      removeRoleArnStored();
+    });
+
+    describe('accounts/:accountName/data/buckets route', () => {
+      it('should render ErrorPage401 for data-consumer-role ARN', async () => {
+        setRoleArnStored(DATA_CONSUMER_ARN);
+
+        renderWithRouterMatch(<PrivateRoutes />, {
+          path: '/*',
+          route: '/accounts/test/data/buckets',
+        });
+
+        await waitFor(() => {
+          expect(screen.getByText(/Access Denied/i)).toBeInTheDocument();
+        });
+      });
+
+      it('should render Data Browser for storage-manager-role ARN', async () => {
+        setRoleArnStored(STORAGE_MANAGER_ARN);
+
+        renderWithRouterMatch(<PrivateRoutes />, {
+          path: '/*',
+          route: '/accounts/test/data/buckets',
+        });
+
+        await waitFor(() => {
+          expect(screen.queryByText(/Access Denied/i)).not.toBeInTheDocument();
+        });
+      });
+    });
+
+    describe('accounts/:accountName/buckets route', () => {
+      it('should render ErrorPage401 for data-consumer-role ARN', async () => {
+        setRoleArnStored(DATA_CONSUMER_ARN);
+
+        renderWithRouterMatch(<PrivateRoutes />, {
+          path: '/*',
+          route: '/accounts/test/buckets',
+        });
+
+        await waitFor(() => {
+          expect(screen.getByText(/Access Denied/i)).toBeInTheDocument();
+        });
+      });
+
+      it('should render Data Browser for storage-manager-role ARN', async () => {
+        setRoleArnStored(STORAGE_MANAGER_ARN);
+
+        renderWithRouterMatch(<PrivateRoutes />, {
+          path: '/*',
+          route: '/accounts/test/buckets',
+        });
+
+        await waitFor(() => {
+          expect(screen.queryByText(/Access Denied/i)).not.toBeInTheDocument();
+        });
+      });
+    });
+
+    describe('buckets route', () => {
+      it('should render ErrorPage401 for data-consumer-role ARN', async () => {
+        setRoleArnStored(DATA_CONSUMER_ARN);
+
+        renderWithRouterMatch(<PrivateRoutes />, {
+          path: '/*',
+          route: '/buckets',
+        });
+
+        await waitFor(() => {
+          expect(screen.getByText(/Access Denied/i)).toBeInTheDocument();
+        });
+      });
+
+      it('should render redirect or empty state for storage-manager-role ARN', async () => {
+        setRoleArnStored(STORAGE_MANAGER_ARN);
+
+        renderWithRouterMatch(<PrivateRoutes />, {
+          path: '/*',
+          route: '/buckets',
+        });
+
+        await waitFor(() => {
+          expect(screen.queryByText(/Access Denied/i)).not.toBeInTheDocument();
+        });
       });
     });
   });

--- a/src/react/Routes.test.tsx
+++ b/src/react/Routes.test.tsx
@@ -446,6 +446,7 @@ describe('Routes component', () => {
   describe('Data Browser route guards', () => {
     const DATA_CONSUMER_ARN = 'arn:aws:iam::000000000000:role/scality-internal/data-consumer-role';
     const STORAGE_MANAGER_ARN = 'arn:aws:iam::000000000000:role/scality-internal/storage-manager-role';
+    const STORAGE_ACCOUNT_OWNER_ARN = 'arn:aws:iam::000000000000:role/scality-internal/storage-account-owner-role';
 
     afterEach(() => {
       removeRoleArnStored();
@@ -531,6 +532,47 @@ describe('Routes component', () => {
 
         await waitFor(() => {
           expect(screen.queryByText(/Access Denied/i)).not.toBeInTheDocument();
+        });
+      });
+    });
+
+    describe('sidebar Data Browser entry gating', () => {
+      it('should hide Data Browser sidebar entry for data-consumer-role ARN', async () => {
+        setRoleArnStored(DATA_CONSUMER_ARN);
+
+        renderWithRouterMatch(<InternalRoutes />, {
+          path: '/*',
+          route: '/accounts',
+        });
+
+        await waitFor(() => {
+          expect(screen.queryByText('Data Browser')).not.toBeInTheDocument();
+        });
+      });
+
+      it('should show Data Browser sidebar entry for storage-manager-role ARN', async () => {
+        setRoleArnStored(STORAGE_MANAGER_ARN);
+
+        renderWithRouterMatch(<InternalRoutes />, {
+          path: '/*',
+          route: '/accounts',
+        });
+
+        await waitFor(() => {
+          expect(screen.queryByText('Data Browser')).toBeInTheDocument();
+        });
+      });
+
+      it('should show Data Browser sidebar entry for storage-account-owner-role ARN', async () => {
+        setRoleArnStored(STORAGE_ACCOUNT_OWNER_ARN);
+
+        renderWithRouterMatch(<InternalRoutes />, {
+          path: '/*',
+          route: '/accounts',
+        });
+
+        await waitFor(() => {
+          expect(screen.queryByText('Data Browser')).toBeInTheDocument();
         });
       });
     });

--- a/src/react/Routes.tsx
+++ b/src/react/Routes.tsx
@@ -263,13 +263,16 @@ export function PrivateRoutes({ hideSideBar = false }: { hideSideBar?: boolean }
   );
 }
 
-function InternalRoutes() {
+function InternalRoutes(): JSX.Element {
   const [isSideBarOpen, setIsSideBarOpen] = useState(
     localStorage.getItem('isSideBarOpen') === null || localStorage.getItem('isSideBarOpen') === 'true',
   );
   const location = useLocation();
   const { isStorageManager, isPlatformAdmin } = useAuthGroups();
   const config = useConfig();
+
+  const storedRoleArn = getRoleArnStored();
+  const isDataConsumerRole = regexArn.exec(storedRoleArn)?.groups?.name === DATA_CONSUMER_ROLE;
 
   const metalK8sInstances = useDeployedMetalk8sInstances();
   const isMetalK8sEnabled = metalK8sInstances.length > 0;
@@ -331,7 +334,7 @@ function InternalRoutes() {
           doesRouteMatch('/accounts/:accountName/users') ||
           doesRouteMatch('/accounts/:accountName/policies'),
       },
-      {
+      !isDataConsumerRole && {
         label: 'Data Browser',
         icon: <Icon name="Bucket" />,
         onClick: () => {

--- a/src/react/Routes.tsx
+++ b/src/react/Routes.tsx
@@ -1,6 +1,6 @@
 import { AppContainer, EmptyState, ErrorPage401, Icon, Loader, Sidebar } from '@scality/core-ui';
 import { useBasenameRelativeNavigate } from '@scality/module-federation';
-import { useCallback, useState } from 'react';
+import { type JSX, useCallback, useState } from 'react';
 import { matchPath, Navigate, Route, Routes, useLocation } from 'react-router';
 import { useAuthLoading } from './AuthLoadingProvider';
 import AccountContent from './account/AccountContent';
@@ -25,7 +25,8 @@ import STSProvider from './STSProvider';
 import ImportCertificate from './truststore/ImportCertificate';
 import Truststore from './truststore/Truststore';
 import ReauthDialog from './ui-elements/ReauthDialog';
-import { useAuthGroups } from './utils/hooks';
+import { DATA_CONSUMER_ROLE, regexArn, useAuthGroups } from './utils/hooks';
+import { getRoleArnStored } from './utils/localStorage';
 
 export const RemoveTrailingSlash = ({ ...rest }) => {
   const location = useLocation();
@@ -69,11 +70,13 @@ const RedirectToAccount = () => {
   }
 };
 
-export function PrivateRoutes({ hideSideBar = false }: { hideSideBar?: boolean }) {
+export function PrivateRoutes({ hideSideBar = false }: { hideSideBar?: boolean }): JSX.Element {
   const { isClientsLoaded } = useAuthLoading();
   const config = useConfig();
 
   const { isPlatformAdmin } = useAuthGroups();
+  const storedRoleArn = getRoleArnStored();
+  const isDataConsumerRole = regexArn.exec(storedRoleArn)?.groups?.name === DATA_CONSUMER_ROLE;
   const metalK8sInstances = useDeployedMetalk8sInstances();
   const isMetalK8sEnabled = metalK8sInstances.length > 0;
   if (!isClientsLoaded) {

--- a/src/react/Routes.tsx
+++ b/src/react/Routes.tsx
@@ -220,17 +220,25 @@ export function PrivateRoutes({ hideSideBar = false }: { hideSideBar?: boolean }
       <Route
         path="accounts/:accountName/data/buckets/*"
         element={
-          <DataServiceRoleProvider>
-            <DataBrowser hideHeader={hideSideBar} />
-          </DataServiceRoleProvider>
+          isDataConsumerRole ? (
+            <ErrorPage401 />
+          ) : (
+            <DataServiceRoleProvider>
+              <DataBrowser hideHeader={hideSideBar} />
+            </DataServiceRoleProvider>
+          )
         }
       />
       <Route
         path="accounts/:accountName/buckets/*"
         element={
-          <DataServiceRoleProvider>
-            <DataBrowser hideHeader={hideSideBar} />
-          </DataServiceRoleProvider>
+          isDataConsumerRole ? (
+            <ErrorPage401 />
+          ) : (
+            <DataServiceRoleProvider>
+              <DataBrowser hideHeader={hideSideBar} />
+            </DataServiceRoleProvider>
+          )
         }
       />
       <Route
@@ -252,9 +260,13 @@ export function PrivateRoutes({ hideSideBar = false }: { hideSideBar?: boolean }
       <Route
         path="buckets/*"
         element={
-          <DataServiceRoleProvider>
-            <RedirectToAccount />
-          </DataServiceRoleProvider>
+          isDataConsumerRole ? (
+            <ErrorPage401 />
+          ) : (
+            <DataServiceRoleProvider>
+              <RedirectToAccount />
+            </DataServiceRoleProvider>
+          )
         }
       />
       <Route path="/" element={<Navigate to="accounts" replace />} />

--- a/src/react/Routes.tsx
+++ b/src/react/Routes.tsx
@@ -25,8 +25,7 @@ import STSProvider from './STSProvider';
 import ImportCertificate from './truststore/ImportCertificate';
 import Truststore from './truststore/Truststore';
 import ReauthDialog from './ui-elements/ReauthDialog';
-import { DATA_CONSUMER_ROLE, regexArn, useAuthGroups } from './utils/hooks';
-import { getRoleArnStored } from './utils/localStorage';
+import { getIsDataConsumerRole, useAuthGroups } from './utils/hooks';
 
 export const RemoveTrailingSlash = ({ ...rest }) => {
   const location = useLocation();
@@ -70,13 +69,14 @@ const RedirectToAccount = () => {
   }
 };
 
+const DataBrowserGuard = ({ children }: { children: JSX.Element }): JSX.Element =>
+  getIsDataConsumerRole() ? <ErrorPage401 /> : children;
+
 export function PrivateRoutes({ hideSideBar = false }: { hideSideBar?: boolean }): JSX.Element {
   const { isClientsLoaded } = useAuthLoading();
   const config = useConfig();
 
   const { isPlatformAdmin } = useAuthGroups();
-  const storedRoleArn = getRoleArnStored();
-  const isDataConsumerRole = regexArn.exec(storedRoleArn)?.groups?.name === DATA_CONSUMER_ROLE;
   const metalK8sInstances = useDeployedMetalk8sInstances();
   const isMetalK8sEnabled = metalK8sInstances.length > 0;
   if (!isClientsLoaded) {
@@ -220,25 +220,21 @@ export function PrivateRoutes({ hideSideBar = false }: { hideSideBar?: boolean }
       <Route
         path="accounts/:accountName/data/buckets/*"
         element={
-          isDataConsumerRole ? (
-            <ErrorPage401 />
-          ) : (
+          <DataBrowserGuard>
             <DataServiceRoleProvider>
               <DataBrowser hideHeader={hideSideBar} />
             </DataServiceRoleProvider>
-          )
+          </DataBrowserGuard>
         }
       />
       <Route
         path="accounts/:accountName/buckets/*"
         element={
-          isDataConsumerRole ? (
-            <ErrorPage401 />
-          ) : (
+          <DataBrowserGuard>
             <DataServiceRoleProvider>
               <DataBrowser hideHeader={hideSideBar} />
             </DataServiceRoleProvider>
-          )
+          </DataBrowserGuard>
         }
       />
       <Route
@@ -260,13 +256,11 @@ export function PrivateRoutes({ hideSideBar = false }: { hideSideBar?: boolean }
       <Route
         path="buckets/*"
         element={
-          isDataConsumerRole ? (
-            <ErrorPage401 />
-          ) : (
+          <DataBrowserGuard>
             <DataServiceRoleProvider>
               <RedirectToAccount />
             </DataServiceRoleProvider>
-          )
+          </DataBrowserGuard>
         }
       />
       <Route path="/" element={<Navigate to="accounts" replace />} />
@@ -283,8 +277,7 @@ function InternalRoutes(): JSX.Element {
   const { isStorageManager, isPlatformAdmin } = useAuthGroups();
   const config = useConfig();
 
-  const storedRoleArn = getRoleArnStored();
-  const isDataConsumerRole = regexArn.exec(storedRoleArn)?.groups?.name === DATA_CONSUMER_ROLE;
+  const isDataConsumerRole = getIsDataConsumerRole();
 
   const metalK8sInstances = useDeployedMetalk8sInstances();
   const isMetalK8sEnabled = metalK8sInstances.length > 0;

--- a/src/react/utils/hooks.ts
+++ b/src/react/utils/hooks.ts
@@ -137,8 +137,8 @@ export const regexArn =
 
 export const STORAGE_MANAGER_ROLE = 'storage-manager-role';
 export const STORAGE_ACCOUNT_OWNER_ROLE = 'storage-account-owner-role';
-const DATA_CONSUMER_ROLE = 'data-consumer-role';
-const DATA_ACCESSOR_ROLE = 'data-accessor-role';
+export const DATA_CONSUMER_ROLE = 'data-consumer-role';
+export const DATA_ACCESSOR_ROLE = 'data-accessor-role';
 export const SCALITY_INTERNAL_ROLES = [
   STORAGE_MANAGER_ROLE,
   STORAGE_ACCOUNT_OWNER_ROLE,

--- a/src/react/utils/hooks.ts
+++ b/src/react/utils/hooks.ts
@@ -11,6 +11,7 @@ import { useErrorHandler } from '../ErrorProvider';
 import { useConfig } from '../next-architecture/ui/ConfigProvider';
 import { addTrailingSlash, errorParser } from '.';
 import { useAwsPaginatedEntities } from './IAMhooks';
+import { getRoleArnStored } from './localStorage';
 
 export const useHeight = (myRef) => {
   const [height, setHeight] = useState(0);
@@ -146,6 +147,10 @@ export const SCALITY_INTERNAL_ROLES = [
   DATA_ACCESSOR_ROLE,
 ];
 export const SCALITY_IAM_ROLES = [STORAGE_ACCOUNT_OWNER_ROLE, DATA_CONSUMER_ROLE, DATA_ACCESSOR_ROLE];
+
+export function getIsDataConsumerRole(): boolean {
+  return regexArn.exec(getRoleArnStored())?.groups?.name === DATA_CONSUMER_ROLE;
+}
 
 const defaultEventDispatcher = () => {
   const { handleClientError, showModalError } = useErrorHandler();


### PR DESCRIPTION
## Summary

Gates the 'Data Browser' sidebar entry and the three Data Browser routes (`/buckets/*`, `/accounts/:accountName/buckets/*`, `/accounts/:accountName/data/buckets/*`) behind a check that the currently assumed role is **not** `data-consumer-role`. The check uses `getRoleArnStored()` + the existing `regexArn`, avoiding any `DataServiceRoleProvider` restructuring (which would trigger a Loader-blocking STS call on mount).

Related:
- JIRA: [ZKUI-476](https://scality.atlassian.net/browse/ZKUI-476)
- Tracking issue: scality/agent-task#151

## Step adherence

- [x] Step 1: Export `DATA_CONSUMER_ROLE` and `DATA_ACCESSOR_ROLE` from `hooks.ts`
- [x] Step 2: Derive `isDataConsumerRole` inline in `PrivateRoutes`
- [x] Step 3: Hide Data Browser sidebar entry for `data-consumer-role`
- [x] Step 4: Guard all three Data Browser routes with `ErrorPage401`
- [x] Step 5: Extend `Routes.test.tsx` with sidebar-gating and route-guard tests
- [x] Simplification: Extracted `getIsDataConsumerRole()` helper in `hooks.ts` and a `DataBrowserGuard` component in `Routes.tsx` to deduplicate the three identical ternary route guards

## Declared deviations (approved by reviewer)

- **Step 2 — `extra-import`**: Added `type JSX` to the existing React import line on `Routes.tsx` to support an explicit `: JSX.Element` return-type annotation on `PrivateRoutes` (the project's `tsconfig.json` uses `jsx: react-jsx`, so the JSX namespace is not globally available). Same pattern as `AuthLoadingProvider.tsx`.
- **Step 4 — `files-outside-list`**: The implementing sub-agent also added partial route-guard tests in `Routes.test.tsx` (the file targeted by step 5). Step 5 then extended those tests with the sidebar-gating cases. Net result: full coverage of the matrix described in the test strategy.

## Test strategy executed

Statically structured Jest + RTL tests added to `Routes.test.tsx`, mirroring the existing `truststore routes` describe block:

- **Route guards** — `ErrorPage401` renders for each of the three routes (`/accounts/test/data/buckets`, `/accounts/test/buckets`, `/buckets`) under a `data-consumer-role` ARN; no `ErrorPage401` under a `storage-manager-role` ARN.
- **Sidebar gating** — `Data Browser` entry absent for `data-consumer-role`; present for `storage-manager-role` and `storage-account-owner-role` (regression guard).

> ⚠️ The Jest suite itself could not be executed in CI runner pre-merge because `development/4` has a pre-existing infra blocker: `@scality/data-browser-library@1.1.20` is ESM-only and Jest 27's resolver does not support its `exports` field, so `jestSetupAfterEnv.tsx` fails to resolve the module. This is unrelated to this change and exists in `HEAD` before any modification. The new tests are statically correct and follow the canonical patterns used elsewhere in the file.

## Risks & follow-up

- **Backport to 4.2.x** is required per Valamir's JIRA comment — open a separate PR against `development/4.2`. The simpler inline-derivation approach was chosen specifically to reduce merge-conflict surface for that backport.
- **`buckets/*` element is `RedirectToAccount`**, which already renders `ErrorPage401` when `!isStorageManager`. Guarding the route is somewhat redundant for the data-consumer case, but harmless and keeps the three routes uniform.
- **`regexArn` on empty/non-matching input** safely yields `undefined` → strict `===` is false → no gating (safe default).
- **Source of truth**: `getRoleArnStored()` reflects the most recently selected role; if that ever moves off localStorage, the guard must be revisited.


[ZKUI-476]: https://scality.atlassian.net/browse/ZKUI-476?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ