### PR TITLE
ZKUI-510: Bump data-browser-library to 1.4.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@scality/certchain": "1.4.0",
         "@scality/core-ui": "0.219.0",
-        "@scality/data-browser-library": "1.3.1",
+        "@scality/data-browser-library": "1.4.1",
         "@scality/module-federation": "1.6.1",
         "@scality/react-chained-query": "^2.1.0",
         "@types/react-table": "^7.7.10",
@@ -5731,9 +5731,9 @@
       }
     },
     "node_modules/@scality/data-browser-library": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.3.1.tgz",
-      "integrity": "sha512-rWCPy7yIlz1Nwxf8Acedpxn8zl4nH9N1KTZfJCVcxyKss600RpdPpmu8M8655+0IrOsyxiqmeL1hGatq/cxIPQ==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.4.1.tgz",
+      "integrity": "sha512-OU7G2oFUI+TbdCASGQPg8qHxWQ9JT4PcsMjjmGEs+x2wFEMYWeQKG+s4qo9AB1UFgUsH7iCNnu/f2zvZ/oEWUQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.983.0",

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@scality/certchain": "1.4.0",
     "@scality/core-ui": "0.219.0",
-    "@scality/data-browser-library": "1.3.1",
+    "@scality/data-browser-library": "1.4.1",
     "@scality/module-federation": "1.6.1",
     "@scality/react-chained-query": "^2.1.0",
     "@types/react-table": "^7.7.10",


### PR DESCRIPTION
## Summary
- Bump `@scality/data-browser-library` from 1.3.1 to 1.4.1

Jira: https://scality.atlassian.net/browse/ZKUI-510

## Test plan
- [ ] CI passes