### PR TITLE
ZKUI-499: Bump data-browser-library to 1.1.21

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@scality/certchain": "1.4.0",
         "@scality/core-ui": "0.218.0",
-        "@scality/data-browser-library": "1.1.20",
+        "@scality/data-browser-library": "1.1.21",
         "@scality/module-federation": "1.6.1",
         "@scality/react-chained-query": "^2.1.0",
         "@types/react-table": "^7.7.10",
@@ -5691,9 +5691,9 @@
       }
     },
     "node_modules/@scality/data-browser-library": {
-      "version": "1.1.20",
-      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.20.tgz",
-      "integrity": "sha512-vjSEC4J5WS5LN7ErQnfmVTZOUPc1ALcYguLVH1fBAs8zl50UPpMgN9fis0LwDTF2HGaZ1s4InInvETtv3BbGqw==",
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.21.tgz",
+      "integrity": "sha512-en3kYM6XIUfDmfgoFPi/s7m5sBio7vBD5Fz/lDr5lzzdcJXJUEBXIQiDxGxvR5tn1jYNblTEXgbyCPekHYxFRg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.983.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@scality/certchain": "1.4.0",
     "@scality/core-ui": "0.218.0",
-    "@scality/data-browser-library": "1.1.20",
+    "@scality/data-browser-library": "1.1.21",
     "@scality/module-federation": "1.6.1",
     "@scality/react-chained-query": "^2.1.0",
     "@types/react-table": "^7.7.10",


### PR DESCRIPTION
## Summary
Automated bump of `@scality/data-browser-library`.

## Links
- Release: https://github.com/scality/data-browser/releases/tag/1.1.21
- Jira: https://scality.atlassian.net/browse/ZKUI-499

🤖 Generated by data-browser auto-bump