### PR TITLE
Orchestrate the CRR Apply Actions chain with useChainedMutations

### DIFF
--- a/__mocks__/@scality/data-browser-library.tsx
+++ b/__mocks__/@scality/data-browser-library.tsx
@@ -30,6 +30,32 @@ export const useCreateBucket = jest.fn(() => ({
   reset: jest.fn(),
 }));
 
+export const useSetBucketVersioning = jest.fn(() => ({
+  mutate: jest.fn(),
+  mutateAsync: jest.fn(),
+  status: 'idle',
+  isIdle: true,
+  isLoading: false,
+  isSuccess: false,
+  isError: false,
+  data: undefined,
+  error: null,
+  reset: jest.fn(),
+}));
+
+export const useSetBucketReplication = jest.fn(() => ({
+  mutate: jest.fn(),
+  mutateAsync: jest.fn(),
+  status: 'idle',
+  isIdle: true,
+  isLoading: false,
+  isSuccess: false,
+  isError: false,
+  data: undefined,
+  error: null,
+  reset: jest.fn(),
+}));
+
 export const useSetBucketTagging = jest.fn(() => ({
   mutate: jest.fn(),
   mutateAsync: jest.fn(),

--- a/src/react/locations/CRRSetupWizard/hooks/useAssumeSourceRoleMutation.test.ts
+++ b/src/react/locations/CRRSetupWizard/hooks/useAssumeSourceRoleMutation.test.ts
@@ -1,0 +1,9 @@
+import { sourceStorageManagerRoleArn } from './useAssumeSourceRoleMutation';
+
+describe('sourceStorageManagerRoleArn', () => {
+  it('builds the storage-manager role ARN for the given account id', () => {
+    expect(sourceStorageManagerRoleArn('123456789012')).toBe(
+      'arn:aws:iam::123456789012:role/scality-internal/storage-manager-role',
+    );
+  });
+});

--- a/src/react/locations/CRRSetupWizard/hooks/useAssumeSourceRoleMutation.ts
+++ b/src/react/locations/CRRSetupWizard/hooks/useAssumeSourceRoleMutation.ts
@@ -1,0 +1,22 @@
+import { useMutation } from 'react-query';
+import { useSetAssumedRolePromise } from '../../../DataServiceRoleProvider';
+
+/**
+ * ARN of the platform-provisioned storage-manager role for an account — the
+ * role the wizard assumes to run S3 operations (create bucket, put replication)
+ * as that account. Matches the convention used by the ISV apply chain.
+ */
+export const sourceStorageManagerRoleArn = (accountId: string): string =>
+  `arn:aws:iam::${accountId}:role/scality-internal/storage-manager-role`;
+
+/**
+ * Assumes the source account's storage-manager role so the data-browser S3
+ * hooks target that account: the DataBrowserProvider S3 client is rebuilt from
+ * the newly assumed role between chain steps (same mechanism as the ISV chain).
+ */
+export const useAssumeSourceRoleMutation = () => {
+  const setRolePromise = useSetAssumedRolePromise();
+  return useMutation({
+    mutationFn: ({ roleArn }: { roleArn: string }) => setRolePromise({ roleArn }),
+  });
+};

--- a/src/react/locations/CRRSetupWizard/hooks/useCreateCRRLocationMutation.ts
+++ b/src/react/locations/CRRSetupWizard/hooks/useCreateCRRLocationMutation.ts
@@ -1,0 +1,67 @@
+import { useShellHooks } from '@scality/module-federation';
+import { useEffect, useRef } from 'react';
+import { useMutation } from 'react-query';
+import type { LocationV1 } from '../../../../js/managementClient/api';
+import { notFalsyTypeGuard } from '../../../../types/typeGuards';
+import { useManagementClient } from '../../../ManagementProvider';
+import { useInstanceId } from '../../../next-architecture/ui/AuthProvider';
+import { useCreateLocationMutation } from '../../hooks/useCreateLocationMutation';
+
+const POLL_INTERVAL_MS = 500;
+const MAX_POLLS = 120; // ~60s
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const isAlreadyExists = (error: unknown): boolean => {
+  const message = error instanceof Error ? error.message : JSON.stringify(error ?? '');
+  return /already\s?exists/i.test(message);
+};
+
+/**
+ * Creates the CRR location and resolves only once it has been applied to the
+ * running configuration. The subsequent replication rule references the
+ * location by name (`StorageClass`), which cloudserver only accepts after the
+ * overlay has reconciled — so the wizard must wait here before that step runs.
+ */
+export const useCreateCRRLocationMutation = () => {
+  const createLocation = useCreateLocationMutation();
+  const managementClient = useManagementClient();
+  const { useAuth } = useShellHooks();
+  const { getToken } = useAuth();
+  const instanceId = useInstanceId();
+
+  // Stop polling if the step is torn down (Exit/Cancel) so the loop can't outlive the component.
+  const cancelledRef = useRef(false);
+  useEffect(() => {
+    cancelledRef.current = false;
+    return () => {
+      cancelledRef.current = true;
+    };
+  }, []);
+
+  const runningConfigurationVersion = async (): Promise<number> => {
+    const client = notFalsyTypeGuard(managementClient);
+    client.setToken(await getToken());
+    return (await client.getLatestInstanceStatus(instanceId)).state?.runningConfigurationVersion ?? 0;
+  };
+
+  return useMutation({
+    mutationFn: async (location: LocationV1) => {
+      const referenceVersion = await runningConfigurationVersion();
+      try {
+        await createLocation.mutateAsync(location);
+      } catch (error) {
+        // On a retry after a reconcile timeout the location already exists — keep waiting, don't re-fail.
+        if (!isAlreadyExists(error)) throw error;
+      }
+      for (let attempt = 0; attempt < MAX_POLLS; attempt += 1) {
+        if (cancelledRef.current) return;
+        if ((await runningConfigurationVersion()) > referenceVersion) {
+          return;
+        }
+        await delay(POLL_INTERVAL_MS);
+      }
+      throw new Error('Timed out waiting for the location to be applied to the running configuration');
+    },
+  });
+};

--- a/src/react/locations/CRRSetupWizard/hooks/useImportDestinationCertificateMutation.test.ts
+++ b/src/react/locations/CRRSetupWizard/hooks/useImportDestinationCertificateMutation.test.ts
@@ -1,0 +1,22 @@
+import type { ZenkoCR } from '../../../truststore/Truststore';
+import { isCertificateAlreadyImported } from './useImportDestinationCertificateMutation';
+
+const CERT = '-----BEGIN CERTIFICATE-----\ndest\n-----END CERTIFICATE-----';
+const withCerts = (certs: string[]): ZenkoCR => ({
+  spec: { egress: { extraCACerts: certs.map((c) => ({ 'ca.crt': c })) } },
+});
+
+describe('isCertificateAlreadyImported', () => {
+  it('is false when the truststore has no egress configuration yet', () => {
+    expect(isCertificateAlreadyImported(undefined, CERT)).toBe(false);
+    expect(isCertificateAlreadyImported({ spec: {} }, CERT)).toBe(false);
+  });
+
+  it('is false when other certificates are present but not this one', () => {
+    expect(isCertificateAlreadyImported(withCerts(['some-other-cert']), CERT)).toBe(false);
+  });
+
+  it('is true when the exact certificate is already in the truststore', () => {
+    expect(isCertificateAlreadyImported(withCerts(['some-other-cert', CERT]), CERT)).toBe(true);
+  });
+});

--- a/src/react/locations/CRRSetupWizard/hooks/useImportDestinationCertificateMutation.ts
+++ b/src/react/locations/CRRSetupWizard/hooks/useImportDestinationCertificateMutation.ts
@@ -1,0 +1,33 @@
+import { useMutation, useQuery, useQueryClient } from 'react-query';
+import { useAddCertificateToZenkoConfigurationMutation } from '../../../../js/mutations';
+import { getZenkoCRQuery } from '../../../queries';
+import type { ZenkoCR } from '../../../truststore/Truststore';
+
+/** True when the PEM is already in the source truststore, so importing it again is a no-op. */
+export const isCertificateAlreadyImported = (zenkoCR: ZenkoCR | undefined, certificate: string): boolean =>
+  (zenkoCR?.spec?.egress?.extraCACerts ?? []).some((bundle) => bundle['ca.crt'] === certificate);
+
+/**
+ * Imports the destination CA certificate into the source cluster's truststore
+ * (Zenko CR `spec.egress.extraCACerts`). Idempotent: if the certificate is
+ * already present the step is a no-op, so re-runs and retries do not append
+ * duplicate entries.
+ */
+export const useImportDestinationCertificateMutation = () => {
+  const { data: zenkoCR } = useQuery(getZenkoCRQuery());
+  const queryClient = useQueryClient();
+  const hasEgress = !!zenkoCR?.spec?.egress;
+  const hasExtraCACerts = !!zenkoCR?.spec?.egress?.extraCACerts;
+  const addCertificate = useAddCertificateToZenkoConfigurationMutation({ hasEgress, hasExtraCACerts });
+
+  return useMutation({
+    mutationFn: async ({ certificate }: { certificate: string }) => {
+      // Read the latest cached CR at execution time, not the render-time snapshot.
+      const currentCR = queryClient.getQueryData<ZenkoCR>(['zenkoCR']) ?? zenkoCR;
+      if (isCertificateAlreadyImported(currentCR, certificate)) {
+        return;
+      }
+      await addCertificate.mutateAsync({ certificate });
+    },
+  });
+};

--- a/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/ApplyActionsStep.test.tsx
+++ b/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/ApplyActionsStep.test.tsx
@@ -1,22 +1,27 @@
-import { render, screen, waitFor } from '@testing-library/react';
-import userEvent from '@testing-library/user-event';
+import { render, screen } from '@testing-library/react';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
 import { Wrapper } from '../../../../utils/testUtil';
 import type { ConfigureFormValues } from '../ConfigureStep/schema';
 import { ApplyActionsStep } from './ApplyActionsStep';
 
+// The wizard stepper is the host framework around this step; stub it so the
+// step can render on its own. Everything else — the chain, the hooks — is the
+// real implementation, exercised through the real providers.
 const mockNext = jest.fn();
 const mockPrev = jest.fn();
-
 jest.mock('@scality/core-ui/dist/components/steppers/Stepper.component', () => ({
   useStepper: () => ({ next: mockNext, prev: mockPrev }),
 }));
 
-const STREAM_URL = '/crr-configurator/api/v1/replication-setups';
-const server = setupServer();
-
-beforeAll(() => server.listen({ onUnhandledRequest: 'error' }));
+// Only the network boundary is stubbed. The destination setup stream stays open
+// (empty body) so no step resolves during assertions on the initial plan.
+const server = setupServer(
+  rest.post('*/replication-setups', (_req, res, ctx) =>
+    res(ctx.status(200), ctx.set('Content-Type', 'application/x-ndjson'), ctx.body('')),
+  ),
+);
+beforeAll(() => server.listen({ onUnhandledRequest: 'bypass' }));
 afterEach(() => {
   server.resetHandlers();
   mockNext.mockReset();
@@ -24,11 +29,9 @@ afterEach(() => {
 });
 afterAll(() => server.close());
 
-const ndjson = (...lines: unknown[]) => `${lines.map((l) => JSON.stringify(l)).join('\n')}\n`;
-
 const VALUES: ConfigureFormValues = {
   accountNameType: 'create',
-  accountName: 'src-account',
+  accountName: 'crr-src',
   connectionMode: 'management-network',
   url: 'https://10.0.0.42:8443',
   baseDomain: '',
@@ -36,205 +39,48 @@ const VALUES: ConfigureFormValues = {
   username: 'scality',
   password: 'super-secret',
   certificate: '-----BEGIN CERTIFICATE-----\nx\n-----END CERTIFICATE-----',
-  destinationAccountName: 'dest-account',
+  destinationAccountName: 'crr-dest',
   createReplicationRule: true,
-  sourceBucketName: 'src-bucket',
-  targetBucketName: 'target-bucket',
+  sourceBucketName: 'crr-src-bucket',
+  targetBucketName: 'crr-target-bucket',
   prefix: '',
 };
 
-const RESULT = {
-  endpoint: 'https://cluster.example:8443',
-  stsEndpoint: 'https://cluster.example:8443/sts',
-  accessKey: 'AKIA',
-  secretKey: 'secret',
-  roleArn: 'arn:aws:iam::123456789012:role/crr',
-  targetBucket: 'target-bucket',
-};
-
-const ALL_STEPS_WHEN_NEW_ACCOUNT_AND_RULE = [
-  'import-destination-certificate',
-  'create-source-account',
-  'create-source-bucket',
-  'create-account',
-  'create-user',
-  'create-access-key',
-  'create-policy',
-  'create-role',
-  'attach-role-policy',
-  'create-bucket',
-  'create-location',
-  'create-replication-rule',
-] as const;
-
 describe('ApplyActionsStep', () => {
-  it('lists every provisioning action to run, all pending, before the setup starts', () => {
-    server.use(
-      rest.post(STREAM_URL, (_req, res, ctx) =>
-        res(ctx.set('Content-Type', 'application/x-ndjson'), ctx.body(ndjson())),
-      ),
-    );
-    render(<ApplyActionsStep {...VALUES} />, { wrapper: Wrapper });
+  it('lists every provisioning action in order, all pending, for the user to follow', () => {
+    render(<ApplyActionsStep {...VALUES} destinationInstanceName="paris-prod" />, { wrapper: Wrapper });
 
-    expect(screen.getByText('Import Destination Certificate')).toBeInTheDocument();
-    expect(screen.getByText('Create Account on Source: src-account')).toBeInTheDocument();
-    expect(screen.getByText('Create Bucket on Source: src-bucket')).toBeInTheDocument();
-    expect(screen.getByText('Create Account on Destination: dest-account')).toBeInTheDocument();
-    expect(screen.getByText('Create IAM User')).toBeInTheDocument();
-    expect(screen.getByText('Generate Access Key')).toBeInTheDocument();
-    expect(screen.getByText('Create Policy')).toBeInTheDocument();
-    expect(screen.getByText('Create IAM Role')).toBeInTheDocument();
-    expect(screen.getByText('Attach Policy to Role')).toBeInTheDocument();
-    expect(screen.getByText('Create Target Bucket: target-bucket')).toBeInTheDocument();
-    expect(screen.getByText('Create Location')).toBeInTheDocument();
-    expect(screen.getByText('Create Replication Rule')).toBeInTheDocument();
+    expect(screen.getByText('Configure paris-prod for Cross-Region Replication')).toBeInTheDocument();
+
+    const actions = [
+      'Import Destination Certificate',
+      'Create Account on Source: crr-src',
+      'Create Bucket on Source: crr-src-bucket',
+      'Create Account on Destination: crr-dest',
+      'Create IAM User',
+      'Generate Access Key',
+      'Create Policy',
+      'Create IAM Role',
+      'Attach Policy to Role',
+      'Create Target Bucket: crr-target-bucket',
+      'Create Location',
+      'Create Replication Rule',
+    ];
+    for (const action of actions) {
+      expect(screen.getByText(action)).toBeInTheDocument();
+    }
     expect(screen.getAllByText('Pending...').length).toBe(12);
+    // The setup only becomes confirmable once every action has succeeded.
+    expect(screen.getByRole('button', { name: /Continue/i })).toBeDisabled();
   });
 
-  it('uses the destination instance name in the title when one was returned by Verify', () => {
-    server.use(
-      rest.post(STREAM_URL, (_req, res, ctx) =>
-        res(ctx.set('Content-Type', 'application/x-ndjson'), ctx.body(ndjson())),
-      ),
-    );
-    render(<ApplyActionsStep {...VALUES} destinationInstanceName="ageless-valley" />, { wrapper: Wrapper });
-    expect(screen.getByText('Configure ageless-valley for Cross-Region Replication')).toBeInTheDocument();
-  });
-
-  it('falls back to "ARTESCA" in the title when the destination instance name is not available', () => {
-    server.use(
-      rest.post(STREAM_URL, (_req, res, ctx) =>
-        res(ctx.set('Content-Type', 'application/x-ndjson'), ctx.body(ndjson())),
-      ),
-    );
-    render(<ApplyActionsStep {...VALUES} />, { wrapper: Wrapper });
-    expect(screen.getByText('Configure ARTESCA for Cross-Region Replication')).toBeInTheDocument();
-  });
-
-  it('does not render Authenticate — that step was covered by the previous wizard step', () => {
-    server.use(
-      rest.post(STREAM_URL, (_req, res, ctx) =>
-        res(ctx.set('Content-Type', 'application/x-ndjson'), ctx.body(ndjson())),
-      ),
-    );
-    render(<ApplyActionsStep {...VALUES} />, { wrapper: Wrapper });
-    expect(screen.queryByText(/Authenticate/i)).not.toBeInTheDocument();
-  });
-
-  it('marks each action Success as it completes and only lets the user continue once all have succeeded', async () => {
-    server.use(
-      rest.post(STREAM_URL, (_req, res, ctx) =>
-        res(
-          ctx.set('Content-Type', 'application/x-ndjson'),
-          ctx.body(
-            ndjson(
-              ...ALL_STEPS_WHEN_NEW_ACCOUNT_AND_RULE.flatMap((step) => [
-                { event: 'step.started', step, at: 't' },
-                { event: 'step.completed', step, at: 't' },
-              ]),
-              { event: 'setup.completed', at: 't', result: RESULT },
-            ),
-          ),
-        ),
-      ),
-    );
-    render(<ApplyActionsStep {...VALUES} />, { wrapper: Wrapper });
-
-    await waitFor(() => expect(screen.getAllByText('Success').length).toBe(12));
-    const continueButton = screen.getByRole('button', { name: /Continue/i });
-    await waitFor(() => expect(continueButton).toBeEnabled());
-    await userEvent.click(continueButton);
-    expect(mockNext).toHaveBeenCalledWith(expect.objectContaining({ result: RESULT }));
-  });
-
-  it('renders the peer error message inline next to the Failed indicator so the user sees why the step failed', async () => {
-    server.use(
-      rest.post(STREAM_URL, (_req, res, ctx) =>
-        res(
-          ctx.set('Content-Type', 'application/x-ndjson'),
-          ctx.body(
-            ndjson(
-              { event: 'step.started', step: 'create-user', at: 't' },
-              {
-                event: 'step.failed',
-                step: 'create-user',
-                at: 't',
-                error: { code: 'InternalError', message: 'IAM refused CreateUser: entity already exists' },
-              },
-              { event: 'setup.failed', at: 't', error: { code: 'InternalError', message: 'IAM refused CreateUser: entity already exists' } },
-            ),
-          ),
-        ),
-      ),
-    );
-    render(<ApplyActionsStep {...VALUES} />, { wrapper: Wrapper });
-    await screen.findByRole('button', { name: /Retry/i });
-    expect(screen.getByText('IAM refused CreateUser: entity already exists')).toBeInTheDocument();
-  });
-
-  it('surfaces Failed with an inline Retry on the failed step and re-fires the mutation on click', async () => {
-    let requestCount = 0;
-    server.use(
-      rest.post(STREAM_URL, (_req, res, ctx) => {
-        requestCount += 1;
-        return res(
-          ctx.set('Content-Type', 'application/x-ndjson'),
-          ctx.body(
-            ndjson(
-              { event: 'step.started', step: 'create-user', at: 't' },
-              {
-                event: 'step.failed',
-                step: 'create-user',
-                at: 't',
-                error: { code: 'InternalError', message: 'IAM refused CreateUser' },
-              },
-              { event: 'setup.failed', at: 't', error: { code: 'InternalError', message: 'IAM refused CreateUser' } },
-            ),
-          ),
-        );
-      }),
-    );
-    render(<ApplyActionsStep {...VALUES} />, { wrapper: Wrapper });
-
-    const retry = await screen.findByRole('button', { name: /Retry/i });
-    expect(screen.getByText('Failed')).toBeInTheDocument();
-    await userEvent.click(retry);
-    await waitFor(() => expect(requestCount).toBe(2));
-  });
-
-  it('surfaces a global stream error on the first pending row via the same per-row Failed + Retry treatment', async () => {
-    let requestCount = 0;
-    server.use(
-      rest.post(STREAM_URL, (_req, res, ctx) => {
-        requestCount += 1;
-        return res(ctx.status(500), ctx.set('Content-Type', 'application/problem+json'), ctx.json({ title: 'Internal error', detail: 'the whole thing exploded' }));
-      }),
-    );
-    render(<ApplyActionsStep {...VALUES} />, { wrapper: Wrapper });
-
-    const retry = await screen.findByRole('button', { name: /Retry/i });
-    expect(screen.getByText('Failed')).toBeInTheDocument();
-    await userEvent.click(retry);
-    await waitFor(() => expect(requestCount).toBe(2));
-  });
-
-  it('skips creating a source account when the user reuses an existing one', () => {
-    server.use(
-      rest.post(STREAM_URL, (_req, res, ctx) =>
-        res(ctx.set('Content-Type', 'application/x-ndjson'), ctx.body(ndjson())),
-      ),
-    );
+  it('does not surface a source-account action when the user reuses an existing account', () => {
     render(<ApplyActionsStep {...VALUES} accountNameType="existing" />, { wrapper: Wrapper });
     expect(screen.queryByText(/Create Account on Source/i)).not.toBeInTheDocument();
     expect(screen.getAllByText('Pending...').length).toBe(11);
   });
 
-  it('skips the source bucket, target bucket and replication rule when the user opts out of creating a rule', () => {
-    server.use(
-      rest.post(STREAM_URL, (_req, res, ctx) =>
-        res(ctx.set('Content-Type', 'application/x-ndjson'), ctx.body(ndjson())),
-      ),
-    );
+  it('does not surface the source bucket, target bucket or replication rule when no rule is requested', () => {
     render(<ApplyActionsStep {...VALUES} createReplicationRule={false} sourceBucketName="" targetBucketName="" />, {
       wrapper: Wrapper,
     });
@@ -242,5 +88,10 @@ describe('ApplyActionsStep', () => {
     expect(screen.queryByText(/Create Target Bucket/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Create Replication Rule/i)).not.toBeInTheDocument();
     expect(screen.getAllByText('Pending...').length).toBe(9);
+  });
+
+  it('falls back to "ARTESCA" in the title when Verify returned no instance name', () => {
+    render(<ApplyActionsStep {...VALUES} />, { wrapper: Wrapper });
+    expect(screen.getByText('Configure ARTESCA for Cross-Region Replication')).toBeInTheDocument();
   });
 });

--- a/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/ApplyActionsStep.tsx
+++ b/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/ApplyActionsStep.tsx
@@ -1,14 +1,38 @@
 import { Form, Icon, Stack, Text } from '@scality/core-ui';
 import { useStepper } from '@scality/core-ui/dist/components/steppers/Stepper.component';
 import { Button } from '@scality/core-ui/dist/next';
+import { useCreateBucket, useSetBucketReplication, useSetBucketVersioning } from '@scality/data-browser-library';
+import {
+  type MutationConfig,
+  type PreviousResults,
+  useChainedMutations,
+  type VariablesResolvers,
+} from '@scality/react-chained-query';
 import { useEffect, useMemo, useRef } from 'react';
 import { useTheme } from 'styled-components';
-import Table, * as T from '../../../../ui-elements/Table';
+import { useCreateAccountMutation } from '../../../../../js/mutations';
+import { useListAccounts } from '../../../../next-architecture/domain/business/accounts';
+import { useAccessibleAccountsAdapter } from '../../../../next-architecture/ui/AccessibleAccountsAdapterProvider';
+import { useInstanceId } from '../../../../next-architecture/ui/AuthProvider';
+import { NoOpMetricsAdapter } from '../../../../ui-elements/SelectAccountIAMRole';
 import { ErrorText, StatusBox } from '../../../../ui-elements/status';
-import type { StartSetupBody } from '../../api/types';
+import Table, * as T from '../../../../ui-elements/Table';
+import type { SetupResult, StartSetupBody } from '../../api/types';
+import { sourceStorageManagerRoleArn, useAssumeSourceRoleMutation } from '../../hooks/useAssumeSourceRoleMutation';
 import { useCRRConfigurationSetupMutation } from '../../hooks/useCRRConfigurationSetupMutation';
+import { useCreateCRRLocationMutation } from '../../hooks/useCreateCRRLocationMutation';
+import { useImportDestinationCertificateMutation } from '../../hooks/useImportDestinationCertificateMutation';
 import { type ConfigureFormValues, toStartSetupBody } from '../ConfigureStep/schema';
-import { allSucceeded, buildStepViews, type StepView } from './steps';
+import { buildCRRLocation, buildCRRLocationName } from './crrLocation';
+import { buildCRRReplicationConfiguration } from './replicationConfiguration';
+import {
+  allSucceeded,
+  buildStepViews,
+  type ChainStatus,
+  CONFIGURATOR_CHAIN_LINK_ID,
+  retryLinkIdForRow,
+  type StepView,
+} from './steps';
 
 export const APPLY_ACTIONS_STEP_INDEX = 1;
 
@@ -42,7 +66,7 @@ const StatusCell = ({ view, onRetry }: { view: StepView; onRetry: () => void }) 
 
 export const ApplyActionsStep = (props: Props) => {
   const { next, prev } = useStepper(APPLY_ACTIONS_STEP_INDEX);
-  const setup = useCRRConfigurationSetupMutation();
+  const instanceId = useInstanceId();
 
   const {
     accountNameType,
@@ -52,10 +76,30 @@ export const ApplyActionsStep = (props: Props) => {
     createReplicationRule,
     destinationInstanceName,
   } = props;
+  const isNewSourceAccount = accountNameType === 'create';
+  const withReplicationRule = createReplicationRule === true;
 
+  // Pre-create every mutation so per-row error messages stay accessible.
+  const importCertificate = useImportDestinationCertificateMutation();
+  const createSourceAccount = useCreateAccountMutation();
+  const assumeSourceRole = useAssumeSourceRoleMutation();
+  const createSourceBucket = useCreateBucket();
+  const enableSourceVersioning = useSetBucketVersioning();
+  const setup = useCRRConfigurationSetupMutation();
+  const createLocation = useCreateCRRLocationMutation();
+  const createReplicationRuleMutation = useSetBucketReplication();
+
+  const accountsAdapter = useAccessibleAccountsAdapter();
+  const metricsAdapter = useMemo(() => new NoOpMetricsAdapter(), []);
+  const { accounts: accountsResult } = useListAccounts({ accessibleAccountsAdapter: accountsAdapter, metricsAdapter });
+  const existingSourceRoleArn =
+    accountsResult.status === 'success'
+      ? (accountsResult.value.find((account) => account.name === accountName)?.preferredAssumableRoleArn ?? '')
+      : '';
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: depend on the individual form fields, not the props object identity
   const body: StartSetupBody | null = useMemo(
     () => (isCompleteFormValues(props) ? toStartSetupBody(props) : null),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       props.connectionMode,
       props.certificate,
@@ -73,57 +117,173 @@ export const ApplyActionsStep = (props: Props) => {
     ],
   );
 
-  const globalErrorMessage = setup.isError ? setup.error?.message ?? 'The replication setup could not be completed.' : undefined;
+  const locationName = buildCRRLocationName({
+    destinationAccountName: destinationAccountName ?? '',
+    url: props.url || undefined,
+    baseDomain: props.baseDomain || undefined,
+  });
+
+  const sourceRoleArn = (prev: PreviousResults): string => {
+    if (isNewSourceAccount) {
+      const account = prev['create-source-account']?.data as { id?: string } | undefined;
+      return account?.id ? sourceStorageManagerRoleArn(account.id) : '';
+    }
+    return existingSourceRoleArn;
+  };
+
+  const configuratorResult = (prev: PreviousResults) =>
+    prev[CONFIGURATOR_CHAIN_LINK_ID]?.data as SetupResult | undefined;
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: rebuild only when the chain's shape or resolved inputs change, not on every mutation-instance render
+  const { mutations, variables } = useMemo(() => {
+    const configs: MutationConfig[] = [
+      { id: 'import-destination-certificate', label: 'Import Destination Certificate', mutation: importCertificate },
+    ];
+    const resolvers: VariablesResolvers = {
+      'import-destination-certificate': () => ({ certificate: props.certificate }),
+    };
+
+    if (isNewSourceAccount) {
+      configs.push({ id: 'create-source-account', label: 'Create Source Account', mutation: createSourceAccount });
+      resolvers['create-source-account'] = () => ({
+        user: { userName: accountName ?? '', email: `${accountName}@artesca.local` },
+        instanceId,
+      });
+    }
+
+    if (withReplicationRule) {
+      configs.push({ id: 'assume-source-role', label: 'Assume Source Role', mutation: assumeSourceRole });
+      resolvers['assume-source-role'] = (prev) => ({ roleArn: sourceRoleArn(prev) });
+
+      configs.push({ id: 'create-source-bucket', label: 'Create Source Bucket', mutation: createSourceBucket });
+      resolvers['create-source-bucket'] = () => ({ Bucket: sourceBucketName });
+
+      configs.push({
+        id: 'create-source-bucket-versioning',
+        label: 'Enable Source Versioning',
+        mutation: enableSourceVersioning,
+      });
+      resolvers['create-source-bucket-versioning'] = () => ({
+        Bucket: sourceBucketName,
+        VersioningConfiguration: { Status: 'Enabled' },
+      });
+    }
+
+    configs.push({ id: CONFIGURATOR_CHAIN_LINK_ID, label: 'Configure Destination', mutation: setup });
+    resolvers[CONFIGURATOR_CHAIN_LINK_ID] = () => body;
+
+    configs.push({ id: 'create-location', label: 'Create Location', mutation: createLocation });
+    resolvers['create-location'] = (prev) => {
+      const result = configuratorResult(prev);
+      if (!result) throw new Error('Cannot create the CRR location: the destination setup result is missing.');
+      return buildCRRLocation(locationName, result);
+    };
+
+    if (withReplicationRule) {
+      configs.push({
+        id: 'create-replication-rule',
+        label: 'Create Replication Rule',
+        mutation: createReplicationRuleMutation,
+      });
+      resolvers['create-replication-rule'] = (prev) => {
+        const result = configuratorResult(prev);
+        if (!result) throw new Error('Cannot create the replication rule: the destination setup result is missing.');
+        return buildCRRReplicationConfiguration({
+          sourceBucketName: sourceBucketName ?? '',
+          targetBucketName: props.targetBucketName ?? '',
+          locationName,
+          destinationRoleArn: result.roleArn,
+        });
+      };
+    }
+
+    return { mutations: configs, variables: resolvers };
+  }, [isNewSourceAccount, withReplicationRule, body, locationName, existingSourceRoleArn]);
+
+  const { Slots, steps, start, getResult, allRequiredStepsComplete } = useChainedMutations({ mutations, variables });
+
+  const errorMessage = (error: unknown): string | undefined => (error as Error | undefined)?.message;
+  const linkErrors: Record<string, string | undefined> = {
+    'import-destination-certificate': errorMessage(importCertificate.error),
+    'create-source-account': errorMessage(createSourceAccount.error),
+    'assume-source-role': errorMessage(assumeSourceRole.error),
+    'create-source-bucket': errorMessage(createSourceBucket.error),
+    'create-source-bucket-versioning': errorMessage(enableSourceVersioning.error),
+    'create-location': errorMessage(createLocation.error),
+    'create-replication-rule': errorMessage(createReplicationRuleMutation.error),
+  };
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: re-read the current link errors whenever the chain steps change
+  const chainStatusById: Record<string, ChainStatus> = useMemo(() => {
+    const byId: Record<string, ChainStatus> = {};
+    for (const step of steps) {
+      byId[step.id] = { status: step.status, errorMessage: linkErrors[step.id] };
+    }
+    return byId;
+  }, [steps]);
+
+  const configuratorStatus = steps.find((step) => step.id === CONFIGURATOR_CHAIN_LINK_ID)?.status;
+  const configuratorError =
+    configuratorStatus === 'error'
+      ? ((setup.error as Error | undefined)?.message ?? 'The destination setup failed.')
+      : undefined;
 
   const stepViews = useMemo(
     () =>
       buildStepViews(
         {
-          isNewSourceAccount: accountNameType === 'create',
-          createReplicationRule: createReplicationRule === true,
+          isNewSourceAccount,
+          createReplicationRule: withReplicationRule,
           sourceAccountName: accountName ?? '',
           sourceBucketName: sourceBucketName ?? '',
           targetBucketName: props.targetBucketName ?? '',
           destinationAccountName: destinationAccountName ?? '',
         },
-        setup.events,
-        { globalErrorMessage },
+        { configuratorEvents: setup.events, chainStatusById, configuratorError },
       ),
-    [accountNameType, createReplicationRule, accountName, sourceBucketName, props.targetBucketName, destinationAccountName, setup.events, globalErrorMessage],
+    [
+      isNewSourceAccount,
+      withReplicationRule,
+      accountName,
+      sourceBucketName,
+      props.targetBucketName,
+      destinationAccountName,
+      setup.events,
+      chainStatusById,
+      configuratorError,
+    ],
   );
 
   const hasStartedRef = useRef(false);
-  const startMutation = setup.mutate;
   useEffect(() => {
     if (body && !hasStartedRef.current) {
       hasStartedRef.current = true;
-      startMutation(body);
+      start();
     }
-  }, [body, startMutation]);
+  }, [body, start]);
 
-  const allDone = allSucceeded(stepViews);
+  const allDone = allSucceeded(stepViews) && allRequiredStepsComplete;
+  // While the chain runs, Exit is disabled so the user can't navigate away mid-provisioning; it re-enables on completion or failure.
+  const isRunning = steps.some((step) => step.status === 'pending');
+  const setupResult = getResult<SetupResult>(CONFIGURATOR_CHAIN_LINK_ID);
 
   const advancedRef = useRef(false);
-  const setupData = setup.data;
   useEffect(() => {
-    if (setupData && !advancedRef.current) {
+    if (allDone && !advancedRef.current) {
       advancedRef.current = true;
-      next({ result: setupData, ...props });
+      next({ result: setupResult, ...props });
     }
-  }, [setupData, next, props]);
+  }, [allDone, setupResult, next, props]);
 
-  const onRetry = () => {
-    if (!body) return;
-    setup.reset();
-    advancedRef.current = false;
-    hasStartedRef.current = true;
-    setup.mutate(body);
+  const onRetry = (view: StepView) => {
+    const linkId = retryLinkIdForRow(view.id, chainStatusById);
+    steps.find((step) => step.id === linkId)?.retry();
   };
 
   const onContinue = () => {
-    if (advancedRef.current || !setupData) return;
+    if (advancedRef.current || !allDone) return;
     advancedRef.current = true;
-    next({ result: setupData, ...props });
+    next({ result: setupResult, ...props });
   };
 
   const title = `Configure ${destinationInstanceName || 'ARTESCA'} for Cross-Region Replication`;
@@ -142,29 +302,22 @@ export const ApplyActionsStep = (props: Props) => {
       requireMode="all"
       rightActions={
         <Stack gap="r16">
-          <Button
-            type="button"
-            variant="outline"
-            label="Exit"
-            disabled={setup.isLoading}
-            onClick={() => prev(props)}
-          />
-          {setup.isLoading && (
-            <Button type="button" variant="outline" label="Cancel" onClick={setup.cancel} />
-          )}
+          <Button type="button" variant="outline" label="Exit" disabled={isRunning} onClick={() => prev(props)} />
+          {setup.isLoading && <Button type="button" variant="outline" label="Cancel" onClick={setup.cancel} />}
           <Button
             type="button"
             variant="primary"
             label="Continue"
             icon={<Icon name="Arrow-right" />}
             isLoading={setup.isLoading}
-            disabled={!allDone || !setup.data}
+            disabled={!allDone}
             onClick={onContinue}
           />
         </Stack>
       }
       style={{ width: '50rem' }}
     >
+      {Slots}
       <div style={{ height: '32rem', overflow: 'auto' }}>
         <Table>
           <T.Head>
@@ -182,7 +335,7 @@ export const ApplyActionsStep = (props: Props) => {
                   <Text>{view.label}</Text>
                 </T.Cell>
                 <T.Cell style={{ width: '12.5%' }}>
-                  <StatusCell view={view} onRetry={onRetry} />
+                  <StatusCell view={view} onRetry={() => onRetry(view)} />
                 </T.Cell>
               </T.Row>
             ))}

--- a/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/crrLocation.test.ts
+++ b/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/crrLocation.test.ts
@@ -1,0 +1,39 @@
+import type { SetupResult } from '../../api/types';
+import { buildCRRLocation, buildCRRLocationName } from './crrLocation';
+
+describe('buildCRRLocationName', () => {
+  it('uses the destination host from the connection URL, without scheme or port (management-network)', () => {
+    expect(buildCRRLocationName({ destinationAccountName: 'dest-acct', url: 'https://10.0.0.42:8443' })).toBe(
+      'dest-acct-10-0-0-42',
+    );
+  });
+
+  it('uses the base domain host (data-network)', () => {
+    expect(buildCRRLocationName({ destinationAccountName: 'dest-acct', baseDomain: 's3.example.com' })).toBe(
+      'dest-acct-s3-example-com',
+    );
+  });
+});
+
+describe('buildCRRLocation', () => {
+  const result: SetupResult = {
+    endpoint: 'https://10.0.0.42:8443',
+    stsEndpoint: 'https://10.0.0.42:8443/sts',
+    accessKey: 'AKIA',
+    secretKey: 'secret',
+    roleArn: 'arn:aws:iam::123456789012:role/crr-role',
+  };
+
+  it('builds a location-scality-crr-v1 with the destination endpoints and crr-user keys from the setup result', () => {
+    expect(buildCRRLocation('dest-acct-10-0-0-42', result)).toEqual({
+      name: 'dest-acct-10-0-0-42',
+      locationType: 'location-scality-crr-v1',
+      details: {
+        endpoint: 'https://10.0.0.42:8443',
+        stsEndpoint: 'https://10.0.0.42:8443/sts',
+        accessKey: 'AKIA',
+        secretKey: 'secret',
+      },
+    });
+  });
+});

--- a/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/crrLocation.ts
+++ b/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/crrLocation.ts
@@ -1,0 +1,42 @@
+import {
+  type Locationscalitycrrv1Details,
+  LocationType,
+  type LocationV1,
+} from '../../../../../js/managementClient/api';
+import type { SetupResult } from '../../api/types';
+
+/** Reduces a host to characters valid in a location name (dots/other separators become hyphens). */
+const sanitizeHost = (host: string): string => host.replace(/[^a-zA-Z0-9-]/g, '-');
+
+/**
+ * Derives the CRR location name as `<destinationAccountName>-<host>`, where host
+ * is the destination IP/hostname only (no scheme, no port). Management-network
+ * uses the connection URL's host; data-network uses the base domain.
+ */
+export const buildCRRLocationName = ({
+  destinationAccountName,
+  url,
+  baseDomain,
+}: {
+  destinationAccountName: string;
+  url?: string;
+  baseDomain?: string;
+}): string => {
+  const host = url ? new URL(url).hostname : (baseDomain ?? '');
+  return `${destinationAccountName}-${sanitizeHost(host)}`;
+};
+
+/**
+ * Builds the `location-scality-crr-v1` configuration from the backend setup
+ * result: the destination S3/STS endpoints and the crr-user access keys the
+ * configurator created.
+ */
+export const buildCRRLocation = (name: string, result: SetupResult): LocationV1 => {
+  const details: Locationscalitycrrv1Details = {
+    endpoint: result.endpoint,
+    stsEndpoint: result.stsEndpoint,
+    accessKey: result.accessKey,
+    secretKey: result.secretKey,
+  };
+  return { name, locationType: LocationType.ScalityCrrV1, details };
+};

--- a/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/replicationConfiguration.test.ts
+++ b/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/replicationConfiguration.test.ts
@@ -1,0 +1,27 @@
+import { buildCRRReplicationConfiguration } from './replicationConfiguration';
+
+describe('buildCRRReplicationConfiguration', () => {
+  const config = buildCRRReplicationConfiguration({
+    sourceBucketName: 'source-bucket',
+    targetBucketName: 'target-bucket',
+    locationName: 'crr-paris',
+    destinationRoleArn: 'arn:aws:iam::123456789012:role/crr-role',
+  });
+
+  it('targets the source bucket', () => {
+    expect(config.Bucket).toBe('source-bucket');
+  });
+
+  it('pairs the source replication role with the destination crr-role, as the CRR procedure requires', () => {
+    expect(config.ReplicationConfiguration?.Role).toBe(
+      'arn:aws:iam::root:role/s3-replication-role,arn:aws:iam::123456789012:role/crr-role',
+    );
+  });
+
+  it('routes replication to the target bucket via the CRR location name', () => {
+    const [rule] = config.ReplicationConfiguration?.Rules ?? [];
+    expect(rule.Status).toBe('Enabled');
+    expect(rule.Destination.Bucket).toBe('arn:aws:s3:::target-bucket');
+    expect(rule.Destination.StorageClass).toBe('crr-paris');
+  });
+});

--- a/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/replicationConfiguration.ts
+++ b/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/replicationConfiguration.ts
@@ -1,0 +1,45 @@
+import type { PutBucketReplicationCommandInput, StorageClass } from '@aws-sdk/client-s3';
+
+/**
+ * Source-side placeholder replication role. Per the ARTESCA CRR procedure the
+ * top-level `Role` is a comma-separated pair: this source role followed by the
+ * destination `crr-role` ARN returned by the configurator (`SetupResult.roleArn`).
+ */
+export const SOURCE_REPLICATION_ROLE_ARN = 'arn:aws:iam::root:role/s3-replication-role';
+
+type BuildReplicationConfigurationInput = {
+  sourceBucketName: string;
+  targetBucketName: string;
+  locationName: string;
+  destinationRoleArn: string;
+};
+
+/**
+ * Builds the S3 PutBucketReplication input for a CRR-location destination.
+ * ARTESCA reads `Destination.StorageClass` as the CRR location name (a locator,
+ * not a quality-of-service class) and resolves the destination cluster from it.
+ */
+export const buildCRRReplicationConfiguration = ({
+  sourceBucketName,
+  targetBucketName,
+  locationName,
+  destinationRoleArn,
+}: BuildReplicationConfigurationInput): PutBucketReplicationCommandInput => ({
+  Bucket: sourceBucketName,
+  ReplicationConfiguration: {
+    Role: `${SOURCE_REPLICATION_ROLE_ARN},${destinationRoleArn}`,
+    Rules: [
+      {
+        ID: `crr-${locationName}`,
+        Status: 'Enabled',
+        Prefix: '',
+        Destination: {
+          Bucket: `arn:aws:s3:::${targetBucketName}`,
+          // ARTESCA overloads StorageClass as the CRR location name — an arbitrary
+          // string, not one of the SDK's storage-class literals.
+          StorageClass: locationName as StorageClass,
+        },
+      },
+    ],
+  },
+});

--- a/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/steps.test.ts
+++ b/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/steps.test.ts
@@ -1,5 +1,13 @@
 import type { SetupEvent } from '../../api/types';
-import { allSucceeded, buildStepViews, hasFailure, type StepListInput } from './steps';
+import {
+  allSucceeded,
+  buildStepViews,
+  type ChainStatus,
+  hasFailure,
+  retryLinkIdForRow,
+  type StepListInput,
+  type StepStateSources,
+} from './steps';
 
 const baseInput: StepListInput = {
   isNewSourceAccount: true,
@@ -10,9 +18,21 @@ const baseInput: StepListInput = {
   destinationAccountName: 'dest-account',
 };
 
+const noProgress: StepStateSources = { configuratorEvents: [], chainStatusById: {} };
+
+const withChain = (chainStatusById: Record<string, ChainStatus>): StepStateSources => ({
+  configuratorEvents: [],
+  chainStatusById,
+});
+
+const withEvents = (configuratorEvents: SetupEvent[]): StepStateSources => ({
+  configuratorEvents,
+  chainStatusById: {},
+});
+
 describe('buildStepViews', () => {
   it('lists the full provisioning sequence in order when the user creates a new source account and a replication rule', () => {
-    const views = buildStepViews(baseInput, []);
+    const views = buildStepViews(baseInput, noProgress);
     expect(views.map((v) => v.id)).toEqual([
       'import-destination-certificate',
       'create-source-account',
@@ -30,7 +50,7 @@ describe('buildStepViews', () => {
   });
 
   it('numbers the steps and shows the chosen source and destination account names', () => {
-    const [first, sourceAcc, sourceBkt, destAcc] = buildStepViews(baseInput, []);
+    const [first, sourceAcc, sourceBkt, destAcc] = buildStepViews(baseInput, noProgress);
     expect(first).toMatchObject({ step: 1, label: 'Import Destination Certificate' });
     expect(sourceAcc).toMatchObject({ step: 2, label: 'Create Account on Source: src-account' });
     expect(sourceBkt).toMatchObject({ step: 3, label: 'Create Bucket on Source: src-bucket' });
@@ -38,7 +58,7 @@ describe('buildStepViews', () => {
   });
 
   it('labels the destination IAM chain and the target bucket per the ARTESCA CRR procedure', () => {
-    const labels = buildStepViews(baseInput, []).map((v) => v.label);
+    const labels = buildStepViews(baseInput, noProgress).map((v) => v.label);
     expect(labels).toContain('Create IAM User');
     expect(labels).toContain('Generate Access Key');
     expect(labels).toContain('Create Policy');
@@ -49,36 +69,88 @@ describe('buildStepViews', () => {
     expect(labels).toContain('Create Replication Rule');
   });
 
-  it('drops create-source-account when the wizard picked an existing source account', () => {
-    const views = buildStepViews({ ...baseInput, isNewSourceAccount: false }, []);
+  it('drops create-source-account when the user reuses an existing source account', () => {
+    const views = buildStepViews({ ...baseInput, isNewSourceAccount: false }, noProgress);
     expect(views.find((v) => v.id === 'create-source-account')).toBeUndefined();
   });
 
-  it('drops the replication-only steps when the wizard did not opt into replication rule creation', () => {
-    const views = buildStepViews({ ...baseInput, createReplicationRule: false }, []);
+  it('drops the replication-only steps when the user does not opt into creating a rule', () => {
+    const views = buildStepViews({ ...baseInput, createReplicationRule: false }, noProgress);
     expect(views.find((v) => v.id === 'create-source-bucket')).toBeUndefined();
     expect(views.find((v) => v.id === 'create-bucket')).toBeUndefined();
     expect(views.find((v) => v.id === 'create-replication-rule')).toBeUndefined();
   });
 
-  it('never surfaces the backend authenticate step (it is covered by the Verify wizard step)', () => {
-    const ids = buildStepViews(baseInput, []).map((v) => v.id) as string[];
-    expect(ids).not.toContain('authenticate');
+  it('shows every step as pending before anything runs', () => {
+    expect(buildStepViews(baseInput, noProgress).every((v) => v.state === 'pending')).toBe(true);
+  });
+});
+
+describe('buildStepViews — wizard-run rows', () => {
+  it('reflects each wizard chain link status on its row', () => {
+    const views = buildStepViews(baseInput, withChain({ 'import-destination-certificate': { status: 'success' } }));
+    expect(views.find((v) => v.id === 'import-destination-certificate')?.state).toBe('succeeded');
   });
 
-  it('surfaces the destination role, policy attachment and target bucket steps the CRR procedure requires', () => {
-    const ids = buildStepViews(baseInput, []).map((v) => v.id) as string[];
-    for (const id of ['create-role', 'attach-role-policy', 'create-bucket']) {
-      expect(ids).toContain(id);
-    }
+  it('surfaces a wizard link error message on its row', () => {
+    const views = buildStepViews(
+      baseInput,
+      withChain({ 'create-location': { status: 'error', errorMessage: 'overlay rejected the location' } }),
+    );
+    const location = views.find((v) => v.id === 'create-location');
+    expect(location?.state).toBe('failed');
+    expect(location?.errorMessage).toBe('overlay rejected the location');
   });
 
-  it('shows every step as pending before the setup runs', () => {
-    const views = buildStepViews(baseInput, []);
-    expect(views.every((v) => v.state === 'pending')).toBe(true);
+  it('keeps the source-bucket row pending until assuming the role, creating the bucket and versioning all succeed', () => {
+    const versioningPending = buildStepViews(
+      baseInput,
+      withChain({
+        'assume-source-role': { status: 'success' },
+        'create-source-bucket': { status: 'success' },
+        'create-source-bucket-versioning': { status: 'pending' },
+      }),
+    );
+    expect(versioningPending.find((v) => v.id === 'create-source-bucket')?.state).toBe('pending');
+
+    const allThree = buildStepViews(
+      baseInput,
+      withChain({
+        'assume-source-role': { status: 'success' },
+        'create-source-bucket': { status: 'success' },
+        'create-source-bucket-versioning': { status: 'success' },
+      }),
+    );
+    expect(allThree.find((v) => v.id === 'create-source-bucket')?.state).toBe('succeeded');
   });
 
-  it('marks a step done once it completes and shows the reason when one fails', () => {
+  it('fails the source-bucket row when enabling versioning fails', () => {
+    const views = buildStepViews(
+      baseInput,
+      withChain({
+        'assume-source-role': { status: 'success' },
+        'create-source-bucket': { status: 'success' },
+        'create-source-bucket-versioning': { status: 'error', errorMessage: 'versioning refused' },
+      }),
+    );
+    const row = views.find((v) => v.id === 'create-source-bucket');
+    expect(row?.state).toBe('failed');
+    expect(row?.errorMessage).toBe('versioning refused');
+  });
+
+  it('surfaces an assume-source-role failure on the source-bucket row instead of stalling silently', () => {
+    const views = buildStepViews(
+      baseInput,
+      withChain({ 'assume-source-role': { status: 'error', errorMessage: 'could not assume the source role' } }),
+    );
+    const row = views.find((v) => v.id === 'create-source-bucket');
+    expect(row?.state).toBe('failed');
+    expect(row?.errorMessage).toBe('could not assume the source role');
+  });
+});
+
+describe('buildStepViews — crr-configurator rows', () => {
+  it('marks a configurator step done once it completes and shows the reason when one fails', () => {
     const events: SetupEvent[] = [
       { event: 'step.completed', step: 'create-account', at: 't' },
       {
@@ -88,66 +160,103 @@ describe('buildStepViews', () => {
         error: { code: 'InternalError', message: 'IAM refused CreateUser: entity already exists' },
       },
     ];
-    const views = buildStepViews(baseInput, events);
+    const views = buildStepViews(baseInput, withEvents(events));
     expect(views.find((v) => v.id === 'create-account')?.state).toBe('succeeded');
     const failed = views.find((v) => v.id === 'create-user');
     expect(failed?.state).toBe('failed');
     expect(failed?.errorMessage).toBe('IAM refused CreateUser: entity already exists');
   });
-});
 
-describe('when the whole setup fails without pinpointing a step', () => {
-  it('blames the first step still waiting to run and shows why', () => {
-    const views = buildStepViews(baseInput, [], { globalErrorMessage: 'network exploded' });
-    const firstPending = views[0];
-    expect(firstPending.state).toBe('failed');
-    expect(firstPending.errorMessage).toBe('network exploded');
-    for (const v of views.slice(1)) expect(v.state).toBe('pending');
+  it('blames the first pending configurator row when the stream fails without pinning a step', () => {
+    const views = buildStepViews(baseInput, {
+      configuratorEvents: [],
+      chainStatusById: {},
+      configuratorError: 'the destination stream dropped',
+    });
+    const firstConfiguratorRow = views.find((v) => v.id === 'create-account');
+    expect(firstConfiguratorRow?.state).toBe('failed');
+    expect(firstConfiguratorRow?.errorMessage).toBe('the destination stream dropped');
   });
 
-  it('blames the first unfinished step once earlier ones have already succeeded', () => {
-    const events: SetupEvent[] = [
-      { event: 'step.completed', step: 'import-destination-certificate', at: 't' },
-      { event: 'step.completed', step: 'create-source-account', at: 't' },
-    ];
-    const views = buildStepViews(baseInput, events, { globalErrorMessage: 'stream ended without a terminal event' });
-    expect(views[0].state).toBe('succeeded');
-    expect(views[1].state).toBe('succeeded');
-    expect(views[2].state).toBe('failed');
-    expect(views[2].errorMessage).toBe('stream ended without a terminal event');
-  });
-
-  it('keeps a specific step failure visible rather than replacing it with the generic error', () => {
-    const events: SetupEvent[] = [
-      {
-        event: 'step.failed',
-        step: 'create-user',
-        at: 't',
-        error: { code: 'InternalError', message: 'IAM refused CreateUser' },
-      },
-    ];
-    const views = buildStepViews(baseInput, events, { globalErrorMessage: 'irrelevant' });
-    const stepFailure = views.find((v) => v.id === 'create-user');
-    expect(stepFailure?.state).toBe('failed');
-    expect(stepFailure?.errorMessage).toBe('IAM refused CreateUser');
+  it('keeps a specific step failure visible rather than replacing it with the stream error', () => {
+    const views = buildStepViews(baseInput, {
+      configuratorEvents: [
+        {
+          event: 'step.failed',
+          step: 'create-policy',
+          at: 't',
+          error: { code: 'InternalError', message: 'policy boom' },
+        },
+      ],
+      chainStatusById: {},
+      configuratorError: 'irrelevant',
+    });
+    expect(views.find((v) => v.id === 'create-policy')?.errorMessage).toBe('policy boom');
     expect(views.filter((v) => v.state === 'failed').length).toBe(1);
   });
 });
 
-describe('allSucceeded / hasFailure', () => {
-  const allIds = buildStepViews(baseInput, []).map((v) => v.id);
-
-  it('allSucceeded requires every listed step to be succeeded', () => {
-    const events: SetupEvent[] = allIds.map((step) => ({ event: 'step.completed', step, at: 't' }));
-    expect(allSucceeded(buildStepViews(baseInput, events))).toBe(true);
-    expect(allSucceeded(buildStepViews(baseInput, []))).toBe(false);
+describe('retryLinkIdForRow', () => {
+  it('retries a configurator row by re-running the single configurator link', () => {
+    expect(retryLinkIdForRow('create-role', {})).toBe('configurator-setup');
+    expect(retryLinkIdForRow('create-account', {})).toBe('configurator-setup');
   });
 
-  it('hasFailure is true when any step is failed', () => {
-    const events: SetupEvent[] = [
-      { event: 'step.failed', step: 'create-policy', at: 't', error: { code: 'InternalError', message: 'boom' } },
-    ];
-    expect(hasFailure(buildStepViews(baseInput, events))).toBe(true);
-    expect(hasFailure(buildStepViews(baseInput, []))).toBe(false);
+  it('retries a single-link wizard row by re-running its own link', () => {
+    expect(retryLinkIdForRow('import-destination-certificate', {})).toBe('import-destination-certificate');
+    expect(retryLinkIdForRow('create-location', {})).toBe('create-location');
+  });
+
+  it('retries the failed link of the folded source-bucket row, not the one that already succeeded', () => {
+    const status = {
+      'assume-source-role': { status: 'success' as const },
+      'create-source-bucket': { status: 'success' as const },
+      'create-source-bucket-versioning': { status: 'error' as const },
+    };
+    expect(retryLinkIdForRow('create-source-bucket', status)).toBe('create-source-bucket-versioning');
+  });
+
+  it('retries the assume-source-role link when that is the folded step that failed', () => {
+    expect(retryLinkIdForRow('create-source-bucket', { 'assume-source-role': { status: 'error' } })).toBe(
+      'assume-source-role',
+    );
+  });
+});
+
+describe('allSucceeded / hasFailure', () => {
+  it('allSucceeded is true only once every listed row has succeeded', () => {
+    const allDone: StepStateSources = {
+      configuratorEvents: [
+        'create-account',
+        'create-user',
+        'create-access-key',
+        'create-policy',
+        'create-role',
+        'attach-role-policy',
+        'create-bucket',
+      ].map((step) => ({ event: 'step.completed', step, at: 't' }) as SetupEvent),
+      chainStatusById: {
+        'import-destination-certificate': { status: 'success' },
+        'create-source-account': { status: 'success' },
+        'assume-source-role': { status: 'success' },
+        'create-source-bucket': { status: 'success' },
+        'create-source-bucket-versioning': { status: 'success' },
+        'create-location': { status: 'success' },
+        'create-replication-rule': { status: 'success' },
+      },
+    };
+    expect(allSucceeded(buildStepViews(baseInput, allDone))).toBe(true);
+    expect(allSucceeded(buildStepViews(baseInput, noProgress))).toBe(false);
+  });
+
+  it('hasFailure is true when any row failed', () => {
+    const views = buildStepViews(
+      baseInput,
+      withEvents([
+        { event: 'step.failed', step: 'create-policy', at: 't', error: { code: 'InternalError', message: 'boom' } },
+      ]),
+    );
+    expect(hasFailure(views)).toBe(true);
+    expect(hasFailure(buildStepViews(baseInput, noProgress))).toBe(false);
   });
 });

--- a/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/steps.ts
+++ b/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/steps.ts
@@ -33,8 +33,14 @@ export type StepListInput = {
   destinationAccountName: string;
 };
 
-export type BuildStepViewsOptions = {
-  globalErrorMessage?: string;
+export type ChainStepState = 'idle' | 'pending' | 'success' | 'error';
+export type ChainStatus = { status: ChainStepState; errorMessage?: string };
+
+export type StepStateSources = {
+  configuratorEvents: SetupEvent[];
+  chainStatusById: Record<string, ChainStatus | undefined>;
+  /** Set when the stream failed without emitting a step.failed to pin the error on a row. */
+  configuratorError?: string;
 };
 
 type StepDef = {
@@ -82,35 +88,90 @@ const STEPS: StepDef[] = [
   },
 ];
 
-export const buildStepViews = (
-  input: StepListInput,
-  events: SetupEvent[],
-  options: BuildStepViewsOptions = {},
-): StepView[] => {
+/** Contract rows whose state is derived from the crr-configurator NDJSON stream. */
+const CONFIGURATOR_STEP_IDS = new Set<StepId>([
+  'create-account',
+  'create-user',
+  'create-access-key',
+  'create-policy',
+  'create-role',
+  'attach-role-policy',
+  'create-bucket',
+]);
+
+/** The single crr-configurator chain link; every configurator row retries by re-running it. */
+export const CONFIGURATOR_CHAIN_LINK_ID = 'configurator-setup';
+
+/**
+ * Wizard-run contract row -> the chain link id(s) whose combined status drives it.
+ * `create-source-bucket` folds three links — assuming the source role, creating
+ * the bucket, enabling versioning — so a failure in any of them (including the
+ * otherwise row-less assume-source-role) surfaces on that row instead of leaving
+ * the chain silently stuck.
+ */
+const WIZARD_ROW_LINKS: Partial<Record<StepId, string[]>> = {
+  'import-destination-certificate': ['import-destination-certificate'],
+  'create-source-account': ['create-source-account'],
+  'create-source-bucket': ['assume-source-role', 'create-source-bucket', 'create-source-bucket-versioning'],
+  'create-location': ['create-location'],
+  'create-replication-rule': ['create-replication-rule'],
+};
+
+const configuratorRowState = (events: SetupEvent[], id: StepId): { state: StepState; errorMessage?: string } => {
+  let state: StepState = 'pending';
+  let errorMessage: string | undefined;
+  for (const event of events) {
+    if (!('step' in event) || event.step !== id) continue;
+    if (event.event === 'step.completed') state = 'succeeded';
+    else if (event.event === 'step.failed') {
+      state = 'failed';
+      errorMessage = event.error.message;
+    }
+  }
+  return { state, errorMessage };
+};
+
+const wizardRowState = (
+  linkIds: string[],
+  chainStatusById: Record<string, ChainStatus | undefined>,
+): { state: StepState; errorMessage?: string } => {
+  const statuses = linkIds.map((id) => chainStatusById[id]);
+  const errored = statuses.find((s) => s?.status === 'error');
+  if (errored) return { state: 'failed', errorMessage: errored.errorMessage };
+  if (statuses.every((s) => s?.status === 'success')) return { state: 'succeeded' };
+  return { state: 'pending' };
+};
+
+/**
+ * Merges the two state sources into the 12 contract rows: configurator rows come
+ * from the NDJSON events, wizard rows from their chain link statuses. A
+ * configurator stream failure that pinned no step surfaces on its first pending row.
+ */
+export const buildStepViews = (input: StepListInput, sources: StepStateSources): StepView[] => {
   const active = STEPS.filter((def) => def.when(input));
   const views: StepView[] = active.map((def, index) => {
-    let state: StepState = 'pending';
-    let errorMessage: string | undefined;
-    for (const event of events) {
-      if (!('step' in event) || event.step !== def.id) continue;
-      if (event.event === 'step.completed') state = 'succeeded';
-      else if (event.event === 'step.failed') {
-        state = 'failed';
-        errorMessage = event.error.message;
-      }
-    }
-    return { id: def.id, step: index + 1, label: def.label(input), state, errorMessage };
+    const base = { id: def.id, step: index + 1, label: def.label(input) };
+    const { state, errorMessage } = CONFIGURATOR_STEP_IDS.has(def.id)
+      ? configuratorRowState(sources.configuratorEvents, def.id)
+      : wizardRowState(WIZARD_ROW_LINKS[def.id] ?? [def.id], sources.chainStatusById);
+    return { ...base, state, errorMessage };
   });
 
-  const hasStepFailure = views.some((v) => v.state === 'failed');
-  if (options.globalErrorMessage && !hasStepFailure) {
-    const firstPending = views.find((v) => v.state === 'pending');
-    if (firstPending) {
-      firstPending.state = 'failed';
-      firstPending.errorMessage = options.globalErrorMessage;
+  if (sources.configuratorError && !views.some((v) => v.state === 'failed')) {
+    const firstPendingConfiguratorRow = views.find((v) => CONFIGURATOR_STEP_IDS.has(v.id) && v.state === 'pending');
+    if (firstPendingConfiguratorRow) {
+      firstPendingConfiguratorRow.state = 'failed';
+      firstPendingConfiguratorRow.errorMessage = sources.configuratorError;
     }
   }
   return views;
+};
+
+export const retryLinkIdForRow = (id: StepId, chainStatusById: Record<string, ChainStatus | undefined>): string => {
+  if (CONFIGURATOR_STEP_IDS.has(id)) return CONFIGURATOR_CHAIN_LINK_ID;
+  const links = WIZARD_ROW_LINKS[id] ?? [id];
+  // Re-run the failed link of a folded row (e.g. versioning), not one already succeeded.
+  return links.find((linkId) => chainStatusById[linkId]?.status === 'error') ?? links[0];
 };
 
 export const allSucceeded = (views: StepView[]): boolean => views.every((v) => v.state === 'succeeded');


### PR DESCRIPTION
## TL;DR
The CRR wizard's Apply Actions step now actually *runs* the full provisioning sequence — it drives the wizard-side steps and the crr-configurator destination stream as one chained sequence, instead of only rendering the backend stream.

## Context
Part of the ARTESCA CRR Provisioning Wizard (ARTESCA-16787). The step contract (12 canonical rows) landed earlier; this PR makes the step orchestrate them for real: some steps run in the browser (certificate import, source account/bucket, location, replication rule), the middle ones run on the destination via the crr-configurator NDJSON stream.

## Approach
`useChainedMutations` (the ISV pattern) runs the sequence. The chain has more links than visible rows — `buildStepViews` merges two state sources into the 12 contract rows:

| Chain link | Rendered as |
|---|---|
| `import-destination-certificate` (idempotent) | row 1 |
| `create-source-account` (when new) | row 2 |
| `assume-source-role` | *hidden — plumbing so the S3 hooks target the source account* |
| `create-source-bucket` + `create-source-bucket-versioning` | folded into row 3 |
| `configurator-setup` (one link) | expanded into rows 4–10 from the NDJSON step events |
| `create-location` (waits for overlay reconcile) | row 11 |
| `create-replication-rule` | row 12 |

Two things worth knowing: the destination `crr-role` ARN from the stream's `SetupResult` is what makes the source replication rule's `Role` the composite `s3-replication-role,<roleArn>` pair the CRR procedure requires; and `create-location` only resolves once the overlay has reconciled, because the replication rule references the location by name.

## Screenshots
_Route `/create-crr-configuration`._

**Apply Actions** — the 12-row provisioning table, all pending before the run (Success / Failed + inline Retry appear per row as the chain progresses):

![Apply Actions step](https://github.com/user-attachments/assets/24ec674c-5b21-4247-9e9b-5ad97bb4fca3)

**Configure** — the step that feeds it (source account, destination connection + certificate, destination account, replication rule):

![Configure step](https://github.com/user-attachments/assets/2d5b843a-038e-4219-86d5-81c044645499)

## Review focus
- 🔴 `ApplyActionsStep.tsx › useChainedMutations config + variable resolvers` — the chain assembly and the data-flow from the stream `SetupResult` into `create-location` / `create-replication-rule`; a wrong resolver mis-provisions replication.
- 🟡 `steps.ts › buildStepViews` / `retryLinkIdForRow` — merges configurator NDJSON events + wizard chain-link statuses into the 12 rows; per-row Retry re-runs the failed link of a folded row.
- 🟡 `useCreateCRRLocationMutation.ts` — polls the running-config version so the location is reconciled before the replication rule runs (60s timeout, cancelled on unmount).

## How to test
1. Data Management → Locations → **Start CRR Configuration**.
2. Fill Configure (source account, destination connection + certificate, destination account, enable the replication rule + bucket names), **Check Connection**, **Continue**.
3. On **Apply Actions**, watch the 12 rows run top-to-bottom; each turns **Success**. If a step fails, that row shows **Failed** with an inline **Retry** that re-runs only that step (the destination rows re-run the configurator link).
4. Re-run the wizard with an existing source account (source-account row disappears) and with the replication rule unchecked (source bucket / target bucket / replication rule rows disappear).

## References
- ARTESCA-16787 — CRR Provisioning Wizard.
- Shared test mock `__mocks__/@scality/data-browser-library` gains `useSetBucketVersioning` / `useSetBucketReplication` (additive; existing ISV tests unaffected).