### PR TITLE
fix(isv): gate VBR auto-create repository default on ARTESCA+ Veeam deployment

### DIFF
--- a/src/react/ISV/components/ISVConfiguration.tsx
+++ b/src/react/ISV/components/ISVConfiguration.tsx
@@ -9,6 +9,7 @@ import { useSearchParams } from 'react-router';
 import { DEFAULT_IMMUTABLE_PERIOD_DAYS, VEEAM_OFFICE_365 } from '../constants';
 import { FormData, ISVPlatform } from '../engine/types';
 import { getCapacityBytes } from '../hooks/useCapacityUnit';
+import { useIsVeeamVBROnly } from '../hooks/useIsVeeamVBROnly';
 import { FormRenderer } from './FormRenderer';
 import { ISVFormProvider, useISVFormContext } from './ISVFormContext';
 import { ISVSkipModal } from './ISVSkipModal';
@@ -103,9 +104,10 @@ const ISVConfigurationInner = ({ formMethods }: ISVConfigurationInnerProps) => {
   );
 };
 
-const getDefaultFormValues = (
+export const getDefaultFormValues = (
   platform: ISVPlatform,
   paramsAccountName: string | null,
+  isVeeamVBROnly: boolean,
 ): Partial<FormData> => {
   const hasImmutableField = platform.fields.some((f) => f.name === 'enableImmutableBackup');
   const baseDefaults: Partial<FormData> = {
@@ -130,7 +132,12 @@ const getDefaultFormValues = (
 
   const defaults = { ...fieldDefaults, ...baseDefaults };
 
-  if (platform.id === 'veeam-vbr') {
+  // Auto-create repository is only offered for the Veeam VBR assistant AND only on
+  // ARTESCA+ Veeam deployments (artesca_plus_veeam flag). Its toggle in
+  // VeeamRepositoryFields is gated on isVeeamVBROnly, so the default must match:
+  // gating on platform.id alone leaks the default onto classical deployments where
+  // the toggle is hidden, silently triggering repository creation (ARTESCA-17881).
+  if (platform.id === 'veeam-vbr' && isVeeamVBROnly) {
     return {
       ...defaults,
       autoCreateRepository: true,
@@ -145,10 +152,11 @@ export const ISVConfiguration = () => {
   const { platform } = useISVStepper();
   const [searchParams] = useSearchParams();
   const paramsAccountName = searchParams.get('account');
+  const isVeeamVBROnly = useIsVeeamVBROnly();
 
   const formMethods = useForm<FormData>({
     mode: 'all',
-    defaultValues: getDefaultFormValues(platform, paramsAccountName),
+    defaultValues: getDefaultFormValues(platform, paramsAccountName, isVeeamVBROnly),
     resolver: joiResolver(platform.validator),
     shouldUnregister: false,
   });

--- a/src/react/ISV/components/__tests__/ISVConfiguration.test.tsx
+++ b/src/react/ISV/components/__tests__/ISVConfiguration.test.tsx
@@ -2,13 +2,13 @@ import { act, fireEvent, render, screen, waitFor } from '@testing-library/react'
 import userEvent from '@testing-library/user-event';
 import { useListAccounts } from '../../../next-architecture/domain/business/accounts';
 import { mockShellHooks, renderWithCustomRoute, Wrapper } from '../../../utils/testUtil';
-import { VEEAM_OFFICE_365 } from '../../constants';
+import { DEFAULT_IMMUTABLE_PERIOD_DAYS, VEEAM_OFFICE_365 } from '../../constants';
 import { CommvaultPlatform } from '../../platforms/commvault';
 import { KastenPlatform } from '../../platforms/kasten';
 import { RubrikPlatform } from '../../platforms/rubrik';
 import { VeeamVBOPlatform } from '../../platforms/veeam-vbo';
 import { VeeamVBRPlatform } from '../../platforms/veeam-vbr';
-import { ISVConfiguration } from '../ISVConfiguration';
+import { getDefaultFormValues, ISVConfiguration } from '../ISVConfiguration';
 import { ISVStepperContext } from '../ISVStepperContext';
 
 const mockNavigate = jest.fn();
@@ -1103,5 +1103,26 @@ describe('ISVConfiguration', () => {
         expect(selectors.continueButton()).not.toBeDisabled();
       });
     });
+  });
+});
+
+describe('getDefaultFormValues auto-create repository gating', () => {
+  it('defaults autoCreateRepository to true for VBR on an ARTESCA+ Veeam deployment', () => {
+    const defaults = getDefaultFormValues(VeeamVBRPlatform, null, true);
+
+    expect(defaults.autoCreateRepository).toBe(true);
+    expect(defaults.immutablePeriodDays).toBe(DEFAULT_IMMUTABLE_PERIOD_DAYS);
+  });
+
+  it('does not enable autoCreateRepository for VBR on a non ARTESCA+ (classical) deployment', () => {
+    const defaults = getDefaultFormValues(VeeamVBRPlatform, null, false);
+
+    expect(defaults.autoCreateRepository).toBeUndefined();
+  });
+
+  it('does not enable autoCreateRepository for a non-VBR platform even on an ARTESCA+ Veeam deployment', () => {
+    const defaults = getDefaultFormValues(CommvaultPlatform, null, true);
+
+    expect(defaults.autoCreateRepository).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Problem

[ARTESCA-17881](https://scality.atlassian.net/browse/ARTESCA-17881) — the ARTESCA+ Veeam assistant's repository auto-creation runs on a **classical (non ARTESCA+)** deployment. On an `artesca-demo` AMI, launching the Veeam assistant tried to create the Veeam repository.

## Root cause

Commit `63e3e50` changed the `autoCreateRepository` default gate in `ISVConfiguration.tsx › getDefaultFormValues` from the deployment flag (`isVeeamVBROnly` / `artesca_plus_veeam`) to `platform.id === 'veeam-vbr'`.

That fixed a leak where non-VBR platforms inherited the default on ARTESCA+ deployments, but introduced the inverse regression: on a classical box, selecting the Veeam VBR assistant now defaults `autoCreateRepository` to `true`. The toggle in `VeeamRepositoryFields` is still gated on `isVeeamVBROnly`, so it's **hidden** on a classical deployment — the user can neither see nor disable it — and the ARTESCA+-only steps (`veeamArchiveFolder`, `veeamBackupClientsFolder`, `veeamBackupConfigFolder`, `createVeeamRepo`) fire on `form.autoCreateRepository === true`.

The two conditions are orthogonal: `isVeeamVBROnly` = deployment has the `artesca_plus_veeam` flag; `platform.id === 'veeam-vbr'` = user selected the VBR assistant. The default must require **both**, matching the UI gate.

## Fix

Require `platform.id === 'veeam-vbr' && isVeeamVBROnly`. This restores the deployment gate the commit removed while keeping the platform guard that fixed the earlier non-VBR case.

## Tests

Added regression tests for the default-values gating:
- VBR + ARTESCA+ Veeam → `autoCreateRepository: true` (unchanged behavior)
- VBR + classical (non ARTESCA+) → not set ← the bug
- non-VBR + ARTESCA+ Veeam → not set (guards the case `63e3e50` originally fixed)

Verification:
- Full ISV suite: 344/344 pass
- `tsc --noemit`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[ARTESCA-17881]: https://scality.atlassian.net/browse/ARTESCA-17881?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ