### PR TITLE
feature(crr): add wizard shell and Configure step with source/destination/replication sections

### DIFF
--- a/src/react/Routes.tsx
+++ b/src/react/Routes.tsx
@@ -17,6 +17,8 @@ import DataBrowser from './databrowser/DataBrowser';
 import EndpointCreate from './endpoint/EndpointCreate';
 import Endpoints from './endpoint/Endpoints';
 import { ISVSteps } from './ISV/components/ISVSteps';
+import { CRRSetupWizard } from './locations/CRRSetupWizard/CRRSetupWizard';
+import { useCRRFeature } from './locations/CRRSetupWizard/hooks/useCRRFeature';
 import LocationEditor from './locations/LocationEditor';
 import { Locations } from './locations/Locations';
 import ManagementProvider from './ManagementProvider';
@@ -69,7 +71,6 @@ const RedirectToAccount = () => {
   }
 };
 
-
 export function PrivateRoutes({ hideSideBar = false }: { hideSideBar?: boolean }): JSX.Element {
   const { isClientsLoaded } = useAuthLoading();
   const config = useConfig();
@@ -77,6 +78,7 @@ export function PrivateRoutes({ hideSideBar = false }: { hideSideBar?: boolean }
   const { isPlatformAdmin } = useAuthGroups();
   const metalK8sInstances = useDeployedMetalk8sInstances();
   const isMetalK8sEnabled = metalK8sInstances.length > 0;
+  const isCRRWizardEnabled = useCRRFeature();
   if (!isClientsLoaded) {
     return (
       <Loader centered>
@@ -175,6 +177,16 @@ export function PrivateRoutes({ hideSideBar = false }: { hideSideBar?: boolean }
           </DataServiceRoleProvider>
         }
       />
+      {isCRRWizardEnabled && (
+        <Route
+          path="create-crr-configuration/*"
+          element={
+            <DataServiceRoleProvider>
+              <CRRSetupWizard />
+            </DataServiceRoleProvider>
+          }
+        />
+      )}
       <Route
         path={`accounts/:accountName/policies/:policyArn/attachments/*`}
         element={
@@ -293,6 +305,7 @@ function InternalRoutes(): JSX.Element {
     '/accounts/:accountName/users/:user/update-user',
     '/accounts/:accountName/create-policy',
     '/isv/configuration',
+    '/create-crr-configuration',
     '/truststore/import-certificate',
     '/accounts/:accountName/buckets/-/create',
     '/accounts/:accountName/buckets/:bucketName/lifecycle/create',

--- a/src/react/locations/CRRSetupWizard/CRRSetupWizard.test.tsx
+++ b/src/react/locations/CRRSetupWizard/CRRSetupWizard.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { Wrapper } from '../../utils/testUtil';
+import { CRRSetupWizard } from './CRRSetupWizard';
+
+const VERIFY_URL = '/crr-configurator/api/v1/verify';
+const server = setupServer();
+
+beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+const PEM = '-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----';
+
+/**
+ * Fills the whole Configure form with valid values from a user's point of view —
+ * clicks the labelled inputs by their accessible name, disambiguating the two
+ * "Account Name" fields by the surrounding section title.
+ */
+const fillValidForm = async () => {
+  const accountNameInputs = screen.getAllByRole('textbox', { name: /Account Name/i });
+  const [sourceAccountName, destinationAccountName] = accountNameInputs;
+  await userEvent.type(sourceAccountName, 'source-account');
+  await userEvent.type(screen.getByRole('textbox', { name: /^URL/i }), 'https://10.0.0.42:8443');
+  await userEvent.type(screen.getByRole('textbox', { name: /^Username/i }), 'scality');
+  await userEvent.type(screen.getByLabelText(/^Password/i), 'super-secret');
+  await userEvent.type(screen.getByRole('textbox', { name: /^Certificate/i }), PEM);
+  await userEvent.type(destinationAccountName, 'dest-account');
+};
+
+describe('CRRSetupWizard — Configure step', () => {
+  it('confirms the destination is reachable when the user clicks Check Connection', async () => {
+    server.use(
+      rest.post(VERIFY_URL, (_req, res, ctx) =>
+        res(ctx.json({ ok: true, mode: 'management-network', instanceName: 'ageless-valley' })),
+      ),
+    );
+    render(<CRRSetupWizard />, { wrapper: Wrapper });
+
+    await fillValidForm();
+    await userEvent.click(screen.getByRole('button', { name: /Check Connection/i }));
+
+    expect(await screen.findByText(/Destination reachable/i)).toBeInTheDocument();
+  });
+
+  it('surfaces the ARTESCA problem code when Check Connection is rejected', async () => {
+    server.use(
+      rest.post(VERIFY_URL, (_req, res, ctx) =>
+        res(
+          ctx.status(400),
+          ctx.set('Content-Type', 'application/problem+json'),
+          ctx.body(
+            JSON.stringify({
+              type: 'about:blank',
+              title: 'Invalid destination certificate',
+              status: 400,
+              code: 'DestinationCertificateInvalid',
+            }),
+          ),
+        ),
+      ),
+    );
+    render(<CRRSetupWizard />, { wrapper: Wrapper });
+
+    await fillValidForm();
+    await userEvent.click(screen.getByRole('button', { name: /Check Connection/i }));
+
+    expect(await screen.findByText(/pasted certificate is not a valid PEM/i)).toBeInTheDocument();
+  });
+
+  it('blocks the user on Configure with an error toast when the silent verify fails on Continue', async () => {
+    server.use(
+      rest.post(VERIFY_URL, (_req, res, ctx) =>
+        res(
+          ctx.status(502),
+          ctx.set('Content-Type', 'application/problem+json'),
+          ctx.body(
+            JSON.stringify({
+              type: 'about:blank',
+              title: 'Destination unreachable',
+              status: 502,
+              code: 'DestinationUnreachable',
+            }),
+          ),
+        ),
+      ),
+    );
+    render(<CRRSetupWizard />, { wrapper: Wrapper });
+
+    await fillValidForm();
+    await userEvent.click(screen.getByRole('button', { name: /Continue/i }));
+
+    expect(await screen.findByText(/destination cluster did not respond/i)).toBeInTheDocument();
+  });
+});

--- a/src/react/locations/CRRSetupWizard/CRRSetupWizard.tsx
+++ b/src/react/locations/CRRSetupWizard/CRRSetupWizard.tsx
@@ -1,0 +1,26 @@
+import { Stepper, spacing } from '@scality/core-ui';
+import { Box } from '@scality/core-ui/dist/next';
+import { useTheme } from 'styled-components';
+import { ApplyActionsStep } from './steps/ApplyActionsStep';
+import { ConfigureStep } from './steps/ConfigureStep';
+import { SummaryStep } from './steps/SummaryStep';
+
+const STEPS = [
+  { label: 'Configure', Component: ConfigureStep },
+  { label: 'Apply Actions', Component: ApplyActionsStep },
+  { label: 'Summary', Component: SummaryStep },
+] as const;
+
+export const CRRSetupWizard = () => {
+  const theme = useTheme();
+  return (
+    <Box
+      height="100%"
+      backgroundColor={theme.backgroundLevel4}
+      paddingTop={spacing.r16}
+      style={{ boxSizing: 'border-box' }}
+    >
+      <Stepper steps={STEPS} />
+    </Box>
+  );
+};

--- a/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep.tsx
+++ b/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep.tsx
@@ -1,0 +1,10 @@
+import { Banner, Icon } from '@scality/core-ui';
+import { Box } from '@scality/core-ui/dist/next';
+
+export const ApplyActionsStep = () => (
+  <Box padding="r24">
+    <Banner variant="base" icon={<Icon name="Info-circle" />} title="Apply Actions">
+      This step runs the destination-side setup chain. It lands in the next brick.
+    </Banner>
+  </Box>
+);

--- a/src/react/locations/CRRSetupWizard/steps/ConfigureStep/ConfigureStep.tsx
+++ b/src/react/locations/CRRSetupWizard/steps/ConfigureStep/ConfigureStep.tsx
@@ -68,7 +68,14 @@ export const ConfigureStep = () => {
       'password',
       'certificate',
     ]);
-    if (!valid) return;
+    if (!valid) {
+      showToast({
+        open: true,
+        status: 'error',
+        message: 'Complete the destination fields before checking the connection',
+      });
+      return;
+    }
     const body = toVerifyBody(getValues());
     try {
       await runVerify(body);

--- a/src/react/locations/CRRSetupWizard/steps/ConfigureStep/ConfigureStep.tsx
+++ b/src/react/locations/CRRSetupWizard/steps/ConfigureStep/ConfigureStep.tsx
@@ -1,0 +1,123 @@
+import { Form, Icon, Stack, useToast } from '@scality/core-ui';
+import { useStepper } from '@scality/core-ui/dist/components/steppers/Stepper.component';
+import { Button } from '@scality/core-ui/dist/next';
+import { useBasenameRelativeNavigate } from '@scality/module-federation';
+import { useRef } from 'react';
+import { FormProvider, useForm } from 'react-hook-form';
+import { ServiceError } from '../../api/crrConfiguratorClient';
+import type { ProblemCode, VerifyRequestBody } from '../../api/types';
+import { useCRRConfigurationVerifyMutation } from '../../hooks/useCRRConfigurationVerifyMutation';
+import { DestinationAccountSection } from './DestinationAccountSection';
+import { DestinationConnectionSection } from './DestinationConnectionSection';
+import { ReplicationSection } from './ReplicationSection';
+import { SourceSection } from './SourceSection';
+import { type ConfigureFormValues, configureResolver, defaultConfigureValues, toVerifyBody } from './schema';
+
+/** Step index for the wizard's Stepper.next() calls. */
+export const CONFIGURE_STEP_INDEX = 0;
+
+const errorCopy: Partial<Record<ProblemCode, string>> = {
+  DestinationUnreachable: 'The destination cluster did not respond.',
+  DestinationDnsResolutionFailed: 'One or more destination hostnames could not be resolved.',
+  DestinationCertificateInvalid: 'The pasted certificate is not a valid PEM bundle.',
+  DestinationAuthFailed: 'The destination refused these admin credentials.',
+  AssumeRoleFailed: 'The destination rejected the storage-manager role assumption.',
+  Unauthorized: 'Your session was rejected by the source cluster. Sign in again.',
+  Forbidden: 'You need the Storage Manager role to run this wizard.',
+};
+
+const errorMessage = (error: unknown): string => {
+  if (error instanceof ServiceError) {
+    const code = error.problem.code as ProblemCode | undefined;
+    return (code && errorCopy[code]) ?? error.problem.title ?? 'Connection to the destination failed.';
+  }
+  return (error as Error)?.message ?? 'Connection to the destination failed.';
+};
+
+export const ConfigureStep = () => {
+  const { next } = useStepper(CONFIGURE_STEP_INDEX);
+  const navigate = useBasenameRelativeNavigate();
+  const { showToast } = useToast();
+  const verify = useCRRConfigurationVerifyMutation();
+  const lastVerifiedRef = useRef<string | null>(null);
+
+  const formMethods = useForm<ConfigureFormValues>({
+    mode: 'all',
+    resolver: configureResolver,
+    defaultValues: defaultConfigureValues,
+  });
+  const {
+    handleSubmit,
+    getValues,
+    trigger,
+    formState: { isValid },
+  } = formMethods;
+
+  const runVerify = async (body: VerifyRequestBody) => {
+    await verify.mutateAsync(body);
+    lastVerifiedRef.current = JSON.stringify(body);
+  };
+
+  const onCheckConnection = async () => {
+    const valid = await trigger([
+      'connectionMode',
+      'url',
+      'baseDomain',
+      's3Endpoint',
+      'username',
+      'password',
+      'certificate',
+    ]);
+    if (!valid) return;
+    const body = toVerifyBody(getValues());
+    try {
+      await runVerify(body);
+      showToast({ open: true, status: 'success', message: 'Destination reachable' });
+    } catch (error) {
+      showToast({ open: true, status: 'error', message: errorMessage(error) });
+    }
+  };
+
+  const onContinue = handleSubmit(async (values) => {
+    const body = toVerifyBody(values);
+    const snapshot = JSON.stringify(body);
+    if (lastVerifiedRef.current === snapshot) {
+      next({ ...values });
+      return;
+    }
+    try {
+      await runVerify(body);
+      next({ ...values });
+    } catch (error) {
+      showToast({ open: true, status: 'error', message: errorMessage(error) });
+    }
+  });
+
+  return (
+    <FormProvider {...formMethods}>
+      <Form
+        onSubmit={onContinue}
+        requireMode="partial"
+        layout={{ title: 'Configure Cross-Region Location', kind: 'page' }}
+        rightActions={
+          <Stack gap="r16">
+            <Button type="button" variant="outline" label="Cancel" onClick={() => navigate('/locations')} />
+            <Button
+              type="submit"
+              variant="primary"
+              label="Continue"
+              isLoading={verify.isLoading}
+              disabled={!isValid}
+              icon={<Icon name="Arrow-right" />}
+            />
+          </Stack>
+        }
+      >
+        <SourceSection />
+        <DestinationConnectionSection isCheckingConnection={verify.isLoading} onCheckConnection={onCheckConnection} />
+        <DestinationAccountSection />
+        <ReplicationSection />
+      </Form>
+    </FormProvider>
+  );
+};

--- a/src/react/locations/CRRSetupWizard/steps/ConfigureStep/DestinationAccountSection.tsx
+++ b/src/react/locations/CRRSetupWizard/steps/ConfigureStep/DestinationAccountSection.tsx
@@ -1,0 +1,26 @@
+import { FormGroup, FormSection } from '@scality/core-ui';
+import { Input } from '@scality/core-ui/dist/next';
+import { useFormContext } from 'react-hook-form';
+import type { ConfigureFormValues } from './schema';
+
+export const DestinationAccountSection = () => {
+  const {
+    register,
+    formState: { errors, touchedFields },
+  } = useFormContext<ConfigureFormValues>();
+  const nameError = touchedFields.destinationAccountName ? errors.destinationAccountName?.message : undefined;
+
+  return (
+    <FormSection forceLabelWidth={280} title={{ name: 'Destination Account' }}>
+      <FormGroup
+        id="destinationAccountName"
+        direction="horizontal"
+        label="Account Name"
+        required
+        helpErrorPosition="bottom"
+        error={nameError}
+        content={<Input id="destinationAccountName" autoComplete="off" {...register('destinationAccountName')} />}
+      />
+    </FormSection>
+  );
+};

--- a/src/react/locations/CRRSetupWizard/steps/ConfigureStep/DestinationConnectionSection.tsx
+++ b/src/react/locations/CRRSetupWizard/steps/ConfigureStep/DestinationConnectionSection.tsx
@@ -1,0 +1,127 @@
+import { FormGroup, FormSection, Radio, Stack, Wrap } from '@scality/core-ui';
+import { Button, Input } from '@scality/core-ui/dist/next';
+import { Controller, useFormContext } from 'react-hook-form';
+import { CertificateSection } from '../../../../ui-elements/CertificateSection';
+import type { ConfigureFormValues } from './schema';
+
+type Props = {
+  isCheckingConnection: boolean;
+  onCheckConnection: () => void;
+};
+
+export const DestinationConnectionSection = ({ isCheckingConnection, onCheckConnection }: Props) => {
+  const {
+    control,
+    register,
+    watch,
+    formState: { errors, touchedFields },
+  } = useFormContext<ConfigureFormValues>();
+  const connectionMode = watch('connectionMode');
+  const errorIfTouched = (field: keyof ConfigureFormValues) =>
+    touchedFields[field] ? errors[field]?.message : undefined;
+
+  return (
+    <FormSection forceLabelWidth={280} title={{ name: 'Destination Connection' }}>
+      <FormGroup
+        id="connectionMode"
+        direction="horizontal"
+        label="Mode"
+        required
+        helpErrorPosition="bottom"
+        content={
+          <Controller
+            name="connectionMode"
+            control={control}
+            render={({ field }) => (
+              <Stack direction="horizontal" gap="r16">
+                <Radio
+                  name="connectionMode"
+                  value="management-network"
+                  checked={field.value === 'management-network'}
+                  onChange={() => field.onChange('management-network')}
+                  label="Management Network"
+                />
+                <Radio
+                  name="connectionMode"
+                  value="data-network"
+                  checked={field.value === 'data-network'}
+                  onChange={() => field.onChange('data-network')}
+                  label="Data Network"
+                />
+              </Stack>
+            )}
+          />
+        }
+      />
+      {connectionMode === 'management-network' && (
+        <FormGroup
+          id="url"
+          direction="horizontal"
+          label="URL"
+          required
+          helpErrorPosition="bottom"
+          error={errorIfTouched('url')}
+          content={<Input id="url" noPlaceholderPrefix placeholder="https://<IP>:8443" {...register('url')} />}
+        />
+      )}
+      {connectionMode === 'data-network' && (
+        <FormGroup
+          id="baseDomain"
+          direction="horizontal"
+          label="Base Domain"
+          required
+          helpErrorPosition="bottom"
+          error={errorIfTouched('baseDomain')}
+          content={<Input id="baseDomain" {...register('baseDomain')} />}
+        />
+      )}
+      {connectionMode === 'data-network' && (
+        <FormGroup
+          id="s3Endpoint"
+          direction="horizontal"
+          label="S3 Endpoint"
+          required
+          helpErrorPosition="bottom"
+          error={errorIfTouched('s3Endpoint')}
+          content={
+            <Input
+              id="s3Endpoint"
+              noPlaceholderPrefix
+              placeholder="https://s3.example.com"
+              {...register('s3Endpoint')}
+            />
+          }
+        />
+      )}
+      <FormGroup
+        id="username"
+        direction="horizontal"
+        label="Username"
+        required
+        helpErrorPosition="bottom"
+        error={errorIfTouched('username')}
+        content={<Input id="username" autoComplete="off" {...register('username')} />}
+      />
+      <FormGroup
+        id="password"
+        direction="horizontal"
+        label="Password"
+        required
+        helpErrorPosition="bottom"
+        error={errorIfTouched('password')}
+        content={<Input id="password" type="password" autoComplete="new-password" {...register('password')} />}
+      />
+      <CertificateSection name="certificate" />
+      <Wrap width="100%">
+        <div />
+        <Button
+          type="button"
+          variant="secondary"
+          label="Check Connection"
+          isLoading={isCheckingConnection}
+          onClick={onCheckConnection}
+        />
+      </Wrap>
+    </FormSection>
+  );
+};

--- a/src/react/locations/CRRSetupWizard/steps/ConfigureStep/ReplicationSection.tsx
+++ b/src/react/locations/CRRSetupWizard/steps/ConfigureStep/ReplicationSection.tsx
@@ -1,0 +1,59 @@
+import { Checkbox, FormGroup, FormSection } from '@scality/core-ui';
+import { Input } from '@scality/core-ui/dist/next';
+import { useFormContext } from 'react-hook-form';
+import type { ConfigureFormValues } from './schema';
+
+export const ReplicationSection = () => {
+  const {
+    register,
+    watch,
+    formState: { errors, touchedFields },
+  } = useFormContext<ConfigureFormValues>();
+  const enabled = watch('createReplicationRule');
+  const errorIfTouched = (field: keyof ConfigureFormValues) =>
+    touchedFields[field] ? errors[field]?.message : undefined;
+
+  return (
+    <FormSection forceLabelWidth={280} title={{ name: 'Replication' }}>
+      <FormGroup
+        id="createReplicationRule"
+        direction="horizontal"
+        label="Create Replication Rule"
+        helpErrorPosition="bottom"
+        content={<Checkbox id="createReplicationRule" {...register('createReplicationRule')} />}
+      />
+      {enabled && (
+        <FormGroup
+          id="sourceBucketName"
+          direction="horizontal"
+          label="Source Bucket Name"
+          required
+          helpErrorPosition="bottom"
+          error={errorIfTouched('sourceBucketName')}
+          content={<Input id="sourceBucketName" autoComplete="off" {...register('sourceBucketName')} />}
+        />
+      )}
+      {enabled && (
+        <FormGroup
+          id="targetBucketName"
+          direction="horizontal"
+          label="Target Bucket Name"
+          required
+          helpErrorPosition="bottom"
+          error={errorIfTouched('targetBucketName')}
+          content={<Input id="targetBucketName" autoComplete="off" {...register('targetBucketName')} />}
+        />
+      )}
+      {enabled && (
+        <FormGroup
+          id="prefix"
+          direction="horizontal"
+          label="Prefix (optional)"
+          helpErrorPosition="bottom"
+          error={errorIfTouched('prefix')}
+          content={<Input id="prefix" autoComplete="off" {...register('prefix')} />}
+        />
+      )}
+    </FormSection>
+  );
+};

--- a/src/react/locations/CRRSetupWizard/steps/ConfigureStep/SourceSection.tsx
+++ b/src/react/locations/CRRSetupWizard/steps/ConfigureStep/SourceSection.tsx
@@ -1,0 +1,104 @@
+import { FormGroup, FormSection } from '@scality/core-ui';
+import { Input, Select } from '@scality/core-ui/dist/next';
+import { useMemo } from 'react';
+import { Controller, useFormContext } from 'react-hook-form';
+import { RadioGroup } from '../../../../ISV/components/RadioGroup';
+import { useListAccounts } from '../../../../next-architecture/domain/business/accounts';
+import { useAccessibleAccountsAdapter } from '../../../../next-architecture/ui/AccessibleAccountsAdapterProvider';
+import { NoOpMetricsAdapter } from '../../../../ui-elements/SelectAccountIAMRole';
+import type { ConfigureFormValues } from './schema';
+
+const RADIO_OPTIONS = [
+  { value: 'create', label: 'Create a new Account' },
+  { value: 'existing', label: 'Use an existing Account' },
+];
+
+export const SourceSection = () => {
+  const {
+    control,
+    register,
+    setValue,
+    watch,
+    formState: { errors, touchedFields },
+  } = useFormContext<ConfigureFormValues>();
+  const accountNameType = watch('accountNameType');
+  const accountNameError = touchedFields.accountName ? errors.accountName?.message : undefined;
+
+  const accessibleAccountsAdapter = useAccessibleAccountsAdapter();
+  const metricsAdapter = useMemo(() => new NoOpMetricsAdapter(), []);
+  const { accounts: accountsResult } = useListAccounts({ accessibleAccountsAdapter, metricsAdapter });
+  const accounts = useMemo(
+    () =>
+      accountsResult.status === 'success'
+        ? accountsResult.value.filter((account) => account.name !== 'scality-internal-services')
+        : [],
+    [accountsResult],
+  );
+
+  const canPickExisting = accounts.length > 0;
+  const radioOptions = useMemo(
+    () => RADIO_OPTIONS.map((opt) => (opt.value === 'existing' && !canPickExisting ? { ...opt, disabled: true } : opt)),
+    [canPickExisting],
+  );
+
+  return (
+    <FormSection forceLabelWidth={280} title={{ name: 'Source' }}>
+      <FormGroup
+        id="accountNameType"
+        direction="horizontal"
+        label="Account"
+        required
+        helpErrorPosition="bottom"
+        content={
+          <Controller
+            name="accountNameType"
+            control={control}
+            render={({ field }) => (
+              <RadioGroup
+                options={radioOptions}
+                value={field.value}
+                onChange={(next) => {
+                  field.onChange(next);
+                  setValue('accountName', '', { shouldValidate: true, shouldDirty: false, shouldTouch: false });
+                }}
+                direction="vertical"
+              />
+            )}
+          />
+        }
+      />
+      <FormGroup
+        id="accountName"
+        direction="horizontal"
+        label="Account Name"
+        required
+        helpErrorPosition="bottom"
+        error={accountNameError}
+        content={
+          accountNameType === 'existing' && canPickExisting ? (
+            <Controller
+              name="accountName"
+              control={control}
+              render={({ field }) => (
+                <Select
+                  id="accountName"
+                  value={field.value}
+                  onChange={(value) => field.onChange(value)}
+                  placeholder="Select existing account"
+                >
+                  {accounts.map((account) => (
+                    <Select.Option key={account.name} value={account.name}>
+                      {account.name}
+                    </Select.Option>
+                  ))}
+                </Select>
+              )}
+            />
+          ) : (
+            <Input id="accountName" autoComplete="off" {...register('accountName')} />
+          )
+        }
+      />
+    </FormSection>
+  );
+};

--- a/src/react/locations/CRRSetupWizard/steps/ConfigureStep/index.ts
+++ b/src/react/locations/CRRSetupWizard/steps/ConfigureStep/index.ts
@@ -1,0 +1,1 @@
+export { CONFIGURE_STEP_INDEX, ConfigureStep } from './ConfigureStep';

--- a/src/react/locations/CRRSetupWizard/steps/ConfigureStep/schema.ts
+++ b/src/react/locations/CRRSetupWizard/steps/ConfigureStep/schema.ts
@@ -54,7 +54,11 @@ const managementUrlPattern = new RegExp(`^https://(?:${ipv4Octet}\\.){3}${ipv4Oc
 // biome-ignore-start lint/suspicious/noThenProperty: `then` is Joi's conditional schema branch, not a promise-like method
 export const configureSchema = Joi.object<ConfigureFormValues>({
   accountNameType: Joi.string().valid('create', 'existing').required(),
-  accountName: Joi.string().min(1).required(),
+  accountName: Joi.when('accountNameType', {
+    is: 'create',
+    then: accountNameValidationSchema,
+    otherwise: Joi.string().min(1).required(),
+  }),
 
   connectionMode: Joi.string().valid('management-network', 'data-network').required(),
   url: Joi.when('connectionMode', {

--- a/src/react/locations/CRRSetupWizard/steps/ConfigureStep/schema.ts
+++ b/src/react/locations/CRRSetupWizard/steps/ConfigureStep/schema.ts
@@ -1,0 +1,143 @@
+import Joi from 'joi';
+import type { FieldErrors, Resolver } from 'react-hook-form';
+import type { VerifyRequestBody } from '../../api/types';
+
+export type AccountNameType = 'create' | 'existing';
+export type ConnectionMode = 'management-network' | 'data-network';
+
+export type ConfigureFormValues = {
+  /** Source account selection — field names match the `CreateOrSelectNameField` convention. */
+  accountNameType: AccountNameType;
+  accountName: string;
+
+  connectionMode: ConnectionMode;
+  url: string;
+  baseDomain: string;
+  s3Endpoint: string;
+  username: string;
+  password: string;
+  certificate: string;
+
+  destinationAccountName: string;
+
+  createReplicationRule: boolean;
+  sourceBucketName: string;
+  targetBucketName: string;
+  prefix: string;
+};
+
+export const defaultConfigureValues: ConfigureFormValues = {
+  accountNameType: 'create',
+  accountName: '',
+  connectionMode: 'management-network',
+  url: '',
+  baseDomain: '',
+  s3Endpoint: '',
+  username: '',
+  password: '',
+  certificate: '',
+  destinationAccountName: '',
+  createReplicationRule: false,
+  sourceBucketName: '',
+  targetBucketName: '',
+  prefix: '',
+};
+
+const httpsUri = Joi.string()
+  .uri({ scheme: ['https'] })
+  .required();
+
+const ipv4Octet = '(?:25[0-5]|2[0-4]\\d|1\\d\\d|[1-9]?\\d)';
+const managementUrlPattern = new RegExp(`^https://(?:${ipv4Octet}\\.){3}${ipv4Octet}:8443/?$`);
+
+// biome-ignore-start lint/suspicious/noThenProperty: `then` is Joi's conditional schema branch, not a promise-like method
+export const configureSchema = Joi.object<ConfigureFormValues>({
+  accountNameType: Joi.string().valid('create', 'existing').required(),
+  accountName: Joi.string().min(1).required(),
+
+  connectionMode: Joi.string().valid('management-network', 'data-network').required(),
+  url: Joi.when('connectionMode', {
+    is: 'management-network',
+    then: Joi.string()
+      .pattern(managementUrlPattern)
+      .required()
+      .messages({ 'string.pattern.base': 'URL must match https://<IP>:8443' }),
+    otherwise: Joi.string().allow(''),
+  }),
+  baseDomain: Joi.when('connectionMode', {
+    is: 'data-network',
+    then: Joi.string().hostname().required(),
+    otherwise: Joi.string().allow(''),
+  }),
+  s3Endpoint: Joi.when('connectionMode', {
+    is: 'data-network',
+    then: httpsUri,
+    otherwise: Joi.string().allow(''),
+  }),
+  username: Joi.string().required(),
+  password: Joi.string().required(),
+  certificate: Joi.string()
+    .pattern(/-----BEGIN CERTIFICATE-----/)
+    .required()
+    .messages({ 'string.pattern.base': 'Paste a PEM-encoded certificate' }),
+
+  destinationAccountName: Joi.string().min(1).required(),
+
+  createReplicationRule: Joi.boolean().required(),
+  sourceBucketName: Joi.when('createReplicationRule', {
+    is: true,
+    then: Joi.string().min(1).required(),
+    otherwise: Joi.string().allow(''),
+  }),
+  targetBucketName: Joi.when('createReplicationRule', {
+    is: true,
+    then: Joi.string().min(1).required(),
+    otherwise: Joi.string().allow(''),
+  }),
+  prefix: Joi.string().allow(''),
+});
+// biome-ignore-end lint/suspicious/noThenProperty: `then` is Joi's conditional schema branch, not a promise-like method
+
+/**
+ * Inline Joi resolver — avoids sharing `@hookform/resolvers/joi` across the
+ * Federation container, which has caused runtime `toNestErrors is not a
+ * function` on legacy shells that hold an older shared singleton. The form is
+ * flat, so we assign each field's error at its top-level path.
+ */
+export const configureResolver: Resolver<ConfigureFormValues> = (values) => {
+  const { error } = configureSchema.validate(values, { abortEarly: false });
+  if (!error) {
+    return { values, errors: {} as Record<string, never> };
+  }
+  const errors: FieldErrors<ConfigureFormValues> = {};
+  for (const detail of error.details) {
+    const path = detail.path.join('.') as keyof ConfigureFormValues;
+    if (!errors[path]) {
+      errors[path] = { type: detail.type, message: detail.message };
+    }
+  }
+  return { values: {} as Record<string, never>, errors };
+};
+
+/**
+ * Extracts the destination-connection payload the configurator's /verify endpoint
+ * expects from the wizard form values.
+ */
+export const toVerifyBody = (values: ConfigureFormValues): VerifyRequestBody => ({
+  destinationConnection:
+    values.connectionMode === 'management-network'
+      ? {
+          mode: 'management-network',
+          baseUrl: values.url,
+          adminUser: values.username,
+          adminPassword: values.password,
+        }
+      : {
+          mode: 'data-network',
+          baseDomain: values.baseDomain,
+          s3Endpoint: values.s3Endpoint,
+          adminUser: values.username,
+          adminPassword: values.password,
+        },
+  destinationCertificate: values.certificate,
+});

--- a/src/react/locations/CRRSetupWizard/steps/ConfigureStep/schema.ts
+++ b/src/react/locations/CRRSetupWizard/steps/ConfigureStep/schema.ts
@@ -1,5 +1,6 @@
 import Joi from 'joi';
 import type { FieldErrors, Resolver } from 'react-hook-form';
+import { accountNameValidationSchema } from '../../../../account/AccountCreate';
 import type { VerifyRequestBody } from '../../api/types';
 
 export type AccountNameType = 'create' | 'existing';
@@ -81,7 +82,7 @@ export const configureSchema = Joi.object<ConfigureFormValues>({
     .required()
     .messages({ 'string.pattern.base': 'Paste a PEM-encoded certificate' }),
 
-  destinationAccountName: Joi.string().min(1).required(),
+  destinationAccountName: accountNameValidationSchema,
 
   createReplicationRule: Joi.boolean().required(),
   sourceBucketName: Joi.when('createReplicationRule', {

--- a/src/react/locations/CRRSetupWizard/steps/SummaryStep.tsx
+++ b/src/react/locations/CRRSetupWizard/steps/SummaryStep.tsx
@@ -1,0 +1,10 @@
+import { Banner, Icon } from '@scality/core-ui';
+import { Box } from '@scality/core-ui/dist/next';
+
+export const SummaryStep = () => (
+  <Box padding="r24">
+    <Banner variant="base" icon={<Icon name="Info-circle" />} title="Summary">
+      Displays the resulting credentials once the setup completes. It lands in the next brick.
+    </Banner>
+  </Box>
+);

--- a/src/react/locations/LocationsList.tsx
+++ b/src/react/locations/LocationsList.tsx
@@ -22,6 +22,7 @@ import DeleteConfirmation from '../ui-elements/DeleteConfirmation';
 import { HelpLocationTargetBucket } from '../ui-elements/Help';
 import { TableHeaderWrapper } from '../ui-elements/Table';
 import { getLocationType } from '../utils/storageOptions';
+import { useCRRFeature } from './CRRSetupWizard/hooks/useCRRFeature';
 import { PauseAndResume } from './PauseAndResume';
 import { getLocationDeletionBlocker } from './utils';
 
@@ -183,6 +184,7 @@ const ActionButtons = ({ rowValues }: { rowValues: Location }) => {
 
 export function LocationsList() {
   const navigate = useBasenameRelativeNavigate();
+  const isCRRWizardEnabled = useCRRFeature();
   const locationsEndpointsAdapter = useLocationsEndpointsAdapter();
   const metricsAdapter = useMetricsAdapter();
   const { locations } = useListLocations({
@@ -341,13 +343,22 @@ export function LocationsList() {
         <TableHeaderWrapper
           search={<Table.SearchWithQueryParams queryParams={SEARCH_QUERY_PARAM} />}
           actions={
-            <Button
-              icon={<Icon name="Create-add" />}
-              label="Create Location"
-              variant="primary"
-              onClick={() => navigate('/create-location')}
-              type="submit"
-            />
+            <Stack gap="r16">
+              {isCRRWizardEnabled && (
+                <Button
+                  label="Start CRR Configuration"
+                  variant="secondary"
+                  onClick={() => navigate('/create-crr-configuration')}
+                />
+              )}
+              <Button
+                icon={<Icon name="Create-add" />}
+                label="Create Location"
+                variant="primary"
+                onClick={() => navigate('/create-location')}
+                type="submit"
+              />
+            </Stack>
           }
         />
 

--- a/src/react/ui-elements/CertificateSection.tsx
+++ b/src/react/ui-elements/CertificateSection.tsx
@@ -80,12 +80,13 @@ export const CertificateSection = ({ name, isEdit }: Props) => {
           rows={10}
           {...registered}
           value={value}
+          aria-describedby={errorMessage ? `${name}-error` : undefined}
           onChange={(event: ChangeEvent<HTMLTextAreaElement>) => {
             registered.onChange(event);
           }}
         />
       </Stack>
-      {errorMessage && <ErrorText>{errorMessage}</ErrorText>}
+      {errorMessage && <ErrorText id={`${name}-error`}>{errorMessage}</ErrorText>}
     </CertificateContainer>
   );
 };

--- a/src/react/ui-elements/CertificateSection.tsx
+++ b/src/react/ui-elements/CertificateSection.tsx
@@ -1,0 +1,91 @@
+import { Dropzone, Stack, Text, TextArea } from '@scality/core-ui';
+import type { ChangeEvent } from 'react';
+import { useFormContext } from 'react-hook-form';
+import styled from 'styled-components';
+
+const ErrorText = styled.span`
+  color: ${(props) => props.theme.statusCritical};
+  font-size: 0.75rem;
+`;
+
+const CertificateContainer = styled.div`
+  background-color: ${(props) => props.theme.backgroundLevel2};
+  border-radius: 3px;
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  color: ${(props) => props.theme.textPrimary};
+  max-width: 45rem;
+`;
+
+const PLACEHOLDER = `Example:
+-----BEGIN CERTIFICATE-----
+CA
+-----END CERTIFICATE-----`;
+
+type Props = {
+  /** RHF field name bound to the PEM value. */
+  name: string;
+  /** Drop the required marker (`*`) — set to true when editing an existing entity. */
+  isEdit?: boolean;
+};
+
+/**
+ * Self-contained PEM certificate import — label + drag-and-drop OR paste.
+ * Must be rendered inside a `<FormProvider>`; renders as a direct section
+ * child, not inside a FormGroup.
+ */
+export const CertificateSection = ({ name, isEdit }: Props) => {
+  const {
+    register,
+    setValue,
+    watch,
+    formState: { errors, touchedFields },
+  } = useFormContext();
+  const value = watch(name) ?? '';
+  const registered = register(name);
+  const errorMessage = touchedFields[name] ? (errors[name]?.message as string | undefined) : undefined;
+
+  const readFile = (files: File[]) => {
+    if (!files[0]) {
+      setValue(name, '', { shouldValidate: true, shouldDirty: true, shouldTouch: true });
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = () => {
+      setValue(name, reader.result as string, { shouldValidate: true, shouldDirty: true, shouldTouch: true });
+    };
+    reader.onerror = () => {
+      setValue(name, '', { shouldValidate: true, shouldDirty: true, shouldTouch: true });
+    };
+    reader.readAsText(files[0], 'utf-8');
+  };
+
+  return (
+    <CertificateContainer>
+      <label htmlFor={name}>
+        <Text isEmphazed>{`Certificate import ${isEdit ? '' : '*'}`.trim()}</Text>
+      </label>
+      <Stack direction="vertical" style={{ gap: '0px' }}>
+        <Dropzone
+          variant="inline"
+          labels={{ label: 'Drag and drop file here OR', buttonLabel: 'Browse' }}
+          multiple={false}
+          onChange={readFile}
+        />
+        <TextArea
+          id={name}
+          placeholder={PLACEHOLDER}
+          rows={10}
+          {...registered}
+          value={value}
+          onChange={(event: ChangeEvent<HTMLTextAreaElement>) => {
+            registered.onChange(event);
+          }}
+        />
+      </Stack>
+      {errorMessage && <ErrorText>{errorMessage}</ErrorText>}
+    </CertificateContainer>
+  );
+};


### PR DESCRIPTION
Lands the CRR Provisioning Wizard's shell and its first step. Users open it from a `Start CRR Configuration` button on the Locations page (only visible when the `CRR_CONFIGURATOR` feature flag is enabled) and are presented with a single Configure page grouped into three sections: Source (create or reuse an account on the source cluster), Destination Connection (network mode, URL or base domain + S3 endpoint, admin credentials, PEM certificate, destination account name), and Replication (an optional replication rule with source bucket, target bucket and prefix). A Check Connection button inside the Destination section validates the destination on demand and shows a success or error toast tied to the ARTESCA problem code. Continue silently re-verifies unless the last verify already covered the exact same connection values, and blocks progression with an error toast if that verify fails; a successful advance is transparent, as expected in a wizard flow. Apply actions and Summary land as placeholders and are filled in by the follow-up brick.

Under the hood, the Configure step is composed of three small section components that share form state via `FormProvider`, wrapping a strict Joi schema with conditional branches on the connection mode and the replication toggle. The PEM certificate input is a reusable `CertificateSection` copied from identity-ui's identity-provider form (drag-and-drop or paste) — long-term this belongs in `@scality/core-ui` so both apps share it.

Deviation from the plan: F5 was originally scoped to just a Configure destination step; scope was widened during review to also cover the Source and Replication sections and the Locations-page entry point.

Next: the Apply actions step, which streams the destination-side setup chain and reports its progress.

screenshots :

<img width="1920" height="1080" alt="Screenshot 2026-07-20 at 16 43 06 (2)" src="https://github.com/user-attachments/assets/3ad9dd9a-db71-4962-84c2-91a06c9c28a3" />
<img width="1920" height="1080" alt="Screenshot 2026-07-20 at 16 43 24 (2)" src="https://github.com/user-attachments/assets/81ae7469-e65d-43e5-a2c1-49703ce70e81" />
