### PR TITLE
fix(routes): gate Data Browser for storage-usage-consumer-role

### DIFF
--- a/src/react/Routes.test.tsx
+++ b/src/react/Routes.test.tsx
@@ -444,7 +444,7 @@ describe('Routes component', () => {
   });
 
   describe('Data Browser route guards', () => {
-    const DATA_CONSUMER_ARN = 'arn:aws:iam::000000000000:role/scality-internal/data-consumer-role';
+    const STORAGE_USAGE_CONSUMER_ARN = 'arn:aws:iam::000000000000:role/scality-internal/storage-usage-consumer-role';
     const STORAGE_MANAGER_ARN = 'arn:aws:iam::000000000000:role/scality-internal/storage-manager-role';
     const STORAGE_ACCOUNT_OWNER_ARN = 'arn:aws:iam::000000000000:role/scality-internal/storage-account-owner-role';
 
@@ -453,8 +453,8 @@ describe('Routes component', () => {
     });
 
     describe('accounts/:accountName/data/buckets route', () => {
-      it('should render ErrorPage401 for data-consumer-role ARN', async () => {
-        setRoleArnStored(DATA_CONSUMER_ARN);
+      it('should render ErrorPage401 for storage-usage-consumer-role ARN', async () => {
+        setRoleArnStored(STORAGE_USAGE_CONSUMER_ARN);
 
         renderWithRouterMatch(<PrivateRoutes />, {
           path: '/*',
@@ -481,8 +481,8 @@ describe('Routes component', () => {
     });
 
     describe('accounts/:accountName/buckets route', () => {
-      it('should render ErrorPage401 for data-consumer-role ARN', async () => {
-        setRoleArnStored(DATA_CONSUMER_ARN);
+      it('should render ErrorPage401 for storage-usage-consumer-role ARN', async () => {
+        setRoleArnStored(STORAGE_USAGE_CONSUMER_ARN);
 
         renderWithRouterMatch(<PrivateRoutes />, {
           path: '/*',
@@ -509,8 +509,8 @@ describe('Routes component', () => {
     });
 
     describe('buckets route', () => {
-      it('should render ErrorPage401 for data-consumer-role ARN', async () => {
-        setRoleArnStored(DATA_CONSUMER_ARN);
+      it('should render ErrorPage401 for storage-usage-consumer-role ARN', async () => {
+        setRoleArnStored(STORAGE_USAGE_CONSUMER_ARN);
 
         renderWithRouterMatch(<PrivateRoutes />, {
           path: '/*',
@@ -537,8 +537,8 @@ describe('Routes component', () => {
     });
 
     describe('sidebar Data Browser entry gating', () => {
-      it('should hide Data Browser sidebar entry for data-consumer-role ARN', async () => {
-        setRoleArnStored(DATA_CONSUMER_ARN);
+      it('should hide Data Browser sidebar entry for storage-usage-consumer-role ARN', async () => {
+        setRoleArnStored(STORAGE_USAGE_CONSUMER_ARN);
 
         renderWithRouterMatch(<InternalRoutes />, {
           path: '/*',

--- a/src/react/Routes.tsx
+++ b/src/react/Routes.tsx
@@ -25,7 +25,7 @@ import STSProvider from './STSProvider';
 import ImportCertificate from './truststore/ImportCertificate';
 import Truststore from './truststore/Truststore';
 import ReauthDialog from './ui-elements/ReauthDialog';
-import { getIsDataConsumerRole, useAuthGroups } from './utils/hooks';
+import { getIsStorageUsageConsumerRole, useAuthGroups } from './utils/hooks';
 
 export const RemoveTrailingSlash = ({ ...rest }) => {
   const location = useLocation();
@@ -70,7 +70,7 @@ const RedirectToAccount = () => {
 };
 
 const DataBrowserGuard = ({ children }: { children: JSX.Element }): JSX.Element =>
-  getIsDataConsumerRole() ? <ErrorPage401 /> : children;
+  getIsStorageUsageConsumerRole() ? <ErrorPage401 /> : children;
 
 export function PrivateRoutes({ hideSideBar = false }: { hideSideBar?: boolean }): JSX.Element {
   const { isClientsLoaded } = useAuthLoading();
@@ -277,7 +277,7 @@ function InternalRoutes(): JSX.Element {
   const { isStorageManager, isPlatformAdmin } = useAuthGroups();
   const config = useConfig();
 
-  const isDataConsumerRole = getIsDataConsumerRole();
+  const isStorageUsageConsumerRole = getIsStorageUsageConsumerRole();
 
   const metalK8sInstances = useDeployedMetalk8sInstances();
   const isMetalK8sEnabled = metalK8sInstances.length > 0;
@@ -339,7 +339,7 @@ function InternalRoutes(): JSX.Element {
           doesRouteMatch('/accounts/:accountName/users') ||
           doesRouteMatch('/accounts/:accountName/policies'),
       },
-      !isDataConsumerRole && {
+      !isStorageUsageConsumerRole && {
         label: 'Data Browser',
         icon: <Icon name="Bucket" />,
         onClick: () => {

--- a/src/react/utils/hooks.ts
+++ b/src/react/utils/hooks.ts
@@ -140,16 +140,18 @@ export const STORAGE_MANAGER_ROLE = 'storage-manager-role';
 export const STORAGE_ACCOUNT_OWNER_ROLE = 'storage-account-owner-role';
 export const DATA_CONSUMER_ROLE = 'data-consumer-role';
 export const DATA_ACCESSOR_ROLE = 'data-accessor-role';
+export const STORAGE_USAGE_CONSUMER_ROLE = 'storage-usage-consumer-role';
 export const SCALITY_INTERNAL_ROLES = [
   STORAGE_MANAGER_ROLE,
   STORAGE_ACCOUNT_OWNER_ROLE,
   DATA_CONSUMER_ROLE,
   DATA_ACCESSOR_ROLE,
+  STORAGE_USAGE_CONSUMER_ROLE,
 ];
 export const SCALITY_IAM_ROLES = [STORAGE_ACCOUNT_OWNER_ROLE, DATA_CONSUMER_ROLE, DATA_ACCESSOR_ROLE];
 
-export function getIsDataConsumerRole(): boolean {
-  return regexArn.exec(getRoleArnStored())?.groups?.name === DATA_CONSUMER_ROLE;
+export function getIsStorageUsageConsumerRole(): boolean {
+  return regexArn.exec(getRoleArnStored())?.groups?.name === STORAGE_USAGE_CONSUMER_ROLE;
 }
 
 const defaultEventDispatcher = () => {


### PR DESCRIPTION
## Summary

Fixes the incorrect role gating introduced in #1189. The previous PR gated `data-consumer-role` based on a wrong assumption in the analysis — the role described in ZKUI-476 is `storage-usage-consumer-role`, a new role defined in vault with only `sur:GetMetrics` permission (no S3/IAM access), which had no constant in zenko-ui yet.

- Add `STORAGE_USAGE_CONSUMER_ROLE = 'storage-usage-consumer-role'` constant and include it in `SCALITY_INTERNAL_ROLES`
- Replace `getIsDataConsumerRole` / `isDataConsumerRole` with `getIsStorageUsageConsumerRole` / `isStorageUsageConsumerRole` throughout `Routes.tsx`
- Update tests to use `storage-usage-consumer-role` ARNs

## Test plan

- [ ] CI passes (same test coverage as #1189, corrected role name)
- [ ] Verify Data Browser sidebar entry is hidden when assuming `scality-internal/storage-usage-consumer-role`
- [ ] Verify `/buckets`, `/accounts/:name/buckets/*`, `/accounts/:name/data/buckets/*` return 401 for `storage-usage-consumer-role`
- [ ] Verify Data Browser remains accessible for `storage-manager-role` and `storage-account-owner-role`

Fixes: ZKUI-476