### PR TITLE
improvement(ARTESCA-17610): remove useless Data Browser guard for storage-usage-consumer role

### DIFF
--- a/src/react/Routes.test.tsx
+++ b/src/react/Routes.test.tsx
@@ -454,7 +454,7 @@ describe('Routes component', () => {
     });
   });
 
-  describe('Data Browser route guards', () => {
+  describe('Data Browser sidebar', () => {
     const STORAGE_USAGE_CONSUMER_ARN = 'arn:aws:iam::000000000000:role/scality-internal/storage-usage-consumer-role';
     const STORAGE_MANAGER_ARN = 'arn:aws:iam::000000000000:role/scality-internal/storage-manager-role';
     const STORAGE_ACCOUNT_OWNER_ARN = 'arn:aws:iam::000000000000:role/scality-internal/storage-account-owner-role';
@@ -463,128 +463,42 @@ describe('Routes component', () => {
       removeRoleArnStored();
     });
 
-    describe('accounts/:accountName/data/buckets route', () => {
-      it('should render ErrorPage401 for storage-usage-consumer-role ARN', async () => {
-        setRoleArnStored(STORAGE_USAGE_CONSUMER_ARN);
+    it('should show Data Browser sidebar entry for storage-usage-consumer-role ARN', async () => {
+      setRoleArnStored(STORAGE_USAGE_CONSUMER_ARN);
 
-        renderWithRouterMatch(<PrivateRoutes />, {
-          path: '/*',
-          route: '/accounts/test/data/buckets',
-        });
-
-        await waitFor(() => {
-          expect(screen.getByText(/Not authorized/i)).toBeInTheDocument();
-        });
+      renderWithRouterMatch(<InternalRoutes />, {
+        path: '/*',
+        route: '/accounts',
       });
 
-      it('should render Data Browser for storage-manager-role ARN', async () => {
-        setRoleArnStored(STORAGE_MANAGER_ARN);
-
-        renderWithRouterMatch(<PrivateRoutes />, {
-          path: '/*',
-          route: '/accounts/test/data/buckets',
-        });
-
-        await waitFor(() => {
-          expect(screen.queryByText(/Not authorized/i)).not.toBeInTheDocument();
-        });
+      await waitFor(() => {
+        expect(screen.queryByText('Data Browser')).toBeInTheDocument();
       });
     });
 
-    describe('accounts/:accountName/buckets route', () => {
-      it('should render ErrorPage401 for storage-usage-consumer-role ARN', async () => {
-        setRoleArnStored(STORAGE_USAGE_CONSUMER_ARN);
+    it('should show Data Browser sidebar entry for storage-manager-role ARN', async () => {
+      setRoleArnStored(STORAGE_MANAGER_ARN);
 
-        renderWithRouterMatch(<PrivateRoutes />, {
-          path: '/*',
-          route: '/accounts/test/buckets',
-        });
-
-        await waitFor(() => {
-          expect(screen.getByText(/Not authorized/i)).toBeInTheDocument();
-        });
+      renderWithRouterMatch(<InternalRoutes />, {
+        path: '/*',
+        route: '/accounts',
       });
 
-      it('should render Data Browser for storage-manager-role ARN', async () => {
-        setRoleArnStored(STORAGE_MANAGER_ARN);
-
-        renderWithRouterMatch(<PrivateRoutes />, {
-          path: '/*',
-          route: '/accounts/test/buckets',
-        });
-
-        await waitFor(() => {
-          expect(screen.queryByText(/Not authorized/i)).not.toBeInTheDocument();
-        });
+      await waitFor(() => {
+        expect(screen.queryByText('Data Browser')).toBeInTheDocument();
       });
     });
 
-    describe('buckets route', () => {
-      it('should render ErrorPage401 for storage-usage-consumer-role ARN', async () => {
-        setRoleArnStored(STORAGE_USAGE_CONSUMER_ARN);
+    it('should show Data Browser sidebar entry for storage-account-owner-role ARN', async () => {
+      setRoleArnStored(STORAGE_ACCOUNT_OWNER_ARN);
 
-        renderWithRouterMatch(<PrivateRoutes />, {
-          path: '/*',
-          route: '/buckets',
-        });
-
-        await waitFor(() => {
-          expect(screen.getByText(/Not authorized/i)).toBeInTheDocument();
-        });
+      renderWithRouterMatch(<InternalRoutes />, {
+        path: '/*',
+        route: '/accounts',
       });
 
-      it('should render redirect or empty state for storage-manager-role ARN', async () => {
-        setRoleArnStored(STORAGE_MANAGER_ARN);
-
-        renderWithRouterMatch(<PrivateRoutes />, {
-          path: '/*',
-          route: '/buckets',
-        });
-
-        await waitFor(() => {
-          expect(screen.queryByText(/Not authorized/i)).not.toBeInTheDocument();
-        });
-      });
-    });
-
-    describe('sidebar Data Browser entry gating', () => {
-      it('should hide Data Browser sidebar entry for storage-usage-consumer-role ARN', async () => {
-        setRoleArnStored(STORAGE_USAGE_CONSUMER_ARN);
-
-        renderWithRouterMatch(<InternalRoutes />, {
-          path: '/*',
-          route: '/accounts',
-        });
-
-        await waitFor(() => {
-          expect(screen.queryByText('Data Browser')).not.toBeInTheDocument();
-        });
-      });
-
-      it('should show Data Browser sidebar entry for storage-manager-role ARN', async () => {
-        setRoleArnStored(STORAGE_MANAGER_ARN);
-
-        renderWithRouterMatch(<InternalRoutes />, {
-          path: '/*',
-          route: '/accounts',
-        });
-
-        await waitFor(() => {
-          expect(screen.queryByText('Data Browser')).toBeInTheDocument();
-        });
-      });
-
-      it('should show Data Browser sidebar entry for storage-account-owner-role ARN', async () => {
-        setRoleArnStored(STORAGE_ACCOUNT_OWNER_ARN);
-
-        renderWithRouterMatch(<InternalRoutes />, {
-          path: '/*',
-          route: '/accounts',
-        });
-
-        await waitFor(() => {
-          expect(screen.queryByText('Data Browser')).toBeInTheDocument();
-        });
+      await waitFor(() => {
+        expect(screen.queryByText('Data Browser')).toBeInTheDocument();
       });
     });
   });

--- a/src/react/Routes.tsx
+++ b/src/react/Routes.tsx
@@ -25,7 +25,7 @@ import STSProvider from './STSProvider';
 import ImportCertificate from './truststore/ImportCertificate';
 import Truststore from './truststore/Truststore';
 import ReauthDialog from './ui-elements/ReauthDialog';
-import { getIsStorageUsageConsumerRole, useAuthGroups } from './utils/hooks';
+import { useAuthGroups } from './utils/hooks';
 
 export const RemoveTrailingSlash = ({ ...rest }) => {
   const location = useLocation();
@@ -69,8 +69,6 @@ const RedirectToAccount = () => {
   }
 };
 
-const DataBrowserGuard = ({ children }: { children: JSX.Element }): JSX.Element =>
-  getIsStorageUsageConsumerRole() ? <ErrorPage401 /> : children;
 
 export function PrivateRoutes({ hideSideBar = false }: { hideSideBar?: boolean }): JSX.Element {
   const { isClientsLoaded } = useAuthLoading();
@@ -220,21 +218,17 @@ export function PrivateRoutes({ hideSideBar = false }: { hideSideBar?: boolean }
       <Route
         path="accounts/:accountName/data/buckets/*"
         element={
-          <DataBrowserGuard>
-            <DataServiceRoleProvider>
-              <DataBrowser hideHeader={hideSideBar} />
-            </DataServiceRoleProvider>
-          </DataBrowserGuard>
+          <DataServiceRoleProvider>
+            <DataBrowser hideHeader={hideSideBar} />
+          </DataServiceRoleProvider>
         }
       />
       <Route
         path="accounts/:accountName/buckets/*"
         element={
-          <DataBrowserGuard>
-            <DataServiceRoleProvider>
-              <DataBrowser hideHeader={hideSideBar} />
-            </DataServiceRoleProvider>
-          </DataBrowserGuard>
+          <DataServiceRoleProvider>
+            <DataBrowser hideHeader={hideSideBar} />
+          </DataServiceRoleProvider>
         }
       />
       <Route
@@ -256,11 +250,9 @@ export function PrivateRoutes({ hideSideBar = false }: { hideSideBar?: boolean }
       <Route
         path="buckets/*"
         element={
-          <DataBrowserGuard>
-            <DataServiceRoleProvider>
-              <RedirectToAccount />
-            </DataServiceRoleProvider>
-          </DataBrowserGuard>
+          <DataServiceRoleProvider>
+            <RedirectToAccount />
+          </DataServiceRoleProvider>
         }
       />
       <Route path="/" element={<Navigate to="accounts" replace />} />
@@ -276,8 +268,6 @@ function InternalRoutes(): JSX.Element {
   const location = useLocation();
   const { isStorageManager, isPlatformAdmin } = useAuthGroups();
   const config = useConfig();
-
-  const isStorageUsageConsumerRole = getIsStorageUsageConsumerRole();
 
   const metalK8sInstances = useDeployedMetalk8sInstances();
   const isMetalK8sEnabled = metalK8sInstances.length > 0;
@@ -339,7 +329,7 @@ function InternalRoutes(): JSX.Element {
           doesRouteMatch('/accounts/:accountName/users') ||
           doesRouteMatch('/accounts/:accountName/policies'),
       },
-      !isStorageUsageConsumerRole && {
+      {
         label: 'Data Browser',
         icon: <Icon name="Bucket" />,
         onClick: () => {

--- a/src/react/utils/hooks.ts
+++ b/src/react/utils/hooks.ts
@@ -150,9 +150,6 @@ export const SCALITY_INTERNAL_ROLES = [
 ];
 export const SCALITY_IAM_ROLES = [STORAGE_ACCOUNT_OWNER_ROLE, DATA_CONSUMER_ROLE, DATA_ACCESSOR_ROLE];
 
-export function getIsStorageUsageConsumerRole(): boolean {
-  return regexArn.exec(getRoleArnStored())?.groups?.name === STORAGE_USAGE_CONSUMER_ROLE;
-}
 
 export const defaultEventDispatcher = () => {
   const { handleClientError, showModalError } = useErrorHandler();


### PR DESCRIPTION
## Summary

- Removes `DataBrowserGuard` component that blocked Data Browser routes for the `storage-usage-consumer` role
- Removes `isStorageUsageConsumerRole` sidebar hiding that hid the Data Browser link
- Removes `getIsStorageUsageConsumerRole()` helper (only used for the guard)
- Updates tests to reflect that the Data Browser is now accessible to all roles

## Why

The guard relied on reading the role ARN from localStorage, which caused a race condition on login/logout: the stale role ARN would briefly give the wrong result, causing the Data Browser to flash hidden or visible for the wrong user.

The data-browser library (bumped in ZKUI-477) now shows a proper "Permission denied" message when `ListBuckets` returns a 403, which is the correct place to handle this — it reacts to the actual API response rather than cached state.

## Test plan

- [ ] Log in as a `storage-usage-consumer` user — Data Browser sidebar entry is visible
- [ ] Navigate to Data Browser as `storage-usage-consumer` — "Permission denied" message is shown
- [ ] Log out and log in as a `storage-manager` user — Data Browser works normally with no flicker
- [ ] All Routes tests pass