### PR TITLE
ZKUI-477: Bump data-browser-library to 1.1.24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@scality/certchain": "1.4.0",
         "@scality/core-ui": "0.218.0",
-        "@scality/data-browser-library": "1.1.21",
+        "@scality/data-browser-library": "1.1.24",
         "@scality/module-federation": "1.6.1",
         "@scality/react-chained-query": "^2.1.0",
         "@types/react-table": "^7.7.10",
@@ -5691,9 +5691,9 @@
       }
     },
     "node_modules/@scality/data-browser-library": {
-      "version": "1.1.21",
-      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.21.tgz",
-      "integrity": "sha512-en3kYM6XIUfDmfgoFPi/s7m5sBio7vBD5Fz/lDr5lzzdcJXJUEBXIQiDxGxvR5tn1jYNblTEXgbyCPekHYxFRg==",
+      "version": "1.1.24",
+      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.24.tgz",
+      "integrity": "sha512-+u7pklwzVoV3B4Q8JHgCfiTwt4GhoURh8sNdcHSS99BWA3IMvT7hUY5aqRKkaBP3rqAejKuzHqZDoUJajYGkSQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.983.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@scality/certchain": "1.4.0",
     "@scality/core-ui": "0.218.0",
-    "@scality/data-browser-library": "1.1.21",
+    "@scality/data-browser-library": "1.1.24",
     "@scality/module-federation": "1.6.1",
     "@scality/react-chained-query": "^2.1.0",
     "@types/react-table": "^7.7.10",


### PR DESCRIPTION
## Summary
Automated bump of `@scality/data-browser-library`.

## Links
- Release: https://github.com/scality/data-browser/releases/tag/1.1.24
- Jira: https://scality.atlassian.net/browse/ZKUI-477

🤖 Generated by data-browser auto-bump