### PR TITLE
ARTESCA-17433: exclude CRR locations from lifecycle transition targets

### DIFF
--- a/src/react/databrowser/buckets/StorageClassSelector.tsx
+++ b/src/react/databrowser/buckets/StorageClassSelector.tsx
@@ -4,11 +4,13 @@ import type { StorageClassSelectorProps } from '@scality/data-browser-library';
 import type { LocationInfo } from '../../next-architecture/adapters/accounts-locations/ILocationsAdapter';
 import { useLocationsAndEndpoints } from '../../next-architecture/domain/business/accounts';
 import { useLocationsEndpointsAdapter } from '../../next-architecture/ui/LocationsEndpointsAdapterProvider';
-import { getLocationTypeShort, isHdclientV2, isReplicationTarget } from '../../utils/storageOptions';
+import { getLocationTypeShort, isCRRLocation, isHdclientV2, isReplicationTarget } from '../../utils/storageOptions';
 
 const locationFilter: Record<string, (l: LocationInfo) => boolean> = {
   replication: isReplicationTarget,
-  lifecycle: (l) => !isHdclientV2(l),
+  // CRR locations are replication-only targets: transitions towards them are
+  // rejected by the backend, so they must not be offered for lifecycle rules.
+  lifecycle: (l) => !isHdclientV2(l) && !isCRRLocation(l),
 };
 
 export function StorageClassSelector({ value, onChange, context }: StorageClassSelectorProps) {

--- a/src/react/databrowser/buckets/__tests__/StorageClassSelector.test.tsx
+++ b/src/react/databrowser/buckets/__tests__/StorageClassSelector.test.tsx
@@ -1,0 +1,74 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ThemeProvider } from 'styled-components';
+import { LocationType } from '../../../../js/managementClient/api';
+import type { LocationInfo } from '../../../next-architecture/adapters/accounts-locations/ILocationsAdapter';
+import { theme } from '../../../utils/testUtil';
+import { StorageClassSelector } from '../StorageClassSelector';
+
+const mockUseLocationsAndEndpoints = jest.fn();
+jest.mock('../../../next-architecture/domain/business/accounts', () => ({
+  useLocationsAndEndpoints: () => mockUseLocationsAndEndpoints(),
+}));
+
+jest.mock('../../../next-architecture/ui/LocationsEndpointsAdapterProvider', () => ({
+  useLocationsEndpointsAdapter: () => ({}),
+}));
+
+const locations: LocationInfo[] = [
+  {
+    id: '1',
+    name: 'artesca-s3-location',
+    type: LocationType.ScalityArtescaS3V1,
+    details: {},
+  },
+  {
+    id: '2',
+    name: 'crr-location',
+    type: LocationType.ScalityCrrV1,
+    details: {},
+  },
+  {
+    id: '3',
+    name: 'storage-service',
+    type: LocationType.ScalityHdclientV2,
+    details: {},
+  },
+];
+
+const renderSelector = (context: 'replication' | 'lifecycle') =>
+  render(
+    <ThemeProvider theme={theme}>
+      <StorageClassSelector value="" onChange={jest.fn()} context={context} />
+    </ThemeProvider>,
+  );
+
+describe('StorageClassSelector', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUseLocationsAndEndpoints.mockReturnValue({
+      locationsAndEndpoints: { locations },
+      status: 'success',
+    });
+  });
+
+  it('should not offer CRR nor storage service locations for lifecycle transitions', async () => {
+    renderSelector('lifecycle');
+
+    await userEvent.click(screen.getByRole('textbox'));
+
+    expect(screen.getByRole('option', { name: 'artesca-s3-location (ARTESCA)' })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /crr-location/ })).not.toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /storage-service/ })).not.toBeInTheDocument();
+  });
+
+  it('should offer CRR locations as replication destinations', async () => {
+    renderSelector('replication');
+
+    await userEvent.click(screen.getByRole('textbox'));
+
+    expect(screen.getByRole('option', { name: 'crr-location (CRR)' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'artesca-s3-location (ARTESCA)' })).toBeInTheDocument();
+    expect(screen.queryByRole('option', { name: /storage-service/ })).not.toBeInTheDocument();
+  });
+});

--- a/src/react/utils/storageOptions.ts
+++ b/src/react/utils/storageOptions.ts
@@ -36,6 +36,10 @@ export function isReplicationTarget(location: LocationInfo): boolean {
 export function isHdclientV2(location: LocationInfo): boolean {
   return (location.type as unknown as string) === 'location-scality-hdclient-v2';
 }
+
+export function isCRRLocation(location: LocationInfo): boolean {
+  return (location.type as unknown as string) === 'location-scality-crr-v1';
+}
 export function checkIfExternalLocation(locations: LocationInfo[]): boolean {
   return locations.some((l) => l.type !== LocationType.FileV1);
 }


### PR DESCRIPTION
## Description

Fixes [ARTESCA-17433](https://scality.atlassian.net/browse/ARTESCA-17433).

CRR locations are replication-only targets: the backend (Arsenal [#2439](https://github.com/scality/Arsenal/pull/2439), cloudserver [#5806](https://github.com/scality/cloudserver/pull/5806)) rejects lifecycle transitions towards them. The `StorageClassSelector` injected into the data-browser lifecycle rule form still offered them in the location dropdown.

## Changes

- `StorageClassSelector`: the `lifecycle` filter now excludes CRR locations (in addition to hdclient-v2). The `replication` filter is unchanged — CRR locations remain available as replication destinations.
- New `isCRRLocation` helper in `storageOptions.ts`, alongside the existing `isHdclientV2`.
- Added component tests covering both selector contexts.

[ARTESCA-17433]: https://scality.atlassian.net/browse/ARTESCA-17433?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ