### PR TITLE
Extract useCreateLocationMutation into a reusable hook

### DIFF
--- a/src/react/locations/LocationEditor.tsx
+++ b/src/react/locations/LocationEditor.tsx
@@ -119,6 +119,7 @@ function LocationEditor() {
           if (error.status === 422) {
             throw await error.json();
           }
+          throw error;
         });
     },
   });

--- a/src/react/locations/LocationEditor.tsx
+++ b/src/react/locations/LocationEditor.tsx
@@ -1,12 +1,12 @@
 import { Banner, Form, FormGroup, FormSection, Icon, Loader as LoaderCoreUI, Stack } from '@scality/core-ui';
 import { Button, Input, Select } from '@scality/core-ui/dist/next';
-import { useShellHooks } from '@scality/module-federation';
 import { type ChangeEvent, type ReactNode, useMemo, useState } from 'react';
 import { useMutation } from 'react-query';
 import { useNavigate, useParams } from 'react-router';
 import styled from 'styled-components';
 import type { LocationV1 } from '../../js/managementClient/api';
 import { useWaitForRunningConfigurationVersionToBeUpdated } from '../../js/mutations';
+import { useCreateLocationMutation } from './hooks/useCreateLocationMutation';
 import type { LocationTypeKey } from '../../types/config';
 import { notFalsyTypeGuard } from '../../types/typeGuards';
 import { useManagementClient } from '../ManagementProvider';
@@ -109,20 +109,8 @@ function LocationEditor() {
   };
 
   const managementClient = useManagementClient();
-  const { useAuth } = useShellHooks();
-  const { getToken } = useAuth();
   const instanceId = useInstanceId();
-  const createLocationMutation = useMutation({
-    mutationFn: async (location: LocationV1) => {
-      const client = notFalsyTypeGuard(managementClient);
-      client.setToken(await getToken());
-      return client.createConfigurationOverlayLocation(location, instanceId).catch(async (error) => {
-        if (error.status === 422) {
-          throw await error.json();
-        }
-      });
-    },
-  });
+  const createLocationMutation = useCreateLocationMutation();
   const updateLocationMutation = useMutation({
     mutationFn: (location: LocationV1) => {
       return notFalsyTypeGuard(managementClient)

--- a/src/react/locations/hooks/useCreateLocationMutation.test.ts
+++ b/src/react/locations/hooks/useCreateLocationMutation.test.ts
@@ -42,4 +42,14 @@ describe('useCreateLocationMutation', () => {
     await waitFor(() => expect(result.current?.isError).toBe(true));
     expect(result.current?.error).toEqual(problem);
   });
+
+  it('fails rather than silently succeeding when the overlay errors with a non-validation status', async () => {
+    server.use(rest.post(LOCATION_URL, (_req, res, ctx) => res(ctx.status(500))));
+    const { result, waitFor } = renderHook(() => useCreateLocationMutation(), { wrapper: NewWrapper() });
+
+    // biome-ignore lint/suspicious/noExplicitAny: minimal location payload for the mutation under test
+    result.current?.mutate(location as any);
+
+    await waitFor(() => expect(result.current?.isError).toBe(true));
+  });
 });

--- a/src/react/locations/hooks/useCreateLocationMutation.test.ts
+++ b/src/react/locations/hooks/useCreateLocationMutation.test.ts
@@ -1,0 +1,45 @@
+import { renderHook } from '@testing-library/react-hooks';
+import { rest } from 'msw';
+import { setupServer } from 'msw/node';
+import { INSTANCE_ID } from '../../../js/mock/managementClientMSWHandlers';
+import { NewWrapper, TEST_API_BASE_URL } from '../../utils/testUtil';
+import { useCreateLocationMutation } from './useCreateLocationMutation';
+
+const LOCATION_URL = `${TEST_API_BASE_URL}/api/v1/config/${INSTANCE_ID}/location`;
+const location = { name: 'crr-loc', locationType: 'location-scality-crr-v1', details: {} };
+
+const server = setupServer();
+beforeAll(() => server.listen());
+afterEach(() => server.resetHandlers());
+afterAll(() => server.close());
+
+describe('useCreateLocationMutation', () => {
+  it('creates the location in the configuration overlay', async () => {
+    const received = jest.fn();
+    server.use(
+      rest.post(LOCATION_URL, (req, res, ctx) => {
+        received(req.body);
+        return res(ctx.status(200), ctx.json(location));
+      }),
+    );
+    const { result, waitFor } = renderHook(() => useCreateLocationMutation(), { wrapper: NewWrapper() });
+
+    // biome-ignore lint/suspicious/noExplicitAny: minimal location payload for the mutation under test
+    result.current?.mutate(location as any);
+
+    await waitFor(() => expect(result.current?.isSuccess).toBe(true));
+    expect(received).toHaveBeenCalledWith(location);
+  });
+
+  it('surfaces the validation problem body when the overlay rejects the location with a 422', async () => {
+    const problem = { message: 'a location with this name already exists' };
+    server.use(rest.post(LOCATION_URL, (_req, res, ctx) => res(ctx.status(422), ctx.json(problem))));
+    const { result, waitFor } = renderHook(() => useCreateLocationMutation(), { wrapper: NewWrapper() });
+
+    // biome-ignore lint/suspicious/noExplicitAny: minimal location payload for the mutation under test
+    result.current?.mutate(location as any);
+
+    await waitFor(() => expect(result.current?.isError).toBe(true));
+    expect(result.current?.error).toEqual(problem);
+  });
+});

--- a/src/react/locations/hooks/useCreateLocationMutation.ts
+++ b/src/react/locations/hooks/useCreateLocationMutation.ts
@@ -23,6 +23,7 @@ export const useCreateLocationMutation = () => {
         if (error.status === 422) {
           throw await error.json();
         }
+        throw error;
       });
     },
   });

--- a/src/react/locations/hooks/useCreateLocationMutation.ts
+++ b/src/react/locations/hooks/useCreateLocationMutation.ts
@@ -1,0 +1,29 @@
+import { useShellHooks } from '@scality/module-federation';
+import { useMutation } from 'react-query';
+import type { LocationV1 } from '../../../js/managementClient/api';
+import { notFalsyTypeGuard } from '../../../types/typeGuards';
+import { useManagementClient } from '../../ManagementProvider';
+import { useInstanceId } from '../../next-architecture/ui/AuthProvider';
+
+/**
+ * Creates a location in the configuration overlay. A 422 (validation)
+ * response is surfaced as the parsed problem body so callers can render
+ * the server's reason; other failures propagate as-is.
+ */
+export const useCreateLocationMutation = () => {
+  const managementClient = useManagementClient();
+  const { useAuth } = useShellHooks();
+  const { getToken } = useAuth();
+  const instanceId = useInstanceId();
+  return useMutation({
+    mutationFn: async (location: LocationV1) => {
+      const client = notFalsyTypeGuard(managementClient);
+      client.setToken(await getToken());
+      return client.createConfigurationOverlayLocation(location, instanceId).catch(async (error) => {
+        if (error.status === 422) {
+          throw await error.json();
+        }
+      });
+    },
+  });
+};


### PR DESCRIPTION
Extracts the location-creation mutation that was inlined in `LocationEditor` into its own hook so the CRR setup wizard can reuse it for its `create-location` step.

## What
- New `useCreateLocationMutation` hook (in `locations/hooks/`) wrapping the configuration-overlay create call, surfacing a 422 validation response as the parsed problem body.
- `LocationEditor` now consumes the hook instead of an inline mutation.

## Behaviour
Mostly a pure extraction, with one intentional error-handling fix applied to both location mutations: the original inline `.catch` only re-threw on 422 and silently resolved every other error, so a 500 or network failure reported `isSuccess` (and could start a reconcile wait on a create/update that actually failed). Both `useCreateLocationMutation` (extracted) and the adjacent `updateLocationMutation` now re-throw non-422 errors so they surface correctly. Covered by unit tests (success, 422 problem body, non-422 failure); existing `LocationEditor` tests still pass.

## Next
The CRR wizard's Apply Actions orchestrator will use this hook (alongside the backend setup stream) in a follow-up.