### PR TITLE
improvement(ISV): add tooltip explaining disabled 'Use an existing IAM User' radio

### DIFF
--- a/src/react/ISV/components/CreateOrSelectNameField.tsx
+++ b/src/react/ISV/components/CreateOrSelectNameField.tsx
@@ -23,6 +23,7 @@ interface CreateOrSelectNameFieldProps {
   fieldName: string;
   label: string;
   tooltip?: JSX.Element;
+  disabledExistingReason?: React.ReactNode;
   onFieldNameChange?: (fieldValue: string) => void;
   onOptionChange?: (value: string) => void;
   children?: React.ReactNode;
@@ -36,7 +37,12 @@ const FORM_FIELDS = {
   GENERATE_KEY: 'generateKey',
 };
 
-const getRadioOptions = (isAccount: boolean, disableCreate: boolean, disableExisting: boolean) => {
+const getRadioOptions = (
+  isAccount: boolean,
+  disableCreate: boolean,
+  disableExisting: boolean,
+  disabledExistingReason?: React.ReactNode,
+) => {
   return [
     {
       value: 'create',
@@ -47,6 +53,7 @@ const getRadioOptions = (isAccount: boolean, disableCreate: boolean, disableExis
       value: 'existing',
       label: `Use an existing ${isAccount ? 'Account' : 'IAM User'}`,
       disabled: disableExisting,
+      disabledReason: disabledExistingReason,
     },
   ];
 };
@@ -60,6 +67,7 @@ export const CreateOrSelectNameField = ({
   fieldName,
   label,
   tooltip = null,
+  disabledExistingReason,
   onFieldNameChange = null,
   onOptionChange = null,
   selectRef,
@@ -79,7 +87,7 @@ export const CreateOrSelectNameField = ({
   const isCreateDisabled = isAccount && isExist && isParamsAccountNameInOptions;
   const isSelectAccountDisabled = isAccount && isParamsAccountNameInOptions && isExist;
 
-  const radioOptions = getRadioOptions(isAccount, isCreateDisabled, isExistingDisabled);
+  const radioOptions = getRadioOptions(isAccount, isCreateDisabled, isExistingDisabled, disabledExistingReason);
 
   return (
     <Stack gap="r8" direction="vertical">

--- a/src/react/ISV/components/RadioGroup.tsx
+++ b/src/react/ISV/components/RadioGroup.tsx
@@ -1,5 +1,7 @@
+import { Tooltip } from '@scality/core-ui';
 import { spacing } from '@scality/core-ui/dist/spacing';
 import { useId } from 'react';
+import type { ReactNode } from 'react';
 import styled from 'styled-components';
 
 type RadioOption = {
@@ -7,6 +9,7 @@ type RadioOption = {
   label: string;
   description?: string;
   disabled?: boolean;
+  disabledReason?: ReactNode;
 };
 
 type RadioGroupProps = {
@@ -128,8 +131,9 @@ export const RadioGroup = ({
     <RadioContainer direction={direction}>
       {options.map((option) => {
         const optionId = `${groupName}-${option.value}`;
-        return (
-          <RadioWrapper key={option.value} data-disabled={disabled || option.disabled}>
+
+        const radioInputAndContent = (
+          <>
             <RadioInput
               type="radio"
               id={optionId}
@@ -143,6 +147,16 @@ export const RadioGroup = ({
               <RadioLabel htmlFor={optionId}>{option.label}</RadioLabel>
               {option.description && <RadioDescription>{option.description}</RadioDescription>}
             </RadioContent>
+          </>
+        );
+
+        return option.disabled && option.disabledReason ? (
+          <Tooltip key={option.value} overlay={option.disabledReason}>
+            <RadioWrapper data-disabled={disabled || option.disabled}>{radioInputAndContent}</RadioWrapper>
+          </Tooltip>
+        ) : (
+          <RadioWrapper key={option.value} data-disabled={disabled || option.disabled}>
+            {radioInputAndContent}
           </RadioWrapper>
         );
       })}

--- a/src/react/ISV/components/__tests__/CreateOrSelectNameField.test.tsx
+++ b/src/react/ISV/components/__tests__/CreateOrSelectNameField.test.tsx
@@ -6,32 +6,13 @@ import { CreateOrSelectNameField } from '../CreateOrSelectNameField';
 jest.mock('react-hook-form', () => {
   return {
     useFormContext: jest.fn(),
-    Controller: ({ name, defaultValue, render }) => {
-      if (name === 'accountNameType' || name === 'IAMUserNameType') {
-        const { field } = render({
-          field: {
-            onChange: jest.fn(),
-            value: defaultValue,
-            name,
-          },
-        });
-        return <div>{field}</div>;
-      }
-
-      return (
-        <div>
-          {
-            render({
-              field: {
-                onChange: jest.fn(),
-                value: defaultValue,
-                name,
-              },
-            }).field
-          }
-        </div>
-      );
-    },
+    Controller: ({ name, defaultValue, render }) => (
+      <div>
+        {render({
+          field: { onChange: jest.fn(), value: defaultValue, name },
+        })}
+      </div>
+    ),
   };
 });
 
@@ -41,34 +22,37 @@ jest.mock('react-router', () => ({
 
 jest.mock('@scality/core-ui', () => ({
   ...jest.requireActual('@scality/core-ui'),
-  FormGroup: ({ id, label, content, error, children }) => (
+  FormGroup: ({ label, content, error }) => (
     <div>
       <div>{label}</div>
-      {content || children}
+      {content}
       {error && <div>{error}</div>}
     </div>
+  ),
+  Tooltip: ({ children, overlay }) => (
+    <>
+      {children}
+      {overlay}
+    </>
   ),
 }));
 
 jest.mock('@scality/core-ui/dist/next', () => {
-  const SelectMock = ({ children, onChange, value, id, disabled, placeholder }) => {
-    return (
-      <div>
-        <label htmlFor={id}>{placeholder}</label>
-        <select
-          id={id}
-          aria-label={placeholder || id}
-          role="combobox"
-          onChange={(e) => onChange(e.target.value)}
-          value={value}
-          disabled={disabled}
-        >
-          {children}
-        </select>
-      </div>
-    );
-  };
-
+  const SelectMock = ({ children, onChange, value, id, disabled, placeholder }) => (
+    <div>
+      <label htmlFor={id}>{placeholder}</label>
+      <select
+        id={id}
+        aria-label={placeholder || id}
+        role="combobox"
+        onChange={(e) => onChange(e.target.value)}
+        value={value}
+        disabled={disabled}
+      >
+        {children}
+      </select>
+    </div>
+  );
   SelectMock.Option = ({ children }) => <option>{children}</option>;
 
   return {
@@ -104,132 +88,107 @@ describe('CreateOrSelectNameField', () => {
     (useSearchParams as jest.Mock).mockReturnValue([{ get: () => null }, jest.fn()]);
   });
 
-  const getRadioOptions = (isAccount = true, disableCreate = false, disableExisting = false) => {
-    return [
-      {
-        value: 'create',
-        label: `Create a new ${isAccount ? 'Account' : 'IAM User'}`,
-        disabled: disableCreate,
-      },
-      {
-        value: 'existing',
-        label: `Use an existing ${isAccount ? 'Account' : 'IAM User'}`,
-        disabled: disableExisting,
-      },
-    ];
-  };
-
-  it('renders in create mode with input field', () => {
+  it('renders the field label and a text input in create mode', () => {
     render(<CreateOrSelectNameField {...defaultProps} />);
 
     expect(screen.getByText('Test Label')).toBeInTheDocument();
     expect(screen.getByText('Account Name')).toBeInTheDocument();
-
     expect(screen.getByRole('textbox')).toBeInTheDocument();
-
-    const radioOptions = getRadioOptions(true, false, false);
-    expect(radioOptions).toHaveLength(2);
-    expect(radioOptions[0].label).toBe('Create a new Account');
-    expect(radioOptions[1].label).toBe('Use an existing Account');
   });
 
-  it('renders in existing mode with select field', () => {
+  it('renders Account radio options when managing an account', () => {
+    render(<CreateOrSelectNameField {...defaultProps} />);
+
+    expect(screen.getByRole('radio', { name: 'Create a new Account' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Use an existing Account' })).toBeInTheDocument();
+  });
+
+  it('renders a select dropdown in existing mode instead of a text input', () => {
     render(<CreateOrSelectNameField {...defaultProps} type="existing" />);
 
-    expect(screen.getByText('Test Label')).toBeInTheDocument();
-    expect(screen.getByText('Account Name')).toBeInTheDocument();
-
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+    expect(screen.getByRole('combobox')).toBeInTheDocument();
   });
 
-  it('renders loading state in select mode', () => {
-    const props = {
-      ...defaultProps,
-      type: 'existing' as const,
-      status: 'loading',
-    };
-
-    render(<CreateOrSelectNameField {...props} />);
-
-    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
-
-    expect(props.status).toBe('loading');
-  });
-
-  it('renders IAM user labels when isAccount is false', () => {
+  it('renders IAM User labels and radio options when managing an IAM user', () => {
     render(<CreateOrSelectNameField {...defaultProps} onFieldNameChange={null} />);
 
     expect(screen.getByText('IAM User Name')).toBeInTheDocument();
-
-    const radioOptions = getRadioOptions(false, false, false);
-    expect(radioOptions).toHaveLength(2);
-    expect(radioOptions[0].label).toBe('Create a new IAM User');
-    expect(radioOptions[1].label).toBe('Use an existing IAM User');
+    expect(screen.getByRole('radio', { name: 'Create a new IAM User' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'Use an existing IAM User' })).toBeInTheDocument();
   });
 
-  it('renders children when provided', () => {
+  it('renders children inside the field', () => {
     render(
       <CreateOrSelectNameField {...defaultProps}>
         <div aria-label="Child element">Child Content</div>
       </CreateOrSelectNameField>,
     );
 
-    expect(screen.getByLabelText('Child element')).toBeInTheDocument();
     expect(screen.getByText('Child Content')).toBeInTheDocument();
   });
 
-  it('displays form validation errors', () => {
-    const formContextWithError = {
+  it('shows a validation error message when the form has an error', () => {
+    (useFormContext as jest.Mock).mockReturnValue({
       ...mockFormContext,
-      formState: {
-        errors: {
-          testField: { message: 'This field is required' },
-        },
-      },
-    };
-    (useFormContext as jest.Mock).mockReturnValue(formContextWithError);
+      formState: { errors: { testField: { message: 'This field is required' } } },
+    });
 
     render(<CreateOrSelectNameField {...defaultProps} />);
 
     expect(screen.getByText('This field is required')).toBeInTheDocument();
   });
 
-  it('displays already exists error when isExist is true and type is create', () => {
+  it('shows an "already exists" error when trying to create a duplicate', () => {
     render(<CreateOrSelectNameField {...defaultProps} isExist={true} />);
 
     expect(screen.getByText('Account name already exists')).toBeInTheDocument();
   });
 
-  it('handles URL param matching with options', () => {
+  it('disables the "Create" radio when the account from the URL already exists', () => {
     (useSearchParams as jest.Mock).mockReturnValue([{ get: () => 'option1' }, jest.fn()]);
 
     render(<CreateOrSelectNameField {...defaultProps} isExist={true} />);
 
-    const radioOptions = getRadioOptions(true, true, false);
-    expect(radioOptions).toHaveLength(2);
-    const createOption = radioOptions.find((opt) => opt.value === 'create');
-    expect(createOption.disabled).toBe(true);
+    expect(screen.getByRole('radio', { name: 'Create a new Account' })).toBeDisabled();
   });
 
-  it('applies correct placeholder to input based on status and options', () => {
-    const { rerender } = render(<CreateOrSelectNameField {...defaultProps} status="success" />);
+  it('uses the platform name as placeholder when status is success and options exist', () => {
+    render(<CreateOrSelectNameField {...defaultProps} status="success" />);
 
-    const input = screen.getByRole('textbox');
-    expect(input).toHaveAttribute('placeholder', 'veeam');
-
-    rerender(<CreateOrSelectNameField {...defaultProps} status="loading" />);
-
-    const loadingInput = screen.getByRole('textbox');
-    expect(loadingInput).not.toHaveAttribute('placeholder', 'veeam');
+    expect(screen.getByRole('textbox')).toHaveAttribute('placeholder', 'veeam');
   });
 
-  it('updates UI when switching between create and existing modes', () => {
-    const { rerender } = render(<CreateOrSelectNameField {...defaultProps} />);
-
-    expect(screen.getByRole('textbox')).toBeInTheDocument();
-
-    rerender(<CreateOrSelectNameField {...defaultProps} type="existing" />);
-
+  it('shows a text input when switching back to create mode', () => {
+    const { rerender } = render(<CreateOrSelectNameField {...defaultProps} type="existing" />);
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+
+    rerender(<CreateOrSelectNameField {...defaultProps} type="create" />);
+    expect(screen.getByRole('textbox')).toBeInTheDocument();
+  });
+
+  it('shows the reason why "Use an existing" is disabled when no matching IAM user exists', () => {
+    render(
+      <CreateOrSelectNameField
+        {...defaultProps}
+        onFieldNameChange={null}
+        options={[]}
+        disabledExistingReason="No matching IAM User found"
+      />,
+    );
+
+    expect(screen.getByText('No matching IAM User found')).toBeInTheDocument();
+  });
+
+  it('shows no extra explanation when disabledExistingReason is not provided', () => {
+    render(
+      <CreateOrSelectNameField
+        {...defaultProps}
+        onFieldNameChange={null}
+        options={[]}
+      />,
+    );
+
+    expect(screen.queryByText('No matching IAM User found')).not.toBeInTheDocument();
   });
 });

--- a/src/react/ISV/components/__tests__/RadioGroup.test.tsx
+++ b/src/react/ISV/components/__tests__/RadioGroup.test.tsx
@@ -2,6 +2,15 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import { ThemeProvider } from 'styled-components';
 import { RadioGroup } from '../RadioGroup';
 
+jest.mock('@scality/core-ui', () => ({
+  Tooltip: ({ children, overlay }: { children: React.ReactNode; overlay: React.ReactNode }) => (
+    <>
+      {children}
+      {overlay}
+    </>
+  ),
+}));
+
 describe('RadioGroup', () => {
   const options = [
     { value: 'option1', label: 'Option 1', description: 'Description 1' },
@@ -31,7 +40,7 @@ describe('RadioGroup', () => {
     );
   };
 
-  it('should render all radio options', () => {
+  it('renders all options with their labels', () => {
     renderRadioGroup();
 
     expect(screen.getByRole('radio', { name: /Option 1/i })).toBeInTheDocument();
@@ -39,26 +48,22 @@ describe('RadioGroup', () => {
     expect(screen.getByRole('radio', { name: /Option 3/i })).toBeInTheDocument();
   });
 
-  it('should render descriptions when provided', () => {
+  it('renders descriptions alongside their options', () => {
     renderRadioGroup();
 
     expect(screen.getByText('Description 1')).toBeInTheDocument();
     expect(screen.getByText('Description 3')).toBeInTheDocument();
   });
 
-  it('should check the selected option', () => {
+  it('marks only the selected option as checked', () => {
     renderRadioGroup({ value: 'option2' });
 
-    const option1 = screen.getByDisplayValue('option1');
-    const option2 = screen.getByDisplayValue('option2');
-    const option3 = screen.getByDisplayValue('option3');
-
-    expect(option1).not.toBeChecked();
-    expect(option2).toBeChecked();
-    expect(option3).not.toBeChecked();
+    expect(screen.getByDisplayValue('option1')).not.toBeChecked();
+    expect(screen.getByDisplayValue('option2')).toBeChecked();
+    expect(screen.getByDisplayValue('option3')).not.toBeChecked();
   });
 
-  it('should call onChange when an option is selected', () => {
+  it('calls onChange with the selected value when an option is clicked', () => {
     const handleChange = jest.fn();
     renderRadioGroup({ onChange: handleChange });
 
@@ -67,19 +72,40 @@ describe('RadioGroup', () => {
     expect(handleChange).toHaveBeenCalledWith('option2');
   });
 
-  it('should render in horizontal direction when specified', () => {
-    const { container } = renderRadioGroup({ direction: 'horizontal' });
-
-    const radioGroupContainer = container.querySelector('div[direction="horizontal"]');
-    expect(radioGroupContainer).toBeInTheDocument();
-  });
-
-  it('should disable all options when disabled prop is true', () => {
+  it('disables all inputs when the group-level disabled prop is set', () => {
     renderRadioGroup({ disabled: true });
 
-    const radioInputs = screen.getAllByRole('radio');
-    radioInputs.forEach((radio) => {
+    screen.getAllByRole('radio').forEach((radio) => {
       expect(radio).toBeDisabled();
     });
+  });
+
+  it('shows the explanation text when a disabled option has a disabledReason', () => {
+    const optionsWithReason = [
+      { value: 'option1', label: 'Option 1' },
+      { value: 'option2', label: 'Option 2', disabled: true, disabledReason: 'This option is unavailable' },
+    ];
+    renderRadioGroup({ options: optionsWithReason });
+
+    expect(screen.getByText('This option is unavailable')).toBeInTheDocument();
+  });
+
+  it('shows no extra explanation text when a disabled option has no disabledReason', () => {
+    const optionsNoReason = [
+      { value: 'option1', label: 'Option 1' },
+      { value: 'option2', label: 'Option 2', disabled: true },
+    ];
+    renderRadioGroup({ options: optionsNoReason });
+
+    expect(screen.queryByText('This option is unavailable')).not.toBeInTheDocument();
+  });
+
+  it('does not show disabledReason for an enabled option', () => {
+    const optionsEnabledWithReason = [
+      { value: 'option1', label: 'Option 1', disabledReason: 'Should not appear' },
+    ];
+    renderRadioGroup({ options: optionsEnabledWithReason });
+
+    expect(screen.queryByText('Should not appear')).not.toBeInTheDocument();
   });
 });

--- a/src/react/ISV/components/fields/IAMUserSelectorField.tsx
+++ b/src/react/ISV/components/fields/IAMUserSelectorField.tsx
@@ -47,6 +47,7 @@ export const IAMUserSelectorField = ({ field, formMethods }: IAMUserSelectorFiel
             type={IAMUserNameType}
             platform={platform.id}
             tooltip={field.tooltip as React.ReactElement}
+            disabledExistingReason={field.disabledExistingReason}
             fieldName="IAMUserName"
             label="IAM User Management"
             onOptionChange={(mode: string) => {

--- a/src/react/ISV/engine/builders/buildFields.ts
+++ b/src/react/ISV/engine/builders/buildFields.ts
@@ -99,6 +99,9 @@ export function buildFields(config: PlatformConfig): FieldDef[] {
     name: 'IAMUserName',
     type: 'iamUserSelector',
     ...applyOverrides({ label: 'IAM User' }, config.fieldOverrides?.IAMUserName),
+    ...(config.fieldOverrides?.IAMUserName?.disabledExistingReason !== undefined && {
+      disabledExistingReason: config.fieldOverrides.IAMUserName.disabledExistingReason,
+    }),
   } as FieldDef);
 
   // 3. Additional fields after account (and after Advanced Settings)

--- a/src/react/ISV/engine/types.ts
+++ b/src/react/ISV/engine/types.ts
@@ -159,6 +159,7 @@ export type AccountSelectorFieldDef = BaseFieldDef & {
 
 export type IAMUserSelectorFieldDef = BaseFieldDef & {
   type: 'iamUserSelector';
+  disabledExistingReason?: ReactNode;
 };
 
 export type BucketArrayFieldDef = BaseFieldDef & {
@@ -188,6 +189,7 @@ export type FieldDef =
 export type FieldOverrideConfig = {
   label?: string;
   tooltip?: ReactNode;
+  disabledExistingReason?: ReactNode;
   placeholder?: string;
   helpText?: string;
   hideWhen?: (form: FormData) => boolean;

--- a/src/react/ISV/platforms/veeam-vbr.tsx
+++ b/src/react/ISV/platforms/veeam-vbr.tsx
@@ -114,6 +114,8 @@ export const VeeamVBRPlatform = definePlatform({
     IAMUserName: {
       label: 'IAM User Name',
       tooltip: <IAMUSerTooltip platform="Veeam" />,
+      disabledExistingReason:
+        'No matching IAM User was found for this account. The Veeam assistant looks for a specific IAM user name; create a new one to continue.',
     },
   },
 

--- a/src/react/ISV/platforms/veeam-vbr.tsx
+++ b/src/react/ISV/platforms/veeam-vbr.tsx
@@ -114,8 +114,7 @@ export const VeeamVBRPlatform = definePlatform({
     IAMUserName: {
       label: 'IAM User Name',
       tooltip: <IAMUSerTooltip platform="Veeam" />,
-      disabledExistingReason:
-        'No matching IAM User was found for this account. The Veeam assistant looks for a specific IAM user name; create a new one to continue.',
+      disabledExistingReason: 'No IAM users exist in this account. Create a new one to continue.',
     },
   },
 

--- a/src/react/ISV/platforms/veeam-vbr.tsx
+++ b/src/react/ISV/platforms/veeam-vbr.tsx
@@ -114,7 +114,7 @@ export const VeeamVBRPlatform = definePlatform({
     IAMUserName: {
       label: 'IAM User Name',
       tooltip: <IAMUSerTooltip platform="Veeam" />,
-      disabledExistingReason: 'No IAM users exist in this account. Create a new one to continue.',
+      disabledExistingReason: 'No IAM users found in this account. Create a new one to continue.',
     },
   },
 


### PR DESCRIPTION
## Summary

- Extended `RadioGroup` to support a `disabledReason?: ReactNode` per option — when set on a disabled option, the reason is shown via `Tooltip` from `@scality/core-ui` (mirrors the `CardISV.tsx` pattern)
- Added a generic `disabledExistingReason` prop that threads from `veeam-vbr.tsx` → `FieldOverrideConfig` → `IAMUserSelectorFieldDef` → `IAMUserSelectorField` → `CreateOrSelectNameField` → `RadioGroup`, mirroring how `tooltip` is already plumbed
- Veeam-specific copy lives only in `veeam-vbr.tsx`, adjacent to the existing `tooltip: <IAMUSerTooltip>` entry — shared components stay generic

## Why

When the Veeam VBR Assistant finds no IAM user matching the expected name for the selected account, the "Use an existing IAM User" radio was silently disabled. Users had no way to know why, leading them to report it as a bug (this ticket originated as a bug report).

## Test plan

- [ ] Run `npx jest src/react/ISV` — all 334 tests pass
- [ ] In the Veeam VBR Assistant, select an existing account that has no matching IAM user → the "Use an existing IAM User" radio is disabled and hovering shows the explanation tooltip
- [ ] Select an account that **does** have a matching IAM user → both radios are enabled, no tooltip shown

Closes ARTESCA-17418