### PR TITLE
ZKUI-505: Bump data-browser-library to 1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@scality/certchain": "1.4.0",
         "@scality/core-ui": "0.218.0",
-        "@scality/data-browser-library": "1.1.24",
+        "@scality/data-browser-library": "1.2.1",
         "@scality/module-federation": "1.6.1",
         "@scality/react-chained-query": "^2.1.0",
         "@types/react-table": "^7.7.10",
@@ -5691,9 +5691,9 @@
       }
     },
     "node_modules/@scality/data-browser-library": {
-      "version": "1.1.24",
-      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.1.24.tgz",
-      "integrity": "sha512-+u7pklwzVoV3B4Q8JHgCfiTwt4GhoURh8sNdcHSS99BWA3IMvT7hUY5aqRKkaBP3rqAejKuzHqZDoUJajYGkSQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.2.1.tgz",
+      "integrity": "sha512-U/7PjHvpPucX4XdLtogZlXcOs9F0ugVGP9Ol7BrkJ6bLcufnCP7rXcZog5qPVAu7Ql5fiN/bOdxoNCS4nRmX9A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.983.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@scality/certchain": "1.4.0",
     "@scality/core-ui": "0.218.0",
-    "@scality/data-browser-library": "1.1.24",
+    "@scality/data-browser-library": "1.2.1",
     "@scality/module-federation": "1.6.1",
     "@scality/react-chained-query": "^2.1.0",
     "@types/react-table": "^7.7.10",


### PR DESCRIPTION
## Summary
Automated bump of `@scality/data-browser-library`.

## Links
- Release: https://github.com/scality/data-browser/releases/tag/1.2.1
- Jira: https://scality.atlassian.net/browse/ZKUI-505

🤖 Generated by data-browser auto-bump