### PR TITLE
fix(ARTESCA-17607): fix Rubrik bucket name UX issues (points 2-6)

### DIFF
--- a/src/react/ISV/components/BucketField.tsx
+++ b/src/react/ISV/components/BucketField.tsx
@@ -64,6 +64,7 @@ const useBucketCountManager = ({
 
 interface BucketFieldProps {
   bucketNameTooltip?: React.ReactElement;
+  bucketNameHelpText?: string;
   platform?: string;
   showCapacity?: boolean;
 }
@@ -80,7 +81,7 @@ interface FormValues {
   bucketNumber?: number;
 }
 
-const defaultBucketNameTooltip = <Text>Choose an unique name for your bucket</Text>;
+const defaultBucketNameTooltip = <Text>Choose a unique name for your bucket</Text>;
 
 const BucketContainer = styled.div`
   background-color: ${({ theme }) => theme.backgroundLevel2};
@@ -98,7 +99,8 @@ const BucketNameFormGroup: React.FC<{
   bucketNamePlaceholder: string;
   bucketNumber: number;
   bucketNameTooltip: React.ReactElement;
-}> = ({ index, errors, bucketNamePlaceholder, bucketNumber, bucketNameTooltip }) => {
+  bucketNameHelpText?: string;
+}> = ({ index, errors, bucketNamePlaceholder, bucketNumber, bucketNameTooltip, bucketNameHelpText }) => {
   const { register } = useFormContext<FormValues>();
 
   return (
@@ -107,6 +109,7 @@ const BucketNameFormGroup: React.FC<{
       label={bucketNumber > 1 ? `Bucket #${index + 1} name` : 'Bucket name'}
       required
       labelHelpTooltip={bucketNameTooltip}
+      help={bucketNameHelpText}
       error={(errors?.buckets?.[index]?.name?.message as string) ?? ''}
       helpErrorPosition="bottom"
       content={
@@ -124,6 +127,7 @@ const BucketNameFormGroup: React.FC<{
 
 const BucketField: React.FC<BucketFieldProps> = ({
   bucketNameTooltip = defaultBucketNameTooltip,
+  bucketNameHelpText,
   platform,
   showCapacity,
 }) => {
@@ -213,6 +217,7 @@ const BucketField: React.FC<BucketFieldProps> = ({
             bucketNamePlaceholder={bucketNamePlaceholder}
             bucketNumber={fields.length}
             bucketNameTooltip={bucketNameTooltip}
+            bucketNameHelpText={bucketNameHelpText}
           />
           {renderCapacitySection(0)}
         </FormSection>
@@ -227,6 +232,7 @@ const BucketField: React.FC<BucketFieldProps> = ({
               bucketNamePlaceholder={bucketNamePlaceholder}
               bucketNumber={fields.length}
               bucketNameTooltip={bucketNameTooltip}
+              bucketNameHelpText={bucketNameHelpText}
             />
             <div
               style={{
@@ -240,7 +246,7 @@ const BucketField: React.FC<BucketFieldProps> = ({
       ));
     }
     return null;
-  }, [fields, errors, bucketNamePlaceholder, bucketNameTooltip, renderCapacitySection]);
+  }, [fields, errors, bucketNamePlaceholder, bucketNameTooltip, bucketNameHelpText, renderCapacitySection]);
 
   return (
     <>

--- a/src/react/ISV/components/fields/BucketArrayField.tsx
+++ b/src/react/ISV/components/fields/BucketArrayField.tsx
@@ -19,6 +19,7 @@ export const BucketArrayField: React.FC<BucketArrayFieldProps> = ({ field, platf
     <BucketField
       platform={platform}
       bucketNameTooltip={field.tooltip as React.ReactElement}
+      bucketNameHelpText={field.helpText}
       showCapacity={hasCapacityField}
     />
   );

--- a/src/react/ISV/engine/builders/buildFields.ts
+++ b/src/react/ISV/engine/builders/buildFields.ts
@@ -114,6 +114,8 @@ export function buildFields(config: PlatformConfig): FieldDef[] {
     name: 'buckets',
     type: 'bucketArray',
     label: 'Buckets',
+    tooltip: config.fieldOverrides?.bucketName?.tooltip,
+    helpText: config.fieldOverrides?.bucketName?.helpText,
     itemFields: buildBucketItemFields(config),
   } as FieldDef);
 
@@ -122,7 +124,7 @@ export function buildFields(config: PlatformConfig): FieldDef[] {
   const immutableBase = applyOverrides(
     {
       label: 'Immutable Backup',
-      helpText: 'It enables object-lock on the bucket which means backups will be permanent and unchangeable.',
+      helpText: 'Enables object lock on the bucket, making backups permanent and unchangeable.',
     },
     immutableOverride,
   );

--- a/src/react/ISV/engine/validators.ts
+++ b/src/react/ISV/engine/validators.ts
@@ -139,7 +139,10 @@ export const CommvaultValidator = Joi.object({
 // Rubrik CDM requires buckets to follow the {prefix}-rubrik-{N} naming convention
 const rubrikBucketNameSchema = bucketNameValidationSchema
   .pattern(/^[a-z0-9.-]+-rubrik-\d+$/, { name: 'rubrikSuffix' })
-  .messages({ 'string.pattern.name': 'Bucket name must end with -rubrik-{N} (e.g. my-archive-rubrik-0)' });
+  .messages({
+    'string.min': 'Bucket name must end with -rubrik-<number> (e.g. my-archive-rubrik-0)',
+    'string.pattern.name': 'Bucket name must end with -rubrik-<number> (e.g. my-archive-rubrik-0)',
+  });
 
 const rubrikBucketItemSchema = Joi.object({ name: rubrikBucketNameSchema }).unknown(true);
 

--- a/src/react/ISV/platforms/rubrik.tsx
+++ b/src/react/ISV/platforms/rubrik.tsx
@@ -111,6 +111,7 @@ export const RubrikPlatform = definePlatform({
       label: 'Bucket name',
       placeholder: 'Enter bucket name (e.g. my-archive-rubrik-0)',
       tooltip: <BucketNameTooltip platform="Rubrik" />,
+      helpText: 'Must end with -rubrik-<number> (e.g. my-archive-rubrik-0)',
     },
     IAMUserName: {
       label: 'IAM User Name',


### PR DESCRIPTION
## Summary

Fixes points 2–6 from [ARTESCA-17607](https://scality.atlassian.net/browse/ARTESCA-17607) — UX issues on the bucket name field and form validation in the Rubrik ISV assistant.

- **Point 2 — Error message discrepancy**: `{N}` in the Joi message string was treated as a Joi template variable and resolved to empty, producing `"must end with -rubrik-"`. Replaced with literal `<number>` in both `string.min` and `string.pattern.name` messages.
- **Point 3 — Help text visibility**: Wired `helpText` from `fieldOverrides.bucketName` through `buildFields` → `BucketArrayField` → `BucketField` → `FormGroup.help` so the format requirement renders as visible text below the field instead of being hidden behind the IconHelp tooltip.
- **Point 4 — Tooltip font size**: Wired `tooltip` from `fieldOverrides.bucketName` through the same chain so the platform-specific tooltip (using `ListItem`, consistent with other fields) is used instead of the fallback plain `<Text>` tooltip.
- **Point 5 — "an unique"**: Fixed `"Choose an unique name"` → `"Choose a unique name"` in `defaultBucketNameTooltip`.
- **Point 6 — Immutable Backup help text**: Updated to `"Enables object lock on the bucket, making backups permanent and unchangeable."`.

## Test plan

- [ ] In the Rubrik ISV assistant, enter a bucket name shorter than 3 chars — error should read `Bucket name must end with -rubrik-<number> (e.g. my-archive-rubrik-0)`
- [ ] Enter a bucket name without the `-rubrik-<N>` suffix — same error message
- [ ] Verify helper text `Must end with -rubrik-<number> (e.g. my-archive-rubrik-0)` is visible below the bucket name field without opening any tooltip
- [ ] Verify the tooltip font matches other fields (uses ListItem structure)
- [ ] Check the Immutable Backup toggle shows the updated helper text
- [ ] Run unit tests: `npx jest --testNamePattern="rubrik|Rubrik"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ARTESCA-17607]: https://scality.atlassian.net/browse/ARTESCA-17607?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ