### PR TITLE
chore(deps): bump @scality/data-browser-library to 1.1.22

### DIFF
--- a/__mocks__/@scality/data-browser-library.tsx
+++ b/__mocks__/@scality/data-browser-library.tsx
@@ -17,6 +17,14 @@ export const DataBrowserProvider = ({
   return <>{children}</>;
 };
 
+export const DataBrowserUI = ({
+  children,
+}: {
+  children?: React.ReactNode;
+}) => {
+  return <>{children}</>;
+};
+
 export const useCreateBucket = jest.fn(() => ({
   mutate: jest.fn(),
   mutateAsync: jest.fn(),
@@ -77,6 +85,30 @@ export const useGetBucketLocation = jest.fn(() => ({
 }));
 
 export const useGetObject = jest.fn(() => ({
+  data: undefined,
+  status: 'idle',
+  isLoading: false,
+  isSuccess: false,
+  isError: false,
+  error: null,
+  refetch: jest.fn(),
+}));
+
+export const useBuckets = jest.fn(() => ({
+  data: [],
+  status: 'success',
+  isLoading: false,
+  isSuccess: true,
+  isError: false,
+  error: null,
+  refetch: jest.fn(),
+}));
+
+export const useBucketOverviewContext = jest.fn(() => ({
+  bucketName: '',
+}));
+
+export const useListObjects = jest.fn(() => ({
   data: undefined,
   status: 'idle',
   isLoading: false,

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@scality/certchain": "1.4.0",
         "@scality/core-ui": "0.218.0",
-        "@scality/data-browser-library": "1.1.21",
+        "@scality/data-browser-library": "1.1.22",
         "@scality/module-federation": "1.6.1",
         "@scality/react-chained-query": "^2.1.0",
         "@types/react-table": "^7.7.10",
@@ -5691,9 +5691,9 @@
       }
     },
     "node_modules/@scality/data-browser-library": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.21.tgz",
-      "integrity": "sha512-en3kYM6XIUfDmfgoFPi/s7m5sBio7vBD5Fz/lDr5lzzdcJXJUEBXIQiDxGxvR5tn1jYNblTEXgbyCPekHYxFRg==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.22.tgz",
+      "integrity": "sha512-dnLbtqaL6C2CyxBoNFfF7OgYy64XoQtMQMBjg9GQ8co1yskCXJYFVKOyw4bKOz8Q+X0K5DvNtI+tgYOrelKjfg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.983.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@scality/certchain": "1.4.0",
     "@scality/core-ui": "0.218.0",
-    "@scality/data-browser-library": "1.1.21",
+    "@scality/data-browser-library": "1.1.22",
     "@scality/module-federation": "1.6.1",
     "@scality/react-chained-query": "^2.1.0",
     "@types/react-table": "^7.7.10",


### PR DESCRIPTION
## Summary

Bumps `@scality/data-browser-library` from `1.1.21` to `1.1.22` to pick up the padlock indicator fix from the upstream library. With this bump, the lock icon will correctly appear on legal-hold-locked, retention-locked, and both-locked objects in object-lock-enabled buckets.

## Tickets

- JIRA: [ARTESCA-17570](https://scality.atlassian.net/browse/ARTESCA-17570)
- Tracking issue: scality/agent-task#219

## Step adherence

- [x] **Step 1: Bump @scality/data-browser-library to fixed patch** — `package.json` and `package-lock.json` updated to `1.1.22` with regenerated integrity hash.
- [x] **Step 2: Verify mocks still match the new library API** — Cross-referenced every import from `@scality/data-browser-library` across `src/` against the existing Jest mock. Found four pre-existing gaps and added stub exports for `useBuckets`, `useBucketOverviewContext`, `useListObjects`, and `DataBrowserUI`.

## Declared deviations

- **Step 2** (`pattern-partial`): The existing mock was not fully sufficient — four runtime symbols (`useBuckets`, `useBucketOverviewContext`, `useListObjects`, `DataBrowserUI`) imported from `@scality/data-browser-library` in `src/` were missing from `__mocks__/@scality/data-browser-library.tsx`. Stubs were added following the existing mock structure (`jest.fn()` hooks returning success/idle query/mutation shapes; React passthrough component for `DataBrowserUI`). All 26 targeted tests pass.

## Test strategy executed

- `npm install --package-lock-only` regenerated the lockfile cleanly with the new tarball integrity hash.
- Jest test suites covering the mock surface pass: **4 suites / 26 tests** (then **6 / 43** after the mock additions in step 2 expanded test coverage).
- Manual verification (recommended for reviewers): run zenko-ui locally pointed at a bucket with object-lock enabled and confirm the padlock now appears on legal-hold-locked, retention-locked, and both-locked objects.

## Risks & notes

The bump is a patch release (`1.1.21` → `1.1.22`). Reviewers should confirm the upstream diff range contains only the padlock fix and no peerDependency drift that would require a coordinated `@scality/core-ui` bump.


[ARTESCA-17570]: https://scality.atlassian.net/browse/ARTESCA-17570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ