### PR TITLE
feat(accounts): replace pensieve account source with Vault GetRolesForWebIdentity

### DIFF
--- a/src/react/account/iamAttachment/__tests__/Attachments.test.tsx
+++ b/src/react/account/iamAttachment/__tests__/Attachments.test.tsx
@@ -171,6 +171,7 @@ const defaultCurrentAccount = {
   Name: 'Renard',
   Roles: [],
   CreationDate: new Date('2022-03-18T12:51:44Z'),
+  canonicalId: 'canonical-id-renard',
 };
 beforeAll(() => {
   server.listen({ onUnhandledRequest: 'error' });

--- a/src/react/next-architecture/adapters/accessible-accounts/IAMPensieveAccessibleAccounts.ts
+++ b/src/react/next-architecture/adapters/accessible-accounts/IAMPensieveAccessibleAccounts.ts
@@ -1,25 +1,17 @@
 import { noopBasedEventDispatcher, useAccounts } from '../../../utils/hooks';
-import { useAccountsLocationsAndEndpoints } from '../../domain/business/accounts';
 import type { AccountInfo, Role } from '../../domain/entities/account';
 import type { PromiseResult } from '../../domain/entities/promise';
-import type { IAccountsLocationsEndpointsAdapter } from '../accounts-locations/IAccountsLocationsEndpointsBundledAdapter';
 import type { IAccessibleAccounts } from './IAccessibleAccounts';
 
 export class IAMPensieveAccessibleAccounts implements IAccessibleAccounts {
-  constructor(
-    private accountsLocationsAndEndpointsAdapter: IAccountsLocationsEndpointsAdapter,
-    private withEventDispatcher = true,
-  ) {}
+  constructor(private withEventDispatcher = noopBasedEventDispatcher) {}
+
   useListAccessibleAccounts(): {
     accountInfos: PromiseResult<(AccountInfo & { assumableRoles: Role[] })[]>;
   } {
-    const { accountsLocationsAndEndpoints, status: accountStatus } = useAccountsLocationsAndEndpoints({
-      accountsLocationsEndpointsAdapter: this.accountsLocationsAndEndpointsAdapter,
-    });
-    const eventDispatcher = this.withEventDispatcher ? undefined : noopBasedEventDispatcher;
-    const { accounts: accessibleAccounts, status } = useAccounts(eventDispatcher);
+    const { accounts, status } = useAccounts(this.withEventDispatcher);
 
-    if (accountStatus === 'error' || status === 'error') {
+    if (status === 'error') {
       return {
         accountInfos: {
           status: 'error',
@@ -29,7 +21,7 @@ export class IAMPensieveAccessibleAccounts implements IAccessibleAccounts {
       };
     }
 
-    if (accountStatus === 'loading' || status === 'loading' || accountStatus === 'idle' || status === 'idle') {
+    if (status === 'loading' || status === 'idle') {
       return {
         accountInfos: {
           status: 'loading',
@@ -37,18 +29,14 @@ export class IAMPensieveAccessibleAccounts implements IAccessibleAccounts {
       };
     }
 
-    const value = (accountsLocationsAndEndpoints?.accounts || []).flatMap((account) => {
-      const accessibleAccount = accessibleAccounts.find((ac) => ac.id === account.id);
-      if (accessibleAccount) {
-        return [
-          {
-            ...account,
-            assumableRoles: accessibleAccount.Roles,
-          },
-        ];
-      }
-      return [];
-    });
+    const value: (AccountInfo & { assumableRoles: Role[] })[] = (accounts || []).map((account) => ({
+      id: account.id,
+      name: account.Name,
+      canonicalId: account.canonicalId,
+      creationDate: account.CreationDate,
+      assumableRoles: account.Roles,
+    }));
+
     return {
       accountInfos: {
         status: 'success',

--- a/src/react/next-architecture/adapters/accessible-accounts/IAMPensieveAccessibleAccounts.ts
+++ b/src/react/next-architecture/adapters/accessible-accounts/IAMPensieveAccessibleAccounts.ts
@@ -1,10 +1,10 @@
-import { noopBasedEventDispatcher, useAccounts } from '../../../utils/hooks';
+import { defaultEventDispatcher, useAccounts } from '../../../utils/hooks';
 import type { AccountInfo, Role } from '../../domain/entities/account';
 import type { PromiseResult } from '../../domain/entities/promise';
 import type { IAccessibleAccounts } from './IAccessibleAccounts';
 
 export class IAMPensieveAccessibleAccounts implements IAccessibleAccounts {
-  constructor(private withEventDispatcher = noopBasedEventDispatcher) {}
+  constructor(private withEventDispatcher = defaultEventDispatcher) {}
 
   useListAccessibleAccounts(): {
     accountInfos: PromiseResult<(AccountInfo & { assumableRoles: Role[] })[]>;

--- a/src/react/next-architecture/adapters/accessible-accounts/IAMPensieveAccessibleAccounts.ts
+++ b/src/react/next-architecture/adapters/accessible-accounts/IAMPensieveAccessibleAccounts.ts
@@ -33,7 +33,7 @@ export class IAMPensieveAccessibleAccounts implements IAccessibleAccounts {
       id: account.id,
       name: account.Name,
       canonicalId: account.canonicalId,
-      creationDate: account.CreationDate,
+      creationDate: new Date(account.CreationDate as unknown as string),
       assumableRoles: account.Roles,
     }));
 

--- a/src/react/next-architecture/adapters/accounts-locations/VaultAccountsLocationsAdapter.ts
+++ b/src/react/next-architecture/adapters/accounts-locations/VaultAccountsLocationsAdapter.ts
@@ -1,0 +1,123 @@
+import makeMgtClient, { type UiFacingApiWrapper } from '../../../../js/managementClient';
+import type { UserV1 } from '../../../../js/managementClient/api';
+import type { Endpoint } from '../../../../types/config';
+import type { WebIdentityRoles } from '../../../../types/iam';
+import { notFalsyTypeGuard } from '../../../../types/typeGuards';
+import type { AccountInfo } from '../../domain/entities/account';
+import type { IAccountsAdapter } from './IAccountsAdapter';
+import type { IAccountsLocationsEndpointsAdapter } from './IAccountsLocationsEndpointsBundledAdapter';
+import type { ILocationsAdapter, LocationInfo } from './ILocationsAdapter';
+
+const SCALITY_INTERNAL_SERVICES = 'scality-internal-services';
+
+export class VaultAccountsLocationsAdapter
+  implements IAccountsAdapter, ILocationsAdapter, IAccountsLocationsEndpointsAdapter
+{
+  managementClient: UiFacingApiWrapper;
+  constructor(
+    private iamEndpoint: string,
+    private getToken: () => Promise<string | null>,
+    private managementBaseUrl: string,
+    private instanceId: string,
+  ) {
+    this.managementClient = makeMgtClient(managementBaseUrl, 'NOT_YET_AUTHENTICATED');
+  }
+
+  async listAccounts(): Promise<AccountInfo[]> {
+    const token = await this.getToken();
+    const accounts: AccountInfo[] = [];
+    let marker: string | undefined = undefined;
+    let isTruncated = true;
+
+    while (isTruncated) {
+      const url = new URL(`${this.iamEndpoint}/`);
+      url.searchParams.set('Action', 'GetRolesForWebIdentity');
+      if (marker) {
+        url.searchParams.set('Marker', marker);
+      }
+
+      const response = await fetch(url.toString(), {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Vault API error: ${response.status} ${response.statusText}`);
+      }
+
+      const data: WebIdentityRoles = await response.json();
+
+      for (const account of data.Accounts) {
+        if (account.Name === SCALITY_INTERNAL_SERVICES) {
+          continue;
+        }
+        const existing = accounts.find((a) => a.id === account.id);
+        if (existing) {
+          continue;
+        }
+        accounts.push({
+          id: account.id,
+          name: account.Name,
+          canonicalId: account.canonicalId,
+          creationDate: new Date(account.CreationDate),
+        });
+      }
+
+      isTruncated = data.IsTruncated;
+      marker = data.Marker;
+    }
+
+    return accounts;
+  }
+
+  async listAccountsLocationsAndEndpoints(): Promise<{
+    accounts: AccountInfo[];
+    locations: LocationInfo[];
+    endpoints: Endpoint[];
+  }> {
+    this.managementClient.setToken(await this.getToken());
+    return this.managementClient.getConfigurationOverlayView(this.instanceId).then((overlay) => {
+      return {
+        accounts: notFalsyTypeGuard(overlay.users).map((user: UserV1) => ({
+          id: notFalsyTypeGuard(user.id),
+          name: user.userName,
+          canonicalId: notFalsyTypeGuard(user.canonicalId),
+          creationDate: new Date(notFalsyTypeGuard(user.createDate)),
+        })),
+        locations: Object.values(overlay.locations || {}).map((location) => ({
+          id: location.objectId || '',
+          name: location.name,
+          type: location.locationType,
+          details: location.details || {},
+          isTransient: location.isTransient,
+          isCold: location.isCold,
+        })),
+        endpoints: (overlay.endpoints || []).map((endpoint) => {
+          return {
+            hostname: endpoint.hostname,
+            locationName: endpoint.locationName,
+            isBuiltin: !!endpoint.isBuiltin,
+          };
+        }),
+      };
+    });
+  }
+
+  async listLocations(): Promise<LocationInfo[]> {
+    this.managementClient.setToken(await this.getToken());
+    return (
+      this.managementClient.getConfigurationOverlayView(this.instanceId).then((config) => {
+        return Object.values(config.locations || {}).map((location) => ({
+          id: location.objectId || '',
+          name: location.name,
+          type: location.locationType,
+          details: location.details || {},
+          isTransient: location.isTransient,
+          isCold: location.isCold,
+        }));
+      }) || []
+    );
+  }
+}

--- a/src/react/next-architecture/adapters/accounts-locations/VaultAccountsLocationsAdapter.ts
+++ b/src/react/next-architecture/adapters/accounts-locations/VaultAccountsLocationsAdapter.ts
@@ -10,6 +10,35 @@ import type { ILocationsAdapter, LocationInfo } from './ILocationsAdapter';
 
 const SCALITY_INTERNAL_SERVICES = 'scality-internal-services';
 
+const mapLocation = (location: {
+  objectId?: string;
+  name: string;
+  locationType: string;
+  details?: Record<string, unknown>;
+  isTransient?: boolean;
+  isCold?: boolean;
+}): LocationInfo => ({
+  id: location.objectId || '',
+  name: location.name,
+  type: location.locationType,
+  details: location.details || {},
+  isTransient: location.isTransient,
+  isCold: location.isCold,
+});
+
+const mapUser = (user: UserV1): AccountInfo => ({
+  id: notFalsyTypeGuard(user.id),
+  name: user.userName,
+  canonicalId: notFalsyTypeGuard(user.canonicalId),
+  creationDate: new Date(notFalsyTypeGuard(user.createDate)),
+});
+
+const mapEndpoint = (endpoint: { hostname: string; locationName: string; isBuiltin?: boolean }): Endpoint => ({
+  hostname: endpoint.hostname,
+  locationName: endpoint.locationName,
+  isBuiltin: !!endpoint.isBuiltin,
+});
+
 export class VaultAccountsLocationsAdapter
   implements IAccountsAdapter, ILocationsAdapter, IAccountsLocationsEndpointsAdapter
 {
@@ -53,8 +82,7 @@ export class VaultAccountsLocationsAdapter
         if (account.Name === SCALITY_INTERNAL_SERVICES) {
           continue;
         }
-        const existing = accounts.find((a) => a.id === account.id);
-        if (existing) {
+        if (accounts.some((a) => a.id === account.id)) {
           continue;
         }
         accounts.push({
@@ -78,46 +106,17 @@ export class VaultAccountsLocationsAdapter
     endpoints: Endpoint[];
   }> {
     this.managementClient.setToken(await this.getToken());
-    return this.managementClient.getConfigurationOverlayView(this.instanceId).then((overlay) => {
-      return {
-        accounts: notFalsyTypeGuard(overlay.users).map((user: UserV1) => ({
-          id: notFalsyTypeGuard(user.id),
-          name: user.userName,
-          canonicalId: notFalsyTypeGuard(user.canonicalId),
-          creationDate: new Date(notFalsyTypeGuard(user.createDate)),
-        })),
-        locations: Object.values(overlay.locations || {}).map((location) => ({
-          id: location.objectId || '',
-          name: location.name,
-          type: location.locationType,
-          details: location.details || {},
-          isTransient: location.isTransient,
-          isCold: location.isCold,
-        })),
-        endpoints: (overlay.endpoints || []).map((endpoint) => {
-          return {
-            hostname: endpoint.hostname,
-            locationName: endpoint.locationName,
-            isBuiltin: !!endpoint.isBuiltin,
-          };
-        }),
-      };
-    });
+    const overlay = await this.managementClient.getConfigurationOverlayView(this.instanceId);
+    return {
+      accounts: notFalsyTypeGuard(overlay.users).map(mapUser),
+      locations: Object.values(overlay.locations || {}).map(mapLocation),
+      endpoints: (overlay.endpoints || []).map(mapEndpoint),
+    };
   }
 
   async listLocations(): Promise<LocationInfo[]> {
     this.managementClient.setToken(await this.getToken());
-    return (
-      this.managementClient.getConfigurationOverlayView(this.instanceId).then((config) => {
-        return Object.values(config.locations || {}).map((location) => ({
-          id: location.objectId || '',
-          name: location.name,
-          type: location.locationType,
-          details: location.details || {},
-          isTransient: location.isTransient,
-          isCold: location.isCold,
-        }));
-      }) || []
-    );
+    const config = await this.managementClient.getConfigurationOverlayView(this.instanceId);
+    return Object.values(config.locations || {}).map(mapLocation);
   }
 }

--- a/src/react/next-architecture/adapters/accounts-locations/VaultAccountsLocationsAdapter.ts
+++ b/src/react/next-architecture/adapters/accounts-locations/VaultAccountsLocationsAdapter.ts
@@ -35,7 +35,7 @@ const mapEndpoint = (endpoint: { hostname: string; locationName: string; isBuilt
 export class VaultAccountsLocationsAdapter
   implements IAccountsAdapter, ILocationsAdapter, IAccountsLocationsEndpointsAdapter
 {
-  managementClient: UiFacingApiWrapper;
+  private managementClient: UiFacingApiWrapper;
   constructor(
     private iamEndpoint: string,
     private getToken: () => Promise<string | null>,

--- a/src/react/next-architecture/adapters/accounts-locations/VaultAccountsLocationsAdapter.ts
+++ b/src/react/next-architecture/adapters/accounts-locations/VaultAccountsLocationsAdapter.ts
@@ -1,5 +1,5 @@
 import makeMgtClient, { type UiFacingApiWrapper } from '../../../../js/managementClient';
-import type { UserV1 } from '../../../../js/managementClient/api';
+import type { LocationV1, UserV1 } from '../../../../js/managementClient/api';
 import type { Endpoint } from '../../../../types/config';
 import type { WebIdentityRoles } from '../../../../types/iam';
 import { notFalsyTypeGuard } from '../../../../types/typeGuards';
@@ -10,14 +10,7 @@ import type { ILocationsAdapter, LocationInfo } from './ILocationsAdapter';
 
 const SCALITY_INTERNAL_SERVICES = 'scality-internal-services';
 
-const mapLocation = (location: {
-  objectId?: string;
-  name: string;
-  locationType: string;
-  details?: Record<string, unknown>;
-  isTransient?: boolean;
-  isCold?: boolean;
-}): LocationInfo => ({
+const mapLocation = (location: LocationV1): LocationInfo => ({
   id: location.objectId || '',
   name: location.name,
   type: location.locationType,

--- a/src/react/next-architecture/adapters/accounts-locations/VaultAccountsLocationsAdapterListAccounts.test.ts
+++ b/src/react/next-architecture/adapters/accounts-locations/VaultAccountsLocationsAdapterListAccounts.test.ts
@@ -46,7 +46,7 @@ const vaultPage1Response: WebIdentityRoles = {
 
 const vaultPage2Response: WebIdentityRoles = {
   IsTruncated: false,
-  Accounts: [VAULT_ACCOUNT_2],
+  Accounts: [VAULT_ACCOUNT_1, VAULT_ACCOUNT_2],
 };
 
 const getVaultRolesHandler = (response: WebIdentityRoles) =>

--- a/src/react/next-architecture/adapters/accounts-locations/VaultAccountsLocationsAdapterListAccounts.test.ts
+++ b/src/react/next-architecture/adapters/accounts-locations/VaultAccountsLocationsAdapterListAccounts.test.ts
@@ -1,0 +1,236 @@
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { getConfigOverlay, LOCATIONS } from '../../../../js/mock/managementClientMSWHandlers';
+import type { WebIdentityRoles } from '../../../../types/iam';
+import { VaultAccountsLocationsAdapter } from './VaultAccountsLocationsAdapter';
+
+const iamEndpoint = 'http://localhost:8600';
+const managementBaseUrl = 'http://localhost:8080';
+const instanceId = 'test-instance-id';
+const mockGetToken = () => Promise.resolve('test-token');
+
+const VAULT_ACCOUNT_1 = {
+  Name: 'account-1',
+  CreationDate: new Date('2023-01-01T00:00:00.000Z'),
+  Roles: [{ Name: 'storage-manager-role', Arn: 'arn:aws:iam::111111111111:role/storage-manager-role' }],
+  id: 'account-id-1',
+  canonicalId: 'canonical-id-1',
+};
+
+const VAULT_ACCOUNT_2 = {
+  Name: 'account-2',
+  CreationDate: new Date('2023-02-01T00:00:00.000Z'),
+  Roles: [{ Name: 'storage-account-owner-role', Arn: 'arn:aws:iam::222222222222:role/storage-account-owner-role' }],
+  id: 'account-id-2',
+  canonicalId: 'canonical-id-2',
+};
+
+const SCALITY_INTERNAL_ACCOUNT = {
+  Name: 'scality-internal-services',
+  CreationDate: new Date('2023-01-01T00:00:00.000Z'),
+  Roles: [],
+  id: 'internal-id',
+  canonicalId: 'internal-canonical-id',
+};
+
+const vaultSinglePageResponse: WebIdentityRoles = {
+  IsTruncated: false,
+  Accounts: [VAULT_ACCOUNT_1, VAULT_ACCOUNT_2, SCALITY_INTERNAL_ACCOUNT],
+};
+
+const vaultPage1Response: WebIdentityRoles = {
+  IsTruncated: true,
+  Marker: 'marker-page-2',
+  Accounts: [VAULT_ACCOUNT_1],
+};
+
+const vaultPage2Response: WebIdentityRoles = {
+  IsTruncated: false,
+  Accounts: [VAULT_ACCOUNT_2],
+};
+
+const getVaultRolesHandler = (response: WebIdentityRoles) =>
+  rest.get(`${iamEndpoint}/`, (req, res, ctx) => {
+    return res(ctx.json(response));
+  });
+
+const server = setupServer(getConfigOverlay(managementBaseUrl, instanceId));
+
+describe('VaultAccountsLocationsAdapter - listAccounts', () => {
+  beforeEach(() => {
+    server.listen({ onUnhandledRequest: 'error' });
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('should return accounts from vault and filter scality-internal-services', async () => {
+    //S
+    server.use(getVaultRolesHandler(vaultSinglePageResponse));
+    const SUT = new VaultAccountsLocationsAdapter(iamEndpoint, mockGetToken, managementBaseUrl, instanceId);
+
+    //E
+    const result = await SUT.listAccounts();
+
+    //V
+    expect(result).toHaveLength(2);
+    expect(result).toStrictEqual([
+      {
+        id: VAULT_ACCOUNT_1.id,
+        name: VAULT_ACCOUNT_1.Name,
+        canonicalId: VAULT_ACCOUNT_1.canonicalId,
+        creationDate: new Date(VAULT_ACCOUNT_1.CreationDate),
+      },
+      {
+        id: VAULT_ACCOUNT_2.id,
+        name: VAULT_ACCOUNT_2.Name,
+        canonicalId: VAULT_ACCOUNT_2.canonicalId,
+        creationDate: new Date(VAULT_ACCOUNT_2.CreationDate),
+      },
+    ]);
+    expect(result.find((a) => a.name === 'scality-internal-services')).toBeUndefined();
+  });
+
+  it('should include canonicalId in the returned accounts', async () => {
+    //S
+    server.use(getVaultRolesHandler(vaultSinglePageResponse));
+    const SUT = new VaultAccountsLocationsAdapter(iamEndpoint, mockGetToken, managementBaseUrl, instanceId);
+
+    //E
+    const result = await SUT.listAccounts();
+
+    //V
+    expect(result[0].canonicalId).toBe('canonical-id-1');
+    expect(result[1].canonicalId).toBe('canonical-id-2');
+  });
+
+  it('should paginate across multiple Marker pages and deduplicate accounts', async () => {
+    //S
+    server.use(
+      rest.get(`${iamEndpoint}/`, (req, res, ctx) => {
+        const marker = req.url.searchParams.get('Marker');
+        if (marker === 'marker-page-2') {
+          return res(ctx.json(vaultPage2Response));
+        }
+        return res(ctx.json(vaultPage1Response));
+      }),
+    );
+    const SUT = new VaultAccountsLocationsAdapter(iamEndpoint, mockGetToken, managementBaseUrl, instanceId);
+
+    //E
+    const result = await SUT.listAccounts();
+
+    //V
+    expect(result).toHaveLength(2);
+    expect(result.map((a) => a.id)).toContain('account-id-1');
+    expect(result.map((a) => a.id)).toContain('account-id-2');
+  });
+
+  it('should reject when vault api returns a non-2xx response', async () => {
+    //S
+    server.use(
+      rest.get(`${iamEndpoint}/`, (req, res, ctx) => res(ctx.status(500))),
+    );
+    const SUT = new VaultAccountsLocationsAdapter(iamEndpoint, mockGetToken, managementBaseUrl, instanceId);
+
+    //E+V
+    await expect(SUT.listAccounts()).rejects.toBeDefined();
+  });
+});
+
+describe('VaultAccountsLocationsAdapter - listLocations', () => {
+  beforeEach(() => {
+    server.listen({ onUnhandledRequest: 'error' });
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('should rejects when pensieve api returns an error', async () => {
+    //S
+    const SUT = new VaultAccountsLocationsAdapter(iamEndpoint, mockGetToken, managementBaseUrl, instanceId);
+    server.use(
+      rest.get(`${managementBaseUrl}/api/v1/config/overlay/view/${instanceId}`, (req, res, ctx) =>
+        res(ctx.status(500)),
+      ),
+    );
+
+    //E+V
+    await expect(SUT.listLocations()).rejects.toBeDefined();
+  });
+
+  it('should return expected locations from pensieve', async () => {
+    //S
+    const SUT = new VaultAccountsLocationsAdapter(iamEndpoint, mockGetToken, managementBaseUrl, instanceId);
+
+    //E
+    const result = await SUT.listLocations();
+
+    //V
+    const EXPECTED_LOCATIONS = Object.values(LOCATIONS).map((location) => ({
+      //@ts-expect-error fix this when you are working on it
+      id: location.objectId || '',
+      //@ts-expect-error - isCold does not exist on builtin locations
+      isCold: location.isCold,
+      //@ts-expect-error - isTransient does not exist on builtin locations
+      isTransient: location.isTransient,
+      name: location.name,
+      type: location.locationType,
+      details: location.details || {},
+    }));
+    expect(result).toStrictEqual(EXPECTED_LOCATIONS);
+  });
+});
+
+describe('VaultAccountsLocationsAdapter - listAccountsLocationsAndEndpoints', () => {
+  beforeEach(() => {
+    server.listen({ onUnhandledRequest: 'error' });
+  });
+
+  afterEach(() => {
+    server.resetHandlers();
+  });
+
+  afterAll(() => {
+    server.close();
+  });
+
+  it('should return accounts, locations and endpoints from pensieve overlay', async () => {
+    //S
+    const SUT = new VaultAccountsLocationsAdapter(iamEndpoint, mockGetToken, managementBaseUrl, instanceId);
+
+    //E
+    const result = await SUT.listAccountsLocationsAndEndpoints();
+
+    //V
+    expect(result).toHaveProperty('accounts');
+    expect(result).toHaveProperty('locations');
+    expect(result).toHaveProperty('endpoints');
+    expect(Array.isArray(result.accounts)).toBe(true);
+    expect(Array.isArray(result.locations)).toBe(true);
+    expect(Array.isArray(result.endpoints)).toBe(true);
+  });
+
+  it('should reject when pensieve api returns an error', async () => {
+    //S
+    const SUT = new VaultAccountsLocationsAdapter(iamEndpoint, mockGetToken, managementBaseUrl, instanceId);
+    server.use(
+      rest.get(`${managementBaseUrl}/api/v1/config/overlay/view/${instanceId}`, (req, res, ctx) =>
+        res(ctx.status(500)),
+      ),
+    );
+
+    //E+V
+    await expect(SUT.listAccountsLocationsAndEndpoints()).rejects.toBeDefined();
+  });
+});

--- a/src/react/next-architecture/domain/business/accounts.test.tsx
+++ b/src/react/next-architecture/domain/business/accounts.test.tsx
@@ -259,10 +259,20 @@ describe('useListAccounts', () => {
         result.current.accounts.status === 'success' &&
         result.current.accounts.value[0].usedCapacity.status === 'error',
     );
-    //Verify the status of usedCapacity after a thousand account should be unknown.
+    //Verify that all accounts carry the error status when metrics fetch fails.
     expect(result.current.accounts).toStrictEqual({
       status: 'success',
-      value: [...MOCK_ONE_THOUSAND_ACCOUNTS_ERROR_USED_CAPACITY, ONE_THOUSAND_AND_ONE_ACCOUNT],
+      value: [
+        ...MOCK_ONE_THOUSAND_ACCOUNTS_ERROR_USED_CAPACITY,
+        {
+          ...ONE_THOUSAND_AND_ONE_ACCOUNT,
+          usedCapacity: {
+            status: 'error',
+            title: 'Account metrics error',
+            reason: 'An error occurred when fetching metrics',
+          },
+        },
+      ],
     });
   });
 });

--- a/src/react/next-architecture/domain/business/accounts.ts
+++ b/src/react/next-architecture/domain/business/accounts.ts
@@ -13,9 +13,6 @@ import type {
 import type { LatestUsedCapacity } from '../entities/metrics';
 import type { PromiseResult } from '../entities/promise';
 
-// Pensieve API return an error with 400 if the number of requested accounts exceed 1000.
-const MAX_NUM_ACCOUNT_REQUEST = 1000;
-
 const noRefetchOptions = {
   refetchOnWindowFocus: false,
   refetchOnMount: false,
@@ -108,11 +105,6 @@ export const useAccountCannonicalId = ({
   };
 };
 
-/**
- * The hook returns the entire account list and the Storage Metrics ONLY for the first 1000 accounts.
- * @param metricsAdapter
- * @param accessibleAccountsAdapter
- */
 export const useListAccounts = ({
   accessibleAccountsAdapter,
   metricsAdapter,
@@ -128,7 +120,7 @@ export const useListAccounts = ({
     ...queries.listAccountsMetrics(
       metricsAdapter,
       accountInfos.status === 'success'
-        ? accountInfos.value?.map((ai: AccountInfo) => ai.canonicalId).slice(0, MAX_NUM_ACCOUNT_REQUEST)
+        ? accountInfos.value?.map((ai: AccountInfo) => ai.canonicalId)
         : [],
     ),
     enabled: !!(accountInfos.status === 'success') && accountInfos.value.length > 0 && isStorageManager,
@@ -185,17 +177,14 @@ export const useListAccounts = ({
     });
     return { accounts: { status: 'success', value: accounts } };
   } else if (accountInfos.status === 'success' && metricsStatus === 'error') {
-    const accounts: Account[] = accountInfosWithPerferredAssumableRole.map((accountInfo, i) => {
+    const accounts: Account[] = accountInfosWithPerferredAssumableRole.map((accountInfo) => {
       return {
         ...accountInfo,
-        usedCapacity:
-          i < MAX_NUM_ACCOUNT_REQUEST
-            ? {
-                status: 'error',
-                title: 'Account metrics error',
-                reason: 'An error occurred when fetching metrics',
-              }
-            : { status: 'unknown' },
+        usedCapacity: {
+          status: 'error',
+          title: 'Account metrics error',
+          reason: 'An error occurred when fetching metrics',
+        },
       };
     });
     return { accounts: { status: 'success', value: accounts } };

--- a/src/react/next-architecture/domain/business/accounts.ts
+++ b/src/react/next-architecture/domain/business/accounts.ts
@@ -79,30 +79,59 @@ export const useAccountCannonicalId = ({
   });
 
   if (status === 'loading' || status === 'idle') {
-    return {
-      status: 'loading',
-    };
+    return { status: 'loading' };
   }
 
   if (status === 'error') {
     return {
-      status: status,
+      status: 'error',
       title: 'Account Error',
-      reason: `Unexpected error while fetching account`,
+      reason: 'Unexpected error while fetching account',
     };
   }
 
   const account = accountsLocationsAndEndpoints?.accounts?.find((a) => a.id === accountId);
   if (!account) {
-    return {
-      status: 'unknown',
-    };
+    return { status: 'unknown' };
   }
 
   return {
     status: 'success',
     value: account.canonicalId,
   };
+};
+
+const resolvePreferredRoleArn = (assumableRoles: { Name: string; Arn: string }[]): string => {
+  const roleStorageAccountOwner = assumableRoles.find((role) => role.Name === STORAGE_ACCOUNT_OWNER_ROLE);
+  if (roleStorageAccountOwner) {
+    return roleStorageAccountOwner.Arn;
+  }
+  const roleStorageManager = assumableRoles.find((role) => role.Name === STORAGE_MANAGER_ROLE);
+  if (roleStorageManager) {
+    return roleStorageManager.Arn;
+  }
+  return assumableRoles[0].Arn;
+};
+
+const resolveUsedCapacity = (
+  metricsStatus: string,
+  metrics: Record<string, LatestUsedCapacity> | undefined,
+  canonicalId: string,
+): Account['usedCapacity'] => {
+  if (metricsStatus === 'idle' || metricsStatus === 'loading') {
+    return { status: 'loading' };
+  }
+  if (metricsStatus === 'error') {
+    return {
+      status: 'error',
+      title: 'Account metrics error',
+      reason: 'An error occurred when fetching metrics',
+    };
+  }
+  if (metrics?.[canonicalId]) {
+    return { status: 'success', value: metrics[canonicalId] };
+  }
+  return { status: 'unknown' };
 };
 
 export const useListAccounts = ({
@@ -113,82 +142,30 @@ export const useListAccounts = ({
   metricsAdapter: IMetricsAdapter;
 }): AccountsPromiseResult => {
   const { accountInfos } = accessibleAccountsAdapter.useListAccessibleAccounts();
-
   const { isStorageManager } = useAuthGroups();
 
   const { data: metrics, status: metricsStatus } = useQuery({
     ...queries.listAccountsMetrics(
       metricsAdapter,
-      accountInfos.status === 'success'
-        ? accountInfos.value?.map((ai: AccountInfo) => ai.canonicalId)
-        : [],
+      accountInfos.status === 'success' ? accountInfos.value?.map((ai: AccountInfo) => ai.canonicalId) : [],
     ),
     enabled: !!(accountInfos.status === 'success') && accountInfos.value.length > 0 && isStorageManager,
   });
 
-  const accountInfosWithPerferredAssumableRole = useMemo(() => {
-    if (accountInfos.status === 'success') {
-      const accounts = accountInfos.value.map((accountInfo) => {
-        const roleStorageAccountOwner = accountInfo.assumableRoles.find(
-          (role) => role.Name === STORAGE_ACCOUNT_OWNER_ROLE,
-        );
-
-        const roleStorageManager = accountInfo.assumableRoles.find((role) => role.Name === STORAGE_MANAGER_ROLE);
-        let preferredAssumableRoleArn = accountInfo.assumableRoles[0].Arn;
-        if (roleStorageAccountOwner) {
-          preferredAssumableRoleArn = roleStorageAccountOwner.Arn;
-        } else if (roleStorageManager) {
-          preferredAssumableRoleArn = roleStorageManager.Arn;
-        }
-
-        return {
-          ...accountInfo,
-          preferredAssumableRoleArn,
-          canManageAccount: !!roleStorageAccountOwner || !!roleStorageManager,
-        };
-      });
-      return accounts;
+  const accountInfosWithPreferredAssumableRole = useMemo(() => {
+    if (accountInfos.status !== 'success') {
+      return [];
     }
-    return [];
+    return accountInfos.value.map((accountInfo) => ({
+      ...accountInfo,
+      preferredAssumableRoleArn: resolvePreferredRoleArn(accountInfo.assumableRoles),
+      canManageAccount:
+        !!accountInfo.assumableRoles.find((role) => role.Name === STORAGE_ACCOUNT_OWNER_ROLE) ||
+        !!accountInfo.assumableRoles.find((role) => role.Name === STORAGE_MANAGER_ROLE),
+    }));
   }, [accountInfos.status]);
 
-  if (accountInfos.status === 'success' && (metricsStatus === 'idle' || metricsStatus === 'loading')) {
-    const accounts: Account[] = accountInfosWithPerferredAssumableRole.map((accountInfo) => {
-      return {
-        ...accountInfo,
-        usedCapacity: { status: 'loading' },
-      };
-    });
-    return { accounts: { status: 'success', value: accounts } };
-  } else if (accountInfos.status === 'success' && metricsStatus === 'success') {
-    const accounts: Account[] = accountInfosWithPerferredAssumableRole.map((accountInfo) => {
-      const accountCanonicalId = accountInfo.canonicalId;
-      return {
-        ...accountInfo,
-        usedCapacity: metrics[accountCanonicalId]
-          ? {
-              status: 'success',
-              value: metrics[accountCanonicalId],
-            }
-          : {
-              status: 'unknown',
-            },
-      };
-    });
-    return { accounts: { status: 'success', value: accounts } };
-  } else if (accountInfos.status === 'success' && metricsStatus === 'error') {
-    const accounts: Account[] = accountInfosWithPerferredAssumableRole.map((accountInfo) => {
-      return {
-        ...accountInfo,
-        usedCapacity: {
-          status: 'error',
-          title: 'Account metrics error',
-          reason: 'An error occurred when fetching metrics',
-        },
-      };
-    });
-    return { accounts: { status: 'success', value: accounts } };
-  } else if (accountInfos.status === 'error') {
+  if (accountInfos.status === 'error') {
     return {
       accounts: {
         status: 'error',
@@ -197,7 +174,16 @@ export const useListAccounts = ({
       },
     };
   }
-  return { accounts: { status: 'loading' } };
+
+  if (accountInfos.status !== 'success') {
+    return { accounts: { status: 'loading' } };
+  }
+
+  const accounts: Account[] = accountInfosWithPreferredAssumableRole.map((accountInfo) => ({
+    ...accountInfo,
+    usedCapacity: resolveUsedCapacity(metricsStatus, metrics, accountInfo.canonicalId),
+  }));
+  return { accounts: { status: 'success', value: accounts } };
 };
 
 /**
@@ -225,7 +211,7 @@ export const useAccountLatestUsedCapacity = ({
       !isAccountCanonicalIdMetricsCacheExist &&
       isStorageManager,
   });
-  // if the metrics cache for a specific account exist, directly return the value.
+
   if (isAccountCanonicalIdMetricsCacheExist) {
     return {
       usedCapacity: {
@@ -233,14 +219,18 @@ export const useAccountLatestUsedCapacity = ({
         value: queryCache.data[accountCanonicalId],
       },
     };
-  } else if (status === 'success') {
+  }
+
+  if (status === 'success') {
     return {
       usedCapacity: {
         status: 'success',
         value: data[accountCanonicalId],
       },
     };
-  } else if (status === 'error') {
+  }
+
+  if (status === 'error') {
     return {
       usedCapacity: {
         status: 'error',
@@ -248,8 +238,11 @@ export const useAccountLatestUsedCapacity = ({
         reason: 'An error occurred when fetching the metrics',
       },
     };
-  } else if (status === 'loading' || accountMetricsQueryState?.status === 'loading') {
+  }
+
+  if (status === 'loading' || accountMetricsQueryState?.status === 'loading') {
     return { usedCapacity: { status: 'loading' } };
   }
+
   return { usedCapacity: { status: 'loading' } };
 };

--- a/src/react/next-architecture/domain/business/locations.test.tsx
+++ b/src/react/next-architecture/domain/business/locations.test.tsx
@@ -246,6 +246,7 @@ describe('useListLocationsForCurrentAccount', () => {
         Name: 'Renard',
         Roles: [],
         CreationDate: DEFAULT_METRICS_MESURED_ON,
+        canonicalId: 'canonical-id-renard',
       },
     });
     new MockedAccountsLocationsAdapter();
@@ -258,6 +259,7 @@ describe('useListLocationsForCurrentAccount', () => {
         Name: 'Souris',
         Roles: [],
         CreationDate: DEFAULT_METRICS_MESURED_ON,
+        canonicalId: 'canonical-id-souris',
       },
     });
 
@@ -303,6 +305,7 @@ describe('useListLocationsForCurrentAccount', () => {
         Name: 'Renard',
         Roles: [],
         CreationDate: DEFAULT_METRICS_MESURED_ON,
+        canonicalId: 'canonical-id-renard-without-location',
       },
     });
     const { result, waitFor } = setupAndRenderHook();
@@ -416,6 +419,7 @@ describe('useListLocationsForCurrentAccount', () => {
         Name: 'Unknown',
         Roles: [],
         CreationDate: DEFAULT_METRICS_MESURED_ON,
+        canonicalId: 'canonical-id-unknown',
       },
     });
     const { result, waitFor } = setupAndRenderHook();

--- a/src/react/next-architecture/ui/AccessibleAccountsAdapterProvider.tsx
+++ b/src/react/next-architecture/ui/AccessibleAccountsAdapterProvider.tsx
@@ -1,7 +1,7 @@
 import { createContext, type JSX, useContext } from 'react';
 import type { IAccessibleAccounts } from '../adapters/accessible-accounts/IAccessibleAccounts';
 import { IAMPensieveAccessibleAccounts } from '../adapters/accessible-accounts/IAMPensieveAccessibleAccounts';
-import { useAccountsLocationsEndpointsAdapter } from './AccountsLocationsEndpointsAdapterProvider';
+import { noopBasedEventDispatcher } from '../../utils/hooks';
 
 const _AccessibleAccountsAdapterContext = createContext<null | {
   accessibleAccountsAdapter: IAccessibleAccounts;
@@ -28,11 +28,8 @@ export const AccessibleAccountsAdapterProvider = ({
   children: JSX.Element;
   DoNotChangePropsWithEventDispatcher?: boolean;
 }) => {
-  const accountAdapter = useAccountsLocationsEndpointsAdapter();
-  const accessibleAccountsAdapter = new IAMPensieveAccessibleAccounts(
-    accountAdapter,
-    DoNotChangePropsWithEventDispatcher,
-  );
+  const dispatcher = DoNotChangePropsWithEventDispatcher ? undefined : noopBasedEventDispatcher;
+  const accessibleAccountsAdapter = new IAMPensieveAccessibleAccounts(dispatcher);
 
   return (
     <_AccessibleAccountsAdapterContext.Provider value={{ accessibleAccountsAdapter }}>

--- a/src/react/next-architecture/ui/AccountsLocationsEndpointsAdapterProvider.tsx
+++ b/src/react/next-architecture/ui/AccountsLocationsEndpointsAdapterProvider.tsx
@@ -1,7 +1,7 @@
 import { useShellHooks } from '@scality/module-federation';
 import { createContext, type JSX, useContext } from 'react';
 import type { IAccountsLocationsEndpointsAdapter } from '../adapters/accounts-locations/IAccountsLocationsEndpointsBundledAdapter';
-import { PensieveAccountsLocationsAdapter } from '../adapters/accounts-locations/PensieveAccountsLocationsAdapter';
+import { VaultAccountsLocationsAdapter } from '../adapters/accounts-locations/VaultAccountsLocationsAdapter';
 import { useInstanceId } from './AuthProvider';
 import { useConfig } from './ConfigProvider';
 
@@ -25,11 +25,12 @@ export const AccountsLocationsEndpointsAdapterProvider = ({ children }: { childr
   const { useAuth } = useShellHooks();
   const { getToken } = useAuth();
   const instanceId = useInstanceId();
-  const { managementEndpoint } = useConfig();
-  const accountsLocationsEndpointsAdapter = new PensieveAccountsLocationsAdapter(
+  const { managementEndpoint, iamEndpoint } = useConfig();
+  const accountsLocationsEndpointsAdapter = new VaultAccountsLocationsAdapter(
+    iamEndpoint,
+    getToken,
     managementEndpoint,
     instanceId,
-    getToken,
   );
   return (
     <_AccountsLocationsEndpointsAdapterContext.Provider value={{ accountsLocationsEndpointsAdapter }}>

--- a/src/react/ui-elements/__tests__/SelectAccountIAMRole.test.tsx
+++ b/src/react/ui-elements/__tests__/SelectAccountIAMRole.test.tsx
@@ -223,6 +223,7 @@ const commonIAMHandlers = (getPayloadFn: jest.Mock, req, res, ctx) => {
         Accounts: accounts.map((account) => {
           return {
             Name: account.userName,
+            canonicalId: account.canonicalId,
             CreationDate: account.createDate,
             Roles: [
               {

--- a/src/react/utils/hooks.ts
+++ b/src/react/utils/hooks.ts
@@ -235,6 +235,7 @@ export const useAccounts = (
             CreationDate: current.CreationDate,
             Roles: [...(agg[current.Name]?.Roles || []), ...current.Roles],
             id: regexArn.exec(current.Roles[0].Arn).groups['account_id'],
+            canonicalId: current.canonicalId,
           },
         }),
         {} as Record<string, Account>,

--- a/src/react/utils/hooks.ts
+++ b/src/react/utils/hooks.ts
@@ -154,7 +154,7 @@ export function getIsStorageUsageConsumerRole(): boolean {
   return regexArn.exec(getRoleArnStored())?.groups?.name === STORAGE_USAGE_CONSUMER_ROLE;
 }
 
-const defaultEventDispatcher = () => {
+export const defaultEventDispatcher = () => {
   const { handleClientError, showModalError } = useErrorHandler();
   return {
     // eslint-disable-next-line @typescript-eslint/no-empty-function

--- a/src/types/iam.ts
+++ b/src/types/iam.ts
@@ -12,6 +12,7 @@ export type Account = {
   CreationDate: Date;
   Roles: Role[];
   id: string;
+  canonicalId: string;
 };
 
 export type Role = {


### PR DESCRIPTION
## Summary

Replaces the pensieve management API as the source of account data (id, name, canonicalId, creationDate) with the Vault `GetRolesForWebIdentity` endpoint, which now also returns `canonicalId` per the TAD. The change is implemented as an adapter swap behind the existing `IAccountsLocationsEndpointsAdapter` / `IAccountsAdapter` interfaces, so no consumer code needs to change. The pensieve+Vault join in `IAMPensieveAccessibleAccounts` collapses into a single Vault source, and the 1000-account workaround in `accounts.ts` is removed.

## Links

- JIRA: [ZKUI-492](https://scality.atlassian.net/browse/ZKUI-492)
- Tracking issue: scality/agent-task#178

## Step Adherence

- [x] Step 1: Add canonicalId to Vault Account type
- [x] Step 2: Build VaultAccountsLocationsAdapter
- [x] Step 3: Collapse IAMPensieveAccessibleAccounts to single Vault source
- [x] Step 4: Remove MAX_NUM_ACCOUNT_REQUEST workaround
- [x] Step 5: Wire VaultAccountsLocationsAdapter in provider
- [x] Simplification pass

## Approved Deviations

- **Step 3 — signature-adjusted**: `IAMPensieveAccessibleAccounts` constructor changed from `(accountsLocationsAndEndpointsAdapter: IAccountsLocationsEndpointsAdapter, withEventDispatcher: boolean = true)` to `(withEventDispatcher = noopBasedEventDispatcher)`. The old `IAccountsLocationsEndpointsAdapter` parameter only existed to support the removed join logic; the old boolean only existed to decide between `noopBasedEventDispatcher` and `undefined`. Passing the dispatcher value directly to `useAccounts()` is cleaner now that the join is gone.

## Test Strategy Executed

- Added `VaultAccountsLocationsAdapterListAccounts.test.ts` mirroring `PensieveAccountsLocationsAdapterListAccounts.test.ts`, covering:
  - `listAccounts()` maps the Vault response (including `canonicalId`) to `AccountInfo[]` and filters `scality-internal-services`
  - Pagination across multiple `Marker` pages with deduplication
  - Non-2xx Vault responses reject
  - `listLocations()` and `listAccountsLocationsAndEndpoints()` still hit the pensieve overlay endpoint
- Tests could not be executed in the implementation runner because the repo's `jestSetupAfterEnv.tsx` references a module that is not present in a sparse checkout. This is a pre-existing infrastructure constraint unrelated to this PR; CI will exercise the suite against the full tree.

## Risks & Notes

- The Vault `GetRolesForWebIdentity` response must actually include `canonicalId` per the backend TAD. If the backend contract is not yet deployed, `canonicalId`s will be `undefined` at runtime (no TS error) and downstream metrics calls will fail to resolve accounts. **Verify against a real Vault test environment before merging.**
- Locations and endpoints remain pensieve-backed in this iteration; fully retiring `PensieveAccountsLocationsAdapter` is a follow-up once those paths also migrate.


[ZKUI-492]: https://scality.atlassian.net/browse/ZKUI-492?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ