### PR TITLE
Keep CRR Apply Actions row statuses in sync with the running mutations

### DIFF
--- a/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/ApplyActionsStep.tsx
+++ b/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/ApplyActionsStep.tsx
@@ -134,7 +134,7 @@ export const ApplyActionsStep = (props: Props) => {
   const configuratorResult = (prev: PreviousResults) =>
     prev[CONFIGURATOR_CHAIN_LINK_ID]?.data as SetupResult | undefined;
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: rebuild only when the chain's shape or resolved inputs change, not on every mutation-instance render
+  // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on the mutation instances so a status change rebuilds the config and rows show live status
   const { mutations, variables } = useMemo(() => {
     const configs: MutationConfig[] = [
       { id: 'import-destination-certificate', label: 'Import Destination Certificate', mutation: importCertificate },
@@ -198,7 +198,21 @@ export const ApplyActionsStep = (props: Props) => {
     }
 
     return { mutations: configs, variables: resolvers };
-  }, [isNewSourceAccount, withReplicationRule, body, locationName, existingSourceRoleArn]);
+  }, [
+    isNewSourceAccount,
+    withReplicationRule,
+    body,
+    locationName,
+    existingSourceRoleArn,
+    importCertificate,
+    createSourceAccount,
+    assumeSourceRole,
+    createSourceBucket,
+    enableSourceVersioning,
+    setup,
+    createLocation,
+    createReplicationRuleMutation,
+  ]);
 
   const { Slots, steps, start, getResult, allRequiredStepsComplete } = useChainedMutations({ mutations, variables });
 


### PR DESCRIPTION
The CRR provisioning wizard's Apply Actions table showed every row stuck on "Pending", even after the underlying operations had already succeeded or failed — so the user got no feedback and the run looked frozen.

Each row's status is derived from the mutation instances handed to `useChainedMutations`, but the config holding them was memoized without depending on those instances. React Query returns a new result object on every status change, so the memo kept the original idle instances and the rows never moved off "Pending".

Depending on the mutation instances in that memo — the approach the ISV Apply Actions step already uses — rebuilds the config whenever a status changes, so rows now reflect live Success / Failed / Retry. The chain is not restarted: `useChainedMutations` keys its reset on the step ids, not the array identity.

Verified against a live ARTESCA platform: the rows now update in real time through the run.
