### PR TITLE
feature(crr): add useCRRFeature hook

### DIFF
--- a/src/react/locations/CRRSetupWizard/hooks/useCRRFeature.ts
+++ b/src/react/locations/CRRSetupWizard/hooks/useCRRFeature.ts
@@ -1,0 +1,7 @@
+import { useConfig } from '../../../next-architecture/ui/ConfigProvider';
+
+export const useCRRFeature = () => {
+  const { features } = useConfig();
+
+  return features.includes('CRR_CONFIGURATOR');
+};


### PR DESCRIPTION
## Summary

Ships the feature-flag hook that gates the future CRR Provisioning Wizard on this deployment.
```ts
export const useCRRFeature = () => {
  const { features } = useConfig();
  return features.includes('CRR');
};
```

Consumers use it as a plain boolean: `const isCRREnabled = useCRRFeature();`. Nothing references the hook yet — the wizard components arrive in follow-up PRs and start gating their entry points on it.

## Why a standalone PR

Small, mechanical change. Landing the hook first lets follow-up PRs already import from a stable path (`src/react/locations/CRRSetupWizard/hooks/useCRRFeature`) instead of reintroducing the same lookup boilerplate at every gate site.


Issue: ARTESCA-16787