### PR TITLE
fix(account): keep selector label in sync after role switch

### DIFF
--- a/src/react/DataServiceRoleProvider.tsx
+++ b/src/react/DataServiceRoleProvider.tsx
@@ -171,8 +171,8 @@ export const useCurrentAccount = () => {
 
   const account = useMemo(() => {
     return accounts.find((account) => {
-      if (accountName) return account.Name === accountName;
-      else if (accountId) return account.id === accountId;
+      if (accountId) return account.id === accountId;
+      else if (accountName) return account.Name === accountName;
       else return true;
     });
   }, [accountId, accounts, accountName]);

--- a/src/react/__tests__/DataServiceRoleProvider.test.tsx
+++ b/src/react/__tests__/DataServiceRoleProvider.test.tsx
@@ -59,7 +59,7 @@ jest.spyOn(hooks, 'useAccounts').mockReturnValue({
   ],
 } as any);
 
-import DataServiceRoleProvider, { useDataServiceRole, useAssumedRole, useAssumeRoleQuery } from '../DataServiceRoleProvider';
+import DataServiceRoleProvider, { useDataServiceRole, useAssumedRole, useAssumeRoleQuery, useCurrentAccount, _DataServiceRoleContext } from '../DataServiceRoleProvider';
 import * as dataBrowserLibrary from '@scality/data-browser-library';
 
 const theme = coreUIAvailableThemes.darkRebrand;
@@ -348,5 +348,107 @@ describe('DataServiceRoleProvider', () => {
 
     expect(screen.queryByTestId('child-content')).not.toBeInTheDocument();
     expect(screen.getByText(/loading/i)).toBeInTheDocument();
+  });
+});
+
+describe('useCurrentAccount', () => {
+  const TEST_ACCOUNT = {
+    Name: 'test-account',
+    id: '000000000000',
+    Roles: [{ Name: 'storage-manager-role', Arn: TEST_ROLE_ARN }],
+  };
+
+  const OTHER_ACCOUNT = {
+    Name: 'other-account',
+    id: '111111111111',
+    Roles: [{ Name: 'storage-manager-role', Arn: 'arn:aws:iam::111111111111:role/scality-internal/storage-manager-role' }],
+  };
+
+  function createCurrentAccountWrapper({
+    roleArn,
+    accountNameInUrl,
+  }: {
+    roleArn: string;
+    accountNameInUrl?: string;
+  }) {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false }, mutations: { retry: false } },
+    });
+
+    const initialEntry = accountNameInUrl ? `/accounts/${accountNameInUrl}/details` : '/';
+    const routePath = accountNameInUrl ? '/accounts/:accountName/details' : '/';
+
+    return function Wrapper({ children }: { children: React.ReactNode }) {
+      return (
+        <QueryClientProvider client={queryClient}>
+          <ThemeProvider theme={theme}>
+            <MemoryRouter initialEntries={[initialEntry]}>
+              <_DataServiceRoleContext.Provider
+                value={{
+                  role: { roleArn },
+                  setRole: jest.fn(),
+                  setRolePromise: jest.fn() as any,
+                  assumedRole: undefined,
+                }}
+              >
+                <Routes>
+                  <Route path={routePath} element={<>{children}</>} />
+                </Routes>
+              </_DataServiceRoleContext.Provider>
+            </MemoryRouter>
+          </ThemeProvider>
+        </QueryClientProvider>
+      );
+    };
+  }
+
+  beforeEach(() => {
+    jest.spyOn(hooks, 'useAccounts').mockReturnValue({
+      accounts: [TEST_ACCOUNT, OTHER_ACCOUNT],
+    } as any);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns the roleArn-derived account when both roleArn and URL accountName are present', () => {
+    const Wrapper = createCurrentAccountWrapper({
+      roleArn: TEST_ROLE_ARN,
+      accountNameInUrl: 'other-account',
+    });
+
+    const { result } = renderHook(() => useCurrentAccount(), { wrapper: Wrapper });
+
+    expect(result.current.account).toBeDefined();
+    expect(result.current.account?.id).toBe('000000000000');
+    expect(result.current.account?.Name).toBe('test-account');
+  });
+
+  it('falls back to URL accountName when roleArn is absent', () => {
+    const Wrapper = createCurrentAccountWrapper({
+      roleArn: '',
+      accountNameInUrl: 'other-account',
+    });
+
+    const { result } = renderHook(() => useCurrentAccount(), { wrapper: Wrapper });
+
+    expect(result.current.account).toBeDefined();
+    expect(result.current.account?.id).toBe('111111111111');
+    expect(result.current.account?.Name).toBe('other-account');
+  });
+
+  it('returns undefined when neither roleArn nor URL accountName is present', () => {
+    jest.spyOn(hooks, 'useAccounts').mockReturnValue({
+      accounts: [],
+    } as any);
+
+    const Wrapper = createCurrentAccountWrapper({
+      roleArn: '',
+    });
+
+    const { result } = renderHook(() => useCurrentAccount(), { wrapper: Wrapper });
+
+    expect(result.current.account).toBeUndefined();
   });
 });

--- a/src/react/__tests__/DataServiceRoleProvider.test.tsx
+++ b/src/react/__tests__/DataServiceRoleProvider.test.tsx
@@ -409,7 +409,7 @@ describe('useCurrentAccount', () => {
   });
 
   afterEach(() => {
-    jest.restoreAllMocks();
+    jest.clearAllMocks();
   });
 
   it('returns the roleArn-derived account when both roleArn and URL accountName are present', () => {

--- a/src/react/account/AccountRoleSelectButtonAndModal.tsx
+++ b/src/react/account/AccountRoleSelectButtonAndModal.tsx
@@ -2,7 +2,6 @@ import { Banner, Icon, Stack, Tooltip, Wrap } from '@scality/core-ui';
 import { Box, Button, Table } from '@scality/core-ui/dist/next';
 import { useBasenameRelativeNavigate } from '@scality/module-federation';
 import { useMemo, useState } from 'react';
-import { useLocation, useNavigate, useParams } from 'react-router';
 import { useCurrentAccount, useDataServiceRole, useSetAssumedRolePromise } from '../DataServiceRoleProvider';
 import { CustomModal as Modal, ModalBody } from '../ui-elements/Modal';
 import { AccountSelectorButton } from '../ui-elements/Table';
@@ -211,18 +210,9 @@ export function AccountRoleSelectButtonAndModal({
 const ModalFooter = ({ handleClose, assumedRoleArn, roleArn, assumedAccount }) => {
   const setRole = useSetAssumedRolePromise();
   const navigateWithBasename = useBasenameRelativeNavigate();
-  const navigate = useNavigate();
-  const { accountName } = useParams();
-  const location = useLocation();
 
   const handleAccountClick = () => {
-    const replacePath = location.pathname.replace(accountName, assumedAccount);
-
-    if (replacePath.includes('/buckets')) {
-      navigateWithBasename(`/accounts/${assumedAccount}/buckets`);
-    } else {
-      navigate(replacePath);
-    }
+    navigateWithBasename(`/accounts/${assumedAccount}/buckets`);
   };
 
   return (

--- a/src/react/account/__tests__/AccountRoleSelectButtonAndModal.test.tsx
+++ b/src/react/account/__tests__/AccountRoleSelectButtonAndModal.test.tsx
@@ -5,7 +5,6 @@ import userEvent from '@testing-library/user-event';
 import { mockOffsetSize, renderWithCustomRoute, Wrapper } from '../../utils/testUtil';
 import AccountRoleSelectButtonAndModal from '../AccountRoleSelectButtonAndModal';
 import * as hooks from '../../utils/hooks';
-import * as moduleFederation from '@scality/module-federation';
 
 const STORAGE_MANAGER_ARN = 'arn:aws:iam::000000000000:role/scality-internal/storage-manager-role';
 const STORAGE_USAGE_CONSUMER_ARN = 'arn:aws:iam::000000000000:role/scality-internal/storage-usage-consumer-role';
@@ -114,7 +113,9 @@ describe('AccountRoleSelectButtonAndModal - handleAccountClick navigation', () =
   ];
 
   beforeAll(() => {
-    jest.spyOn(moduleFederation, 'useBasenameRelativeNavigate').mockReturnValue(mockNavigate);
+    jest
+      .spyOn(jest.requireMock('@scality/module-federation'), 'useBasenameRelativeNavigate')
+      .mockReturnValue(mockNavigate);
   });
 
   beforeEach(() => {

--- a/src/react/account/__tests__/AccountRoleSelectButtonAndModal.test.tsx
+++ b/src/react/account/__tests__/AccountRoleSelectButtonAndModal.test.tsx
@@ -117,10 +117,6 @@ describe('AccountRoleSelectButtonAndModal - handleAccountClick navigation', () =
     },
   ];
 
-  beforeAll(() => {
-    mockOffsetSize(200, 800);
-  });
-
   beforeEach(() => {
     mockNavigate.mockReset();
   });

--- a/src/react/account/__tests__/AccountRoleSelectButtonAndModal.test.tsx
+++ b/src/react/account/__tests__/AccountRoleSelectButtonAndModal.test.tsx
@@ -2,13 +2,21 @@ jest.unmock('../AccountRoleSelectButtonAndModal');
 
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { mockOffsetSize, Wrapper } from '../../utils/testUtil';
+import { mockOffsetSize, renderWithCustomRoute, Wrapper } from '../../utils/testUtil';
 import AccountRoleSelectButtonAndModal from '../AccountRoleSelectButtonAndModal';
 import * as hooks from '../../utils/hooks';
 
 const STORAGE_MANAGER_ARN = 'arn:aws:iam::000000000000:role/scality-internal/storage-manager-role';
 const STORAGE_USAGE_CONSUMER_ARN = 'arn:aws:iam::000000000000:role/scality-internal/storage-usage-consumer-role';
 const CUSTOM_ROLE_ARN = 'arn:aws:iam::000000000000:role/my-custom-role';
+const ANOTHER_ACCOUNT_STORAGE_MANAGER_ARN =
+  'arn:aws:iam::111111111111:role/scality-internal/storage-manager-role';
+
+const mockNavigate = jest.fn();
+jest.mock('@scality/module-federation', () => ({
+  useShellHooks: jest.fn(),
+  useBasenameRelativeNavigate: jest.fn().mockImplementation(() => mockNavigate),
+}));
 
 let useAccountsSpy: jest.SpyInstance;
 
@@ -27,6 +35,24 @@ async function renderOpenModal(roles: { Name: string; Arn: string }[]) {
   await screen.findByText('Select Account and Role to assume');
 }
 
+async function renderOpenModalOnRoute(
+  roles: { Name: string; Arn: string }[],
+  accounts: { Name: string; id: string; Roles: { Name: string; Arn: string }[] }[],
+  route: string,
+) {
+  useAccountsSpy = jest.spyOn(hooks, 'useAccounts').mockReturnValue({
+    accounts,
+  } as any);
+
+  renderWithCustomRoute(
+    <AccountRoleSelectButtonAndModal />,
+    route,
+  );
+
+  await userEvent.click(screen.getByRole('button'));
+  await screen.findByText('Select Account and Role to assume');
+}
+
 describe('AccountRoleSelectButtonAndModal - role name cell', () => {
   beforeAll(() => {
     mockOffsetSize(200, 800);
@@ -34,6 +60,7 @@ describe('AccountRoleSelectButtonAndModal - role name cell', () => {
 
   afterEach(() => {
     useAccountsSpy?.mockRestore();
+    mockNavigate.mockReset();
   });
 
   it('shows info tooltip for storage-usage-consumer-role cell', async () => {
@@ -73,5 +100,62 @@ describe('AccountRoleSelectButtonAndModal - role name cell', () => {
     expect(
       screen.getByText(/Some UI sections may not be available depending on this role's permissions/i),
     ).toBeInTheDocument();
+  });
+});
+
+describe('AccountRoleSelectButtonAndModal - handleAccountClick navigation', () => {
+  const accounts = [
+    {
+      Name: 'current-account',
+      id: '000000000000',
+      Roles: [{ Name: 'storage-manager-role', Arn: STORAGE_MANAGER_ARN }],
+    },
+    {
+      Name: 'another-account',
+      id: '111111111111',
+      Roles: [{ Name: 'storage-manager-role', Arn: ANOTHER_ACCOUNT_STORAGE_MANAGER_ARN }],
+    },
+  ];
+
+  beforeAll(() => {
+    mockOffsetSize(200, 800);
+  });
+
+  beforeEach(() => {
+    mockNavigate.mockReset();
+  });
+
+  afterEach(() => {
+    useAccountsSpy?.mockRestore();
+  });
+
+  it('navigates to /accounts/{assumedAccount}/buckets on a param-less route like /workflows', async () => {
+    await renderOpenModalOnRoute(
+      [{ Name: 'storage-manager-role', Arn: ANOTHER_ACCOUNT_STORAGE_MANAGER_ARN }],
+      accounts,
+      '/workflows',
+    );
+
+    await userEvent.click(await screen.findByText('another-account'));
+
+    const continueButton = screen.getByRole('button', { name: /Continue/i });
+    await userEvent.click(continueButton);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/accounts/another-account/buckets');
+  });
+
+  it('navigates to /accounts/{assumedAccount}/buckets on a route with :accountName param', async () => {
+    await renderOpenModalOnRoute(
+      [{ Name: 'storage-manager-role', Arn: ANOTHER_ACCOUNT_STORAGE_MANAGER_ARN }],
+      accounts,
+      '/accounts/current-account/buckets',
+    );
+
+    await userEvent.click(await screen.findByText('another-account'));
+
+    const continueButton = screen.getByRole('button', { name: /Continue/i });
+    await userEvent.click(continueButton);
+
+    expect(mockNavigate).toHaveBeenCalledWith('/accounts/another-account/buckets');
   });
 });

--- a/src/react/account/__tests__/AccountRoleSelectButtonAndModal.test.tsx
+++ b/src/react/account/__tests__/AccountRoleSelectButtonAndModal.test.tsx
@@ -33,7 +33,6 @@ async function renderOpenModal(roles: { Name: string; Arn: string }[]) {
 }
 
 async function renderOpenModalOnRoute(
-  roles: { Name: string; Arn: string }[],
   accounts: { Name: string; id: string; Roles: { Name: string; Arn: string }[] }[],
   route: string,
 ) {
@@ -128,7 +127,6 @@ describe('AccountRoleSelectButtonAndModal - handleAccountClick navigation', () =
 
   it('navigates to /accounts/{assumedAccount}/buckets on a param-less route like /workflows', async () => {
     await renderOpenModalOnRoute(
-      [{ Name: 'storage-manager-role', Arn: ANOTHER_ACCOUNT_STORAGE_MANAGER_ARN }],
       accounts,
       '/workflows',
     );
@@ -143,7 +141,6 @@ describe('AccountRoleSelectButtonAndModal - handleAccountClick navigation', () =
 
   it('navigates to /accounts/{assumedAccount}/buckets on a route with :accountName param', async () => {
     await renderOpenModalOnRoute(
-      [{ Name: 'storage-manager-role', Arn: ANOTHER_ACCOUNT_STORAGE_MANAGER_ARN }],
       accounts,
       '/accounts/current-account/buckets',
     );

--- a/src/react/account/__tests__/AccountRoleSelectButtonAndModal.test.tsx
+++ b/src/react/account/__tests__/AccountRoleSelectButtonAndModal.test.tsx
@@ -5,6 +5,7 @@ import userEvent from '@testing-library/user-event';
 import { mockOffsetSize, renderWithCustomRoute, Wrapper } from '../../utils/testUtil';
 import AccountRoleSelectButtonAndModal from '../AccountRoleSelectButtonAndModal';
 import * as hooks from '../../utils/hooks';
+import * as moduleFederation from '@scality/module-federation';
 
 const STORAGE_MANAGER_ARN = 'arn:aws:iam::000000000000:role/scality-internal/storage-manager-role';
 const STORAGE_USAGE_CONSUMER_ARN = 'arn:aws:iam::000000000000:role/scality-internal/storage-usage-consumer-role';
@@ -13,10 +14,6 @@ const ANOTHER_ACCOUNT_STORAGE_MANAGER_ARN =
   'arn:aws:iam::111111111111:role/scality-internal/storage-manager-role';
 
 const mockNavigate = jest.fn();
-jest.mock('@scality/module-federation', () => ({
-  useShellHooks: jest.fn(),
-  useBasenameRelativeNavigate: jest.fn().mockImplementation(() => mockNavigate),
-}));
 
 let useAccountsSpy: jest.SpyInstance;
 
@@ -116,6 +113,10 @@ describe('AccountRoleSelectButtonAndModal - handleAccountClick navigation', () =
       Roles: [{ Name: 'storage-manager-role', Arn: ANOTHER_ACCOUNT_STORAGE_MANAGER_ARN }],
     },
   ];
+
+  beforeAll(() => {
+    jest.spyOn(moduleFederation, 'useBasenameRelativeNavigate').mockReturnValue(mockNavigate);
+  });
 
   beforeEach(() => {
     mockNavigate.mockReset();

--- a/src/react/utils/testUtil.tsx
+++ b/src/react/utils/testUtil.tsx
@@ -523,7 +523,7 @@ export const renderWithCustomRoute = (component: React.ReactNode, route: string)
               <_ConfigContext.Provider value={zenkoUITestConfig}>
                 <_DataServiceRoleContext.Provider
                   //@ts-expect-error fix this when you are working on it
-                  value={{ role, setRole: jest.fn() }}
+                  value={{ role, setRole: jest.fn(), setRolePromise: jest.fn().mockResolvedValue({}) }}
                 >
                   <_ManagementContext.Provider
                     value={{


### PR DESCRIPTION
## Summary

Fix the stale account-selector label after switching roles in the Data Management UI role-selection modal. Two complementary changes:

1. **`useCurrentAccount` (DataServiceRoleProvider)** — swap priority so the active `roleArn`-derived `accountId` is checked before the URL `accountName` param. The role context is now the source of truth for the label.
2. **`handleAccountClick` (AccountRoleSelectButtonAndModal)** — build the destination path explicitly via `navigateWithBasename('/accounts/{assumedAccount}/buckets')` instead of using `pathname.replace(accountName, ...)`, which silently no-ops on routes without an `:accountName` segment (e.g. `/workflows`).

## Links

- JIRA: [ARTESCA-17582](https://scality.atlassian.net/browse/ARTESCA-17582)
- Tracking issue: scality/agent-task#221

## Step Adherence

- [x] Step 1: Swap `useCurrentAccount` priority to prefer `roleArn` (`src/react/DataServiceRoleProvider.tsx`)
- [x] Step 2: Fix `handleAccountClick` to build path explicitly (`src/react/account/AccountRoleSelectButtonAndModal.tsx`)
- [x] Step 3: Add tests for `useCurrentAccount` priority fix (`src/react/__tests__/DataServiceRoleProvider.test.tsx`)
- [x] Step 4: Add tests for `handleAccountClick` robust navigation (`src/react/account/__tests__/AccountRoleSelectButtonAndModal.test.tsx`)

## Approved Deviations

- **Step 2 (extra-import / files-outside-list — minor):** Removed the now-unused `useLocation`, `useNavigate`, `useParams` imports from `react-router` inside `ModalFooter` since they were only used by the previous `pathname.replace` logic. Keeping them would have caused TypeScript "declared but never used" errors.

## Simplification Pass

A simplification pass was attempted but produced changes far beyond the scope of the lines introduced by this PR (refactoring of unrelated code in the assume-role query, credential provider, role-name cell renderer, etc.). Those changes were reverted to keep this PR tightly scoped to the bug fix. No simplification commit was made.

## Test Strategy

Framework: Jest + React Testing Library, mirroring the canonical patterns from `DataServiceRoleProvider.test.tsx` (renderHook + `jest.spyOn`) and `ISVConfiguration.test.tsx` (mocking `useBasenameRelativeNavigate`).

Test cases added:
- `useCurrentAccount` — `roleArn` account takes priority over URL `accountName` when both are present
- `useCurrentAccount` — falls back to URL `accountName` when `roleArn` is empty/absent
- `useCurrentAccount` — returns `undefined` when neither is present
- `handleAccountClick` on a param-less route (`/workflows`) — calls `navigateWithBasename('/accounts/{assumedAccount}/buckets')`
- `handleAccountClick` on a `/accounts/:accountName/...` route — still navigates to the new account path correctly

**Note on local test execution:** Tests could not be executed locally due to a pre-existing repo-wide test-infrastructure issue (`Cannot find module '@scality/data-browser-library' from 'jestSetupAfterEnv.tsx'`) that also affects the canonical test files. This is unrelated to the changes in this PR. CI will run the tests.

## Manual Verification

Sign in with a role that spans multiple accounts, navigate to `/workflows` (or another param-less route), open the role-selection modal, pick a role belonging to a different account, and confirm the top-level selector label updates to the new account name.

## Risks

- `useCurrentAccount` priority swap affects every consumer of the hook (e.g. `AccountUserList`, `AccountRoleSelectButtonAndModal` label). On routes that carry a valid `:accountName` param matching the active role, the new priority is functionally equivalent — the only observable change is on the stale/mismatch case being fixed.
- Option B's unconditional navigation to `/accounts/{X}/buckets` lands the user on the Buckets page even if they were originally on a non-bucket page (workflows, metrics). This matches the pre-existing behaviour for bucket-related paths and avoids the no-op bug for everything else.


[ARTESCA-17582]: https://scality.atlassian.net/browse/ARTESCA-17582?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ