### PR TITLE
chore(deps): bump @scality/data-browser-library to 1.1.25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@scality/certchain": "1.4.0",
         "@scality/core-ui": "0.219.0",
-        "@scality/data-browser-library": "1.1.24",
+        "@scality/data-browser-library": "1.1.25",
         "@scality/module-federation": "1.6.1",
         "@scality/react-chained-query": "^2.1.0",
         "@types/react-table": "^7.7.10",
@@ -5691,9 +5691,9 @@
       }
     },
     "node_modules/@scality/data-browser-library": {
-      "version": "1.1.24",
-      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.24.tgz",
-      "integrity": "sha512-+u7pklwzVoV3B4Q8JHgCfiTwt4GhoURh8sNdcHSS99BWA3IMvT7hUY5aqRKkaBP3rqAejKuzHqZDoUJajYGkSQ==",
+      "version": "1.1.25",
+      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.25.tgz",
+      "integrity": "sha512-XMkhYp+sT4MZ+2RukzRAG4vQhkznEsE62WRnvmkyPqI5ASoHi0FdraCD21TQK/VYnNPM1YUfA9E8o2PuInUxHA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.983.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@scality/certchain": "1.4.0",
     "@scality/core-ui": "0.219.0",
-    "@scality/data-browser-library": "1.1.24",
+    "@scality/data-browser-library": "1.1.25",
     "@scality/module-federation": "1.6.1",
     "@scality/react-chained-query": "^2.1.0",
     "@types/react-table": "^7.7.10",


### PR DESCRIPTION
## Summary

Bumps `@scality/data-browser-library` from `1.1.24` to `1.1.25` in `package.json` and regenerates `package-lock.json` to reflect the new resolved version. Pure patch-level dependency update — no source-code changes required.

## Tracking

- JIRA: [ZKUI-501](https://scality.atlassian.net/browse/ZKUI-501)
- Issue: scality/agent-task#231

## Step Adherence

- [x] Step 1: Bump @scality/data-browser-library to 1.1.25 (`package.json`, `package-lock.json`)

Mirrors the canonical pattern from prior bump commit `7fad53f7` (ZKUI-477: Bump data-browser-library to 1.1.24) — same two-file change shape.

## Test Strategy Executed

- `npm test` — exit code 0 (Jest config allows "no tests found" success).
- `npm run check-types` — TypeScript compiles cleanly against 1.1.25. One pre-existing TS2307 error unrelated to this change was observed (no regression introduced).

## Risks

Any unexpected breaking change in 1.1.25 (despite SemVer patch level) would surface via `npm run check-types` or Jest failures — none observed.


[ZKUI-501]: https://scality.atlassian.net/browse/ZKUI-501?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ