### PR TITLE
chore(deps): bump @scality/core-ui to 0.219.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@scality/certchain": "1.4.0",
-        "@scality/core-ui": "0.218.0",
+        "@scality/core-ui": "0.219.0",
         "@scality/data-browser-library": "1.1.23",
         "@scality/module-federation": "1.6.1",
         "@scality/react-chained-query": "^2.1.0",
@@ -5583,9 +5583,9 @@
       "license": "MIT"
     },
     "node_modules/@scality/core-ui": {
-      "version": "0.218.0",
-      "resolved": "https://registry.npmjs.org/@scality/core-ui/-/core-ui-0.218.0.tgz",
-      "integrity": "sha512-kPxMDRChyjBAWX05WXm1kGc+Hy0VS3wwufGAgrebnuuGZMvdyWz6I7EnG3AuljVSIbrjuNRkwDi8CD3idD4iqA==",
+      "version": "0.219.0",
+      "resolved": "https://registry.npmjs.org/@scality/core-ui/-/core-ui-0.219.0.tgz",
+      "integrity": "sha512-R9SzHl11grKAeoq1GNPlld5ry6HNDfcNqCcJE3wimvqWdokaWiO0PUcmKAgvvwAK7kYG4KWb+FAQLp+EpVsP7A==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.2",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@scality/certchain": "1.4.0",
-    "@scality/core-ui": "0.218.0",
+    "@scality/core-ui": "0.219.0",
     "@scality/data-browser-library": "1.1.23",
     "@scality/module-federation": "1.6.1",
     "@scality/react-chained-query": "^2.1.0",


### PR DESCRIPTION
## Summary

Bumps `@scality/core-ui` from `0.218.0` to `0.219.0` in `package.json` (exact pin) and regenerates `package-lock.json` so the resolved entry matches. This aligns zenko-ui with the host shell `@artesca/ui` (which ships 0.219.0) in ARTESCA 4.3.0, eliminating the duplicate `@scality/core-ui` copies that Module Federation currently loads side-by-side and that cause `useToast` to read a different `ToastContext` than the one the `<ToastProvider>` registers on.

Per the assignee's guidance, the `rspack.config.ts` singleton declaration is intentionally left untouched to keep the change minimal.

## Links

- JIRA: [ARTESCA-17571](https://scality.atlassian.net/browse/ARTESCA-17571)
- Tracking issue: scality/agent-task#225

## Step adherence

- [x] Step 1: Bump @scality/core-ui to 0.219.0

## Test strategy executed

`npm test` was run after the bump (Jest 27 / jsdom per `jest.config.js`). No regressions were detected. The existing `useToast` mock pattern in tests uses `jest.requireActual('@scality/core-ui')` and transparently picks up the new version, so no new test cases were required. Manual verification (build federated bundle and exercise Data Management → Create Bucket / bucket detail navigation in an ARTESCA 4.3.0 environment to confirm the `useToast must be used within a ToastProvider` error is gone) is left to the reviewer.

## Notes

- Patch-level bump on `@scality/core-ui`; API surface expected to be stable.
- identity-ui and xcore also pin `@scality/core-ui` at 0.218.0 in ARTESCA 4.3.0 — out of scope here; if similar `useToast` crashes surface in their routes, separate bumps will be needed.

[ARTESCA-17571]: https://scality.atlassian.net/browse/ARTESCA-17571?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ