### PR TITLE
fix: use standard IconHelp for predefined-policy tooltip on Policy page (ARTESCA-17384)

### DIFF
--- a/src/react/account/AccountPoliciesList.tsx
+++ b/src/react/account/AccountPoliciesList.tsx
@@ -1,4 +1,4 @@
-import { ConstrainedText, FormattedDateTime, Icon, spacing, Tooltip } from '@scality/core-ui';
+import { ConstrainedText, FormattedDateTime, Icon, IconHelp, spacing } from '@scality/core-ui';
 import { Box, Button, CopyButton } from '@scality/core-ui/dist/next';
 import { useBasenameRelativeNavigate } from '@scality/module-federation';
 import type { ListPoliciesResponse, Policy } from 'aws-sdk/clients/iam';
@@ -232,15 +232,21 @@ const DeletePolicyAction = ({
 const AccessPolicyNameCell = ({ rowValues }: { rowValues: InternalPolicy }) => {
   const { policyPath, policyName } = rowValues;
   const isInternalPolicy = policyPath.includes('scality-internal');
-  const styleProps = { style: { marginLeft: spacing.r16 } };
   return (
     <>
       {isInternalPolicy && (
         <ConstrainedText
           text={
-            <Tooltip overlay={'This is a predefined Scality Policy'} overlayStyle={{ width: '13rem' }}>
-              {policyName} <Icon name="Info" size="xs" color="buttonSecondary" {...styleProps} />
-            </Tooltip>
+            <>
+              {policyName}
+              <span style={{ marginLeft: spacing.r16 }}>
+                <IconHelp
+                  tooltipMessage={'This is a predefined Scality Policy'}
+                  overlayStyle={{ width: '13rem' }}
+                  aria-label="This is a predefined Scality Policy"
+                />
+              </span>
+            </>
           }
           lineClamp={2}
         />


### PR DESCRIPTION
## TL;DR

On **Data Management › Accounts › Policies**, predefined (`scality-internal`) policies now use the shared `IconHelp` component for their help tooltip, so the trigger icon matches the size and style of every other tooltip in the app.

## Context

`ARTESCA-17384` (issue **1 of 2**): tooltips on the Policy page render noticeably smaller than every other tooltip across the application. The alignment half of that ticket (column headers on the Nodes & Volumes tabs) is handled separately in `metalk8s`.

## Approach

The cell hand-rolled its own `Tooltip` wrapping an `Icon name="Info" size="xs"`, which is why it looked smaller than the app-standard help icon. Swapped it for the shared `IconHelp` (default size, built-in tooltip) — same message and overlay width, standard sizing.

**Before:**
```tsx
const styleProps = { style: { marginLeft: spacing.r16 } };
// ...
<Tooltip overlay={'This is a predefined Scality Policy'} overlayStyle={{ width: '13rem' }}>
  {policyName} <Icon name="Info" size="xs" color="buttonSecondary" {...styleProps} />  // ← bespoke xs icon
</Tooltip>
```

**After:**
```tsx
<>
  {policyName}
  <span style={{ marginLeft: spacing.r16 }}>
    <IconHelp                                              // ← standard help icon, default size
      tooltipMessage={'This is a predefined Scality Policy'}
      overlayStyle={{ width: '13rem' }}
      aria-label="This is a predefined Scality Policy"
    />
  </span>
</>
```

## Screenshots

<!-- SCREENSHOT: Data Management › Accounts › <account> › Policies. Hover the help icon next to a predefined (scality-internal) policy name. Capture it alongside a normal app tooltip so the now-consistent icon size is visible. -->

## Review focus

- 🟡 `src/react/account/AccountPoliciesList.tsx › AccessPolicyNameCell` — replaces the bespoke `Tooltip` + `Icon size="xs"` with `IconHelp`. Verify the tooltip still triggers, the message and `13rem` overlay width are unchanged, and the icon only renders for internal (`scality-internal`) policies.

## How to test

1. Go to **Data Management › Accounts › _<account>_ › Policies**.
2. Find a predefined Scality policy (its path contains `scality-internal`).
3. Hover the help icon next to the policy name → tooltip reads *"This is a predefined Scality Policy"*.
4. Confirm the icon is the same size as help icons elsewhere in the app (no longer visibly smaller).

## References

- **ARTESCA-17384** — 4.2 Visual inconsistencies: tooltip size on Policy page and column header alignment on Nodes & Volumes tabs. This PR covers the **tooltip size** fix; the header-alignment fix ships in `metalk8s`.
