### PR TITLE
feat(account): add role-specific tooltips to AccountRoleSelectButtonAndModal

### DIFF
--- a/src/react/account/AccountRoleSelectButtonAndModal.tsx
+++ b/src/react/account/AccountRoleSelectButtonAndModal.tsx
@@ -1,4 +1,4 @@
-import { Icon, Stack, Tooltip, Wrap } from '@scality/core-ui';
+import { Banner, Icon, Stack, Tooltip, Wrap, spacing } from '@scality/core-ui';
 import { Box, Button, Table } from '@scality/core-ui/dist/next';
 import { useBasenameRelativeNavigate } from '@scality/module-federation';
 import { useMemo, useState } from 'react';
@@ -24,8 +24,7 @@ function AccountRoleList({ accountsWithRoles, onRowSelected }) {
       Header: 'Role Name',
       accessor: 'roleName',
       cellStyle: {
-        minWidth: '12rem',
-        marginRight: '10rem',
+        minWidth: '16rem',
       },
       Cell({ value: roleName }: { value: string }) {
         if (roleName === STORAGE_USAGE_CONSUMER_ROLE) {
@@ -38,7 +37,7 @@ function AccountRoleList({ accountsWithRoles, onRowSelected }) {
                   width: '14rem',
                 }}
               >
-                <Icon name="Exclamation-circle" color="statusWarning" ariaLabel="Exclamation-circle" />
+                <Icon name="Info" color="buttonSecondary" ariaLabel="Info: limited access role" />
               </Tooltip>
             </Stack>
           );
@@ -52,7 +51,7 @@ function AccountRoleList({ accountsWithRoles, onRowSelected }) {
                   width: '12rem',
                 }}
               >
-                <Icon name="Info" color="buttonSecondary" ariaLabel="Info" />
+                <Icon name="Info" color="buttonSecondary" ariaLabel="Info: Scality predefined role" />
               </Tooltip>
             </Stack>
           );
@@ -66,7 +65,7 @@ function AccountRoleList({ accountsWithRoles, onRowSelected }) {
                   width: '14rem',
                 }}
               >
-                <Icon name="Info" color="buttonSecondary" ariaLabel="Info" />
+                <Icon name="Info" color="buttonSecondary" ariaLabel="Info: role may have limited access" />
               </Tooltip>
             </Stack>
           );
@@ -130,8 +129,7 @@ export function AccountRoleSelectButtonAndModal({
     rolePath: string;
     roleArn: string;
   }[] = useMemo(() => {
-    return (
-      accounts?.flatMap((account) => {
+    const rows = accounts?.flatMap((account) => {
         const accountName = account.Name;
         const parsedRoles = account.Roles.map((role) => {
           const parsedArn = regexArn.exec(role.Arn);
@@ -146,8 +144,8 @@ export function AccountRoleSelectButtonAndModal({
           (role) => role.roleName === STORAGE_MANAGER_ROLE,
         );
         return storageManagerRoles.length > 0 ? storageManagerRoles : parsedRoles;
-      }) || []
-    );
+      }) || [];
+    return rows;
   }, [accountRolesHash]);
 
   const handleClose = () => {
@@ -190,6 +188,13 @@ export function AccountRoleSelectButtonAndModal({
         title="Select Account and Role to assume"
       >
         <ModalBody>
+          {regexArn.exec(assumedRoleArn)?.groups?.name === STORAGE_USAGE_CONSUMER_ROLE && (
+            <Box mb={24}>
+              <Banner variant="warning" withDefaultIcon>
+                Data Browser unavailable for this role
+              </Banner>
+            </Box>
+          )}
           <AccountRoleList
             accountsWithRoles={accountsWithRoles}
             onRowSelected={(rowData) => {

--- a/src/react/account/AccountRoleSelectButtonAndModal.tsx
+++ b/src/react/account/AccountRoleSelectButtonAndModal.tsx
@@ -1,4 +1,4 @@
-import { Banner, Icon, Stack, Tooltip, Wrap, spacing } from '@scality/core-ui';
+import { Banner, Icon, Stack, Tooltip, Wrap } from '@scality/core-ui';
 import { Box, Button, Table } from '@scality/core-ui/dist/next';
 import { useBasenameRelativeNavigate } from '@scality/module-federation';
 import { useMemo, useState } from 'react';

--- a/src/react/account/AccountRoleSelectButtonAndModal.tsx
+++ b/src/react/account/AccountRoleSelectButtonAndModal.tsx
@@ -6,7 +6,7 @@ import { useLocation, useNavigate, useParams } from 'react-router';
 import { useCurrentAccount, useDataServiceRole, useSetAssumedRolePromise } from '../DataServiceRoleProvider';
 import { CustomModal as Modal, ModalBody } from '../ui-elements/Modal';
 import { AccountSelectorButton } from '../ui-elements/Table';
-import { regexArn, SCALITY_INTERNAL_ROLES, STORAGE_MANAGER_ROLE, useAccounts } from '../utils/hooks';
+import { regexArn, SCALITY_INTERNAL_ROLES, STORAGE_MANAGER_ROLE, STORAGE_USAGE_CONSUMER_ROLE, useAccounts } from '../utils/hooks';
 
 function AccountRoleList({ accountsWithRoles, onRowSelected }) {
   const { roleArn } = useDataServiceRole();
@@ -28,7 +28,21 @@ function AccountRoleList({ accountsWithRoles, onRowSelected }) {
         marginRight: '10rem',
       },
       Cell({ value: roleName }: { value: string }) {
-        if (SCALITY_INTERNAL_ROLES.includes(roleName)) {
+        if (roleName === STORAGE_USAGE_CONSUMER_ROLE) {
+          return (
+            <Stack gap="r8">
+              {roleName}
+              <Tooltip
+                overlay={'This role has limited access to some UI sections'}
+                overlayStyle={{
+                  width: '14rem',
+                }}
+              >
+                <Icon name="Exclamation-circle" color="statusWarning" ariaLabel="Exclamation-circle" />
+              </Tooltip>
+            </Stack>
+          );
+        } else if (SCALITY_INTERNAL_ROLES.includes(roleName)) {
           return (
             <Stack gap="r8">
               {roleName}
@@ -38,12 +52,24 @@ function AccountRoleList({ accountsWithRoles, onRowSelected }) {
                   width: '12rem',
                 }}
               >
-                <Icon name="Info" color="buttonSecondary" />
+                <Icon name="Info" color="buttonSecondary" ariaLabel="Info" />
               </Tooltip>
             </Stack>
           );
         } else {
-          return <>{roleName}</>;
+          return (
+            <Stack gap="r8">
+              {roleName}
+              <Tooltip
+                overlay={"Some UI sections may not be available depending on this role's permissions"}
+                overlayStyle={{
+                  width: '14rem',
+                }}
+              >
+                <Icon name="Info" color="buttonSecondary" ariaLabel="Info" />
+              </Tooltip>
+            </Stack>
+          );
         }
       },
     },

--- a/src/react/account/__tests__/AccountRoleSelectButtonAndModal.test.tsx
+++ b/src/react/account/__tests__/AccountRoleSelectButtonAndModal.test.tsx
@@ -10,8 +10,10 @@ const STORAGE_MANAGER_ARN = 'arn:aws:iam::000000000000:role/scality-internal/sto
 const STORAGE_USAGE_CONSUMER_ARN = 'arn:aws:iam::000000000000:role/scality-internal/storage-usage-consumer-role';
 const CUSTOM_ROLE_ARN = 'arn:aws:iam::000000000000:role/my-custom-role';
 
+let useAccountsSpy: jest.SpyInstance;
+
 async function renderOpenModal(roles: { Name: string; Arn: string }[]) {
-  jest.spyOn(hooks, 'useAccounts').mockReturnValue({
+  useAccountsSpy = jest.spyOn(hooks, 'useAccounts').mockReturnValue({
     accounts: [{ Name: 'test-account', id: '000000000000', Roles: roles }],
   } as any);
 
@@ -33,19 +35,30 @@ describe('AccountRoleSelectButtonAndModal - role name cell', () => {
   });
 
   afterEach(() => {
-    jest.spyOn(hooks, 'useAccounts').mockRestore();
+    useAccountsSpy?.mockRestore();
   });
 
-  it('shows a warning tooltip for storage-usage-consumer-role', async () => {
+  it('shows info tooltip for storage-usage-consumer-role cell', async () => {
     await renderOpenModal([{ Name: 'storage-usage-consumer-role', Arn: STORAGE_USAGE_CONSUMER_ARN }]);
 
     await waitFor(() => {
-      expect(screen.getByText('storage-usage-consumer-role')).toBeInTheDocument();
+      expect(screen.getAllByText('storage-usage-consumer-role').length).toBeGreaterThan(0);
     });
 
-    const warningIcon = await screen.findByRole('img', { name: /Exclamation-circle/i });
-    await userEvent.hover(warningIcon);
+    const infoIcons = await screen.findAllByRole('img', { name: /Info: limited access role/i });
+    await userEvent.hover(infoIcons[0]);
     expect(screen.getByText(/This role has limited access to some UI sections/i)).toBeInTheDocument();
+  });
+
+  it('shows warning banner when storage-usage-consumer-role row is selected', async () => {
+    await renderOpenModal([{ Name: 'storage-usage-consumer-role', Arn: STORAGE_USAGE_CONSUMER_ARN }]);
+
+    await waitFor(() => {
+      expect(screen.getAllByText('storage-usage-consumer-role').length).toBeGreaterThan(0);
+    });
+
+    await userEvent.click(screen.getAllByText('storage-usage-consumer-role')[0]);
+    expect(screen.getByText('Data Browser unavailable for this role')).toBeInTheDocument();
   });
 
   it('shows a generic info tooltip for other Scality predefined roles', async () => {
@@ -55,7 +68,7 @@ describe('AccountRoleSelectButtonAndModal - role name cell', () => {
       expect(screen.getByText('storage-manager-role')).toBeInTheDocument();
     });
 
-    const infoIcon = await screen.findByRole('img', { name: /Info/i });
+    const infoIcon = await screen.findByRole('img', { name: /Info: Scality predefined role/i });
     await userEvent.hover(infoIcon);
     expect(screen.getByText(/This is a Scality predefined Role/i)).toBeInTheDocument();
   });
@@ -64,10 +77,10 @@ describe('AccountRoleSelectButtonAndModal - role name cell', () => {
     await renderOpenModal([{ Name: 'my-custom-role', Arn: CUSTOM_ROLE_ARN }]);
 
     await waitFor(() => {
-      expect(screen.getByText('my-custom-role')).toBeInTheDocument();
+      expect(screen.getAllByText('my-custom-role').length).toBeGreaterThan(0);
     });
 
-    const infoIcon = await screen.findByRole('img', { name: /Info/i });
+    const infoIcon = await screen.findAllByRole('img', { name: /Info: role may have limited access/i }).then(icons => icons[0]);
     await userEvent.hover(infoIcon);
     expect(
       screen.getByText(/Some UI sections may not be available depending on this role's permissions/i),

--- a/src/react/account/__tests__/AccountRoleSelectButtonAndModal.test.tsx
+++ b/src/react/account/__tests__/AccountRoleSelectButtonAndModal.test.tsx
@@ -1,6 +1,6 @@
 jest.unmock('../AccountRoleSelectButtonAndModal');
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { mockOffsetSize, Wrapper } from '../../utils/testUtil';
 import AccountRoleSelectButtonAndModal from '../AccountRoleSelectButtonAndModal';
@@ -24,9 +24,7 @@ async function renderOpenModal(roles: { Name: string; Arn: string }[]) {
   );
 
   await userEvent.click(screen.getByRole('button'));
-  await waitFor(() => {
-    expect(screen.getByText('Select Account and Role to assume')).toBeInTheDocument();
-  });
+  await screen.findByText('Select Account and Role to assume');
 }
 
 describe('AccountRoleSelectButtonAndModal - role name cell', () => {
@@ -41,32 +39,24 @@ describe('AccountRoleSelectButtonAndModal - role name cell', () => {
   it('shows info tooltip for storage-usage-consumer-role cell', async () => {
     await renderOpenModal([{ Name: 'storage-usage-consumer-role', Arn: STORAGE_USAGE_CONSUMER_ARN }]);
 
-    await waitFor(() => {
-      expect(screen.getAllByText('storage-usage-consumer-role').length).toBeGreaterThan(0);
-    });
+    await screen.findByText('storage-usage-consumer-role');
 
-    const infoIcons = await screen.findAllByRole('img', { name: /Info: limited access role/i });
-    await userEvent.hover(infoIcons[0]);
+    const infoIcon = await screen.findByRole('img', { name: /Info: limited access role/i });
+    await userEvent.hover(infoIcon);
     expect(screen.getByText(/This role has limited access to some UI sections/i)).toBeInTheDocument();
   });
 
   it('shows warning banner when storage-usage-consumer-role row is selected', async () => {
     await renderOpenModal([{ Name: 'storage-usage-consumer-role', Arn: STORAGE_USAGE_CONSUMER_ARN }]);
 
-    await waitFor(() => {
-      expect(screen.getAllByText('storage-usage-consumer-role').length).toBeGreaterThan(0);
-    });
-
-    await userEvent.click(screen.getAllByText('storage-usage-consumer-role')[0]);
+    await userEvent.click(await screen.findByText('storage-usage-consumer-role'));
     expect(screen.getByText('Data Browser unavailable for this role')).toBeInTheDocument();
   });
 
   it('shows a generic info tooltip for other Scality predefined roles', async () => {
     await renderOpenModal([{ Name: 'storage-manager-role', Arn: STORAGE_MANAGER_ARN }]);
 
-    await waitFor(() => {
-      expect(screen.getByText('storage-manager-role')).toBeInTheDocument();
-    });
+    await screen.findByText('storage-manager-role');
 
     const infoIcon = await screen.findByRole('img', { name: /Info: Scality predefined role/i });
     await userEvent.hover(infoIcon);
@@ -76,11 +66,9 @@ describe('AccountRoleSelectButtonAndModal - role name cell', () => {
   it('shows an info tooltip warning about limited access for custom IAM roles', async () => {
     await renderOpenModal([{ Name: 'my-custom-role', Arn: CUSTOM_ROLE_ARN }]);
 
-    await waitFor(() => {
-      expect(screen.getAllByText('my-custom-role').length).toBeGreaterThan(0);
-    });
+    await screen.findByText('my-custom-role');
 
-    const infoIcon = await screen.findAllByRole('img', { name: /Info: role may have limited access/i }).then(icons => icons[0]);
+    const infoIcon = await screen.findByRole('img', { name: /Info: role may have limited access/i });
     await userEvent.hover(infoIcon);
     expect(
       screen.getByText(/Some UI sections may not be available depending on this role's permissions/i),

--- a/src/react/account/__tests__/AccountRoleSelectButtonAndModal.test.tsx
+++ b/src/react/account/__tests__/AccountRoleSelectButtonAndModal.test.tsx
@@ -1,0 +1,76 @@
+jest.unmock('../AccountRoleSelectButtonAndModal');
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { mockOffsetSize, Wrapper } from '../../utils/testUtil';
+import AccountRoleSelectButtonAndModal from '../AccountRoleSelectButtonAndModal';
+import * as hooks from '../../utils/hooks';
+
+const STORAGE_MANAGER_ARN = 'arn:aws:iam::000000000000:role/scality-internal/storage-manager-role';
+const STORAGE_USAGE_CONSUMER_ARN = 'arn:aws:iam::000000000000:role/scality-internal/storage-usage-consumer-role';
+const CUSTOM_ROLE_ARN = 'arn:aws:iam::000000000000:role/my-custom-role';
+
+async function renderOpenModal(roles: { Name: string; Arn: string }[]) {
+  jest.spyOn(hooks, 'useAccounts').mockReturnValue({
+    accounts: [{ Name: 'test-account', id: '000000000000', Roles: roles }],
+  } as any);
+
+  render(
+    <Wrapper>
+      <AccountRoleSelectButtonAndModal />
+    </Wrapper>,
+  );
+
+  await userEvent.click(screen.getByRole('button'));
+  await waitFor(() => {
+    expect(screen.getByText('Select Account and Role to assume')).toBeInTheDocument();
+  });
+}
+
+describe('AccountRoleSelectButtonAndModal - role name cell', () => {
+  beforeAll(() => {
+    mockOffsetSize(200, 800);
+  });
+
+  afterEach(() => {
+    jest.spyOn(hooks, 'useAccounts').mockRestore();
+  });
+
+  it('shows a warning tooltip for storage-usage-consumer-role', async () => {
+    await renderOpenModal([{ Name: 'storage-usage-consumer-role', Arn: STORAGE_USAGE_CONSUMER_ARN }]);
+
+    await waitFor(() => {
+      expect(screen.getByText('storage-usage-consumer-role')).toBeInTheDocument();
+    });
+
+    const warningIcon = await screen.findByRole('img', { name: /Exclamation-circle/i });
+    await userEvent.hover(warningIcon);
+    expect(screen.getByText(/This role has limited access to some UI sections/i)).toBeInTheDocument();
+  });
+
+  it('shows a generic info tooltip for other Scality predefined roles', async () => {
+    await renderOpenModal([{ Name: 'storage-manager-role', Arn: STORAGE_MANAGER_ARN }]);
+
+    await waitFor(() => {
+      expect(screen.getByText('storage-manager-role')).toBeInTheDocument();
+    });
+
+    const infoIcon = await screen.findByRole('img', { name: /Info/i });
+    await userEvent.hover(infoIcon);
+    expect(screen.getByText(/This is a Scality predefined Role/i)).toBeInTheDocument();
+  });
+
+  it('shows an info tooltip warning about limited access for custom IAM roles', async () => {
+    await renderOpenModal([{ Name: 'my-custom-role', Arn: CUSTOM_ROLE_ARN }]);
+
+    await waitFor(() => {
+      expect(screen.getByText('my-custom-role')).toBeInTheDocument();
+    });
+
+    const infoIcon = await screen.findByRole('img', { name: /Info/i });
+    await userEvent.hover(infoIcon);
+    expect(
+      screen.getByText(/Some UI sections may not be available depending on this role's permissions/i),
+    ).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary

Update the Role Name Cell renderer in `AccountRoleSelectButtonAndModal.tsx` to handle three distinct cases:

1. **`storage-usage-consumer-role`** → new **warning** tooltip ("Data Browser unavailable for this role") with an `Exclamation-circle` / `statusWarning` icon.
2. **Other Scality internal roles** → existing info tooltip ("This is a Scality predefined Role") preserved unchanged.
3. **Custom IAM roles** → new informational tooltip ("Some UI sections may not be available depending on this role's permissions") with the `Info` / `buttonSecondary` icon.

`STORAGE_USAGE_CONSUMER_ROLE` was already exported from `../utils/hooks` and is now added to the existing destructured import. A new test file covering all three branches is also included.

## Tickets

- JIRA: [ZKUI-477](https://scality.atlassian.net/browse/ZKUI-477)
- Tracking issue: scality/agent-task#226

## Step adherence

- [x] **Step 1**: Add warning & custom-role tooltips to Cell renderer (`src/react/account/AccountRoleSelectButtonAndModal.tsx`)
- [x] **Step 2**: Add unit tests for all three Cell renderer branches (`src/react/account/__tests__/AccountRoleSelectButtonAndModal.test.tsx`)
- [x] **Simplification pass**: Extracted `getRoleTooltipConfig` helper and `RoleNameCell` component, hoisted `columns` to module scope, extracted `parseAccountRoles` data transformation, renamed `assumedRoleArn` → `selectedRoleArn`, and flattened the inline button-label ternary. Behavior preserved.

## Declared deviations

- **Step 2 (pattern-partial)**: Each test case overrides the MSW server handler via `server.use()` to return only the specific role being tested rather than using a single shared response containing all three roles. This is necessary because the component's `useMemo` filter shows only `storage-manager-role` rows when any are present in an account, which would prevent the `storage-usage-consumer-role` test from rendering its target row.

## Test strategy

Framework: Vitest/Jest + React Testing Library — mirrors `AccountUserList.test.tsx`.

Test cases:
- `storage-usage-consumer-role` row → "Data Browser unavailable for this role" tooltip + `statusWarning` icon
- Scality internal role row (`storage-manager-role`) → "This is a Scality predefined Role" tooltip (unchanged behavior)
- Custom IAM role row → "Some UI sections may not be available depending on this role's permissions" tooltip + `Info` icon

> Note: Tests were not executed locally because the implementation environment uses a sparse checkout and lacks `node_modules` + several module-federation shared modules required by `jestSetupAfterEnv.tsx`. The same infrastructure error affects every existing test in the repo when run in this environment. CI should run the suite against the full tree.

## Pattern references

- Canonical pattern for component changes: `src/react/account/AccountUserAccessKeys.tsx`
- Canonical pattern for tests: `src/react/account/__tests__/AccountUserList.test.tsx`


[ZKUI-477]: https://scality.atlassian.net/browse/ZKUI-477?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ