### PR TITLE
feature(crr): add management-network endpoint & source-DNS Apply Actions rows and refine the certificate step

### DIFF
--- a/src/react/locations/CRRSetupWizard/CRRSetupWizard.test.tsx
+++ b/src/react/locations/CRRSetupWizard/CRRSetupWizard.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { rest } from 'msw';
 import { setupServer } from 'msw/node';
@@ -14,20 +14,16 @@ afterAll(() => server.close());
 
 const PEM = '-----BEGIN CERTIFICATE-----\nMIIB\n-----END CERTIFICATE-----';
 
-/**
- * Fills the whole Configure form with valid values from a user's point of view —
- * clicks the labelled inputs by their accessible name, disambiguating the two
- * "Account Name" fields by the surrounding section title.
- */
-const fillValidForm = async () => {
-  const accountNameInputs = screen.getAllByRole('textbox', { name: /Account Name/i });
-  const [sourceAccountName, destinationAccountName] = accountNameInputs;
-  await userEvent.type(sourceAccountName, 'source-account');
-  await userEvent.type(screen.getByRole('textbox', { name: /^URL/i }), 'https://10.0.0.42:8443');
-  await userEvent.type(screen.getByRole('textbox', { name: /^Username/i }), 'scality');
-  await userEvent.type(screen.getByLabelText(/^Password/i), 'super-secret');
-  await userEvent.type(screen.getByRole('textbox', { name: /^Certificate/i }), PEM);
-  await userEvent.type(destinationAccountName, 'dest-account');
+// Two "Account Name" fields (source + destination) share the label; disambiguate by order.
+const fillValidForm = () => {
+  const [sourceAccountName, destinationAccountName] = screen.getAllByRole('textbox', { name: /Account Name/i });
+  const set = (element: HTMLElement, value: string) => fireEvent.change(element, { target: { value } });
+  set(sourceAccountName, 'source-account');
+  set(screen.getByRole('textbox', { name: /^URL/i }), 'https://10.0.0.42:8443');
+  set(screen.getByRole('textbox', { name: /^Username/i }), 'scality');
+  set(screen.getByLabelText(/^Password/i), 'super-secret');
+  set(screen.getByRole('textbox', { name: /^Certificate/i }), PEM);
+  set(destinationAccountName, 'dest-account');
 };
 
 const clickWhenEnabled = async (name: RegExp) => {
@@ -45,7 +41,7 @@ describe('CRRSetupWizard — Configure step', () => {
     );
     render(<CRRSetupWizard />, { wrapper: Wrapper });
 
-    await fillValidForm();
+    fillValidForm();
     await clickWhenEnabled(/Check Connection/i);
 
     expect(await screen.findByText(/Connection established/i)).toBeInTheDocument();
@@ -72,7 +68,7 @@ describe('CRRSetupWizard — Configure step', () => {
     );
     render(<CRRSetupWizard />, { wrapper: Wrapper });
 
-    await fillValidForm();
+    fillValidForm();
     await clickWhenEnabled(/Check Connection/i);
 
     expect(await screen.findByText(/The destination certificate is invalid/i)).toBeInTheDocument();
@@ -97,7 +93,7 @@ describe('CRRSetupWizard — Configure step', () => {
     );
     render(<CRRSetupWizard />, { wrapper: Wrapper });
 
-    await fillValidForm();
+    fillValidForm();
     await clickWhenEnabled(/Continue/i);
 
     expect(await screen.findByText(/Failed to reach the destination/i)).toBeInTheDocument();
@@ -130,7 +126,7 @@ describe('CRRSetupWizard — Configure step', () => {
     );
     render(<CRRSetupWizard />, { wrapper: Wrapper });
 
-    await fillValidForm();
+    fillValidForm();
     await clickWhenEnabled(/Check Connection/i);
 
     // The DNS failure surfaces the fallback modal listing every host that could not be resolved.

--- a/src/react/locations/CRRSetupWizard/hooks/useImportDestinationCertificateMutation.test.ts
+++ b/src/react/locations/CRRSetupWizard/hooks/useImportDestinationCertificateMutation.test.ts
@@ -19,4 +19,10 @@ describe('isCertificateAlreadyImported', () => {
   it('is true when the exact certificate is already in the truststore', () => {
     expect(isCertificateAlreadyImported(withCerts(['some-other-cert', CERT]), CERT)).toBe(true);
   });
+
+  it('ignores trailing-whitespace / line-ending differences so a re-import stays a no-op', () => {
+    expect(isCertificateAlreadyImported(withCerts([CERT]), `${CERT}\n`)).toBe(true);
+    expect(isCertificateAlreadyImported(withCerts([`${CERT}\n`]), CERT)).toBe(true);
+    expect(isCertificateAlreadyImported(withCerts([CERT]), CERT.replace(/\n/g, '\r\n'))).toBe(true);
+  });
 });

--- a/src/react/locations/CRRSetupWizard/hooks/useImportDestinationCertificateMutation.ts
+++ b/src/react/locations/CRRSetupWizard/hooks/useImportDestinationCertificateMutation.ts
@@ -3,9 +3,13 @@ import { useAddCertificateToZenkoConfigurationMutation } from '../../../../js/mu
 import { getZenkoCRQuery } from '../../../queries';
 import type { ZenkoCR } from '../../../truststore/Truststore';
 
+export const normalizeCertificate = (certificate: string): string => certificate.replace(/\r\n/g, '\n').trim();
+
 /** True when the PEM is already in the source truststore, so importing it again is a no-op. */
 export const isCertificateAlreadyImported = (zenkoCR: ZenkoCR | undefined, certificate: string): boolean =>
-  (zenkoCR?.spec?.egress?.extraCACerts ?? []).some((bundle) => bundle['ca.crt'] === certificate);
+  (zenkoCR?.spec?.egress?.extraCACerts ?? []).some(
+    (bundle) => normalizeCertificate(bundle['ca.crt']) === normalizeCertificate(certificate),
+  );
 
 /**
  * Imports the destination CA certificate into the source cluster's truststore
@@ -22,12 +26,13 @@ export const useImportDestinationCertificateMutation = () => {
 
   return useMutation({
     mutationFn: async ({ certificate }: { certificate: string }) => {
+      const normalized = normalizeCertificate(certificate);
       // Read the latest cached CR at execution time, not the render-time snapshot.
       const currentCR = queryClient.getQueryData<ZenkoCR>(['zenkoCR']) ?? zenkoCR;
-      if (isCertificateAlreadyImported(currentCR, certificate)) {
+      if (isCertificateAlreadyImported(currentCR, normalized)) {
         return;
       }
-      await addCertificate.mutateAsync({ certificate });
+      await addCertificate.mutateAsync({ certificate: normalized });
     },
   });
 };

--- a/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/ApplyActionsStep.test.tsx
+++ b/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/ApplyActionsStep.test.tsx
@@ -54,7 +54,6 @@ describe('ApplyActionsStep', () => {
     expect(screen.getByText('Configure paris-prod for Cross-Region Replication')).toBeInTheDocument();
 
     const actions = [
-      'Import Destination Certificate',
       'Create Account on Source: crr-src',
       'Create Bucket on Source: crr-src-bucket',
       'Create Account on Destination: crr-dest',
@@ -64,13 +63,16 @@ describe('ApplyActionsStep', () => {
       'Create IAM Role',
       'Attach Policy to Role',
       'Create Target Bucket: crr-target-bucket',
+      'Register Destination S3 Endpoint',
+      'Configure Source DNS Resolution',
+      'Import Certificate into Truststore',
       'Create Location',
       'Create Replication Rule',
     ];
     for (const action of actions) {
       expect(screen.getByText(action)).toBeInTheDocument();
     }
-    expect(screen.getAllByText('Pending...').length).toBe(12);
+    expect(screen.getAllByText('Pending...').length).toBe(14);
     // The setup only becomes confirmable once every action has succeeded.
     expect(screen.getByRole('button', { name: /Continue/i })).toBeDisabled();
   });
@@ -78,7 +80,7 @@ describe('ApplyActionsStep', () => {
   it('does not surface a source-account action when the user reuses an existing account', () => {
     render(<ApplyActionsStep {...VALUES} accountNameType="existing" />, { wrapper: Wrapper });
     expect(screen.queryByText(/Create Account on Source/i)).not.toBeInTheDocument();
-    expect(screen.getAllByText('Pending...').length).toBe(11);
+    expect(screen.getAllByText('Pending...').length).toBe(13);
   });
 
   it('does not surface the source bucket, target bucket or replication rule when no rule is requested', () => {
@@ -88,7 +90,7 @@ describe('ApplyActionsStep', () => {
     expect(screen.queryByText(/Create Bucket on Source/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Create Target Bucket/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Create Replication Rule/i)).not.toBeInTheDocument();
-    expect(screen.getAllByText('Pending...').length).toBe(9);
+    expect(screen.getAllByText('Pending...').length).toBe(11);
   });
 
   it('falls back to "ARTESCA" in the title when Verify returned no instance name', () => {

--- a/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/ApplyActionsStep.tsx
+++ b/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/ApplyActionsStep.tsx
@@ -1,4 +1,4 @@
-import { Form, Icon, Stack, Text } from '@scality/core-ui';
+import { Form, Icon, Loader, Stack, Text } from '@scality/core-ui';
 import { useStepper } from '@scality/core-ui/dist/components/steppers/Stepper.component';
 import { Button } from '@scality/core-ui/dist/next';
 import { useCreateBucket, useSetBucketReplication, useSetBucketVersioning } from '@scality/data-browser-library';
@@ -58,6 +58,14 @@ const StatusCell = ({ view, onRetry }: { view: StepView; onRetry: () => void }) 
         <span>Failed</span>
         <Button icon={<Icon name="Redo" />} variant="secondary" type="button" label="Retry" onClick={onRetry} />
         {view.errorMessage && <ErrorText>{view.errorMessage}</ErrorText>}
+      </StatusBox>
+    );
+  }
+  if (view.active) {
+    return (
+      <StatusBox>
+        <Loader size="small" />
+        <span>Pending...</span>
       </StatusBox>
     );
   }
@@ -136,9 +144,7 @@ export const ApplyActionsStep = (props: Props) => {
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: keyed on the mutation instances so a status change rebuilds the config and rows show live status
   const { mutations, variables } = useMemo(() => {
-    const configs: MutationConfig[] = [
-      { id: 'import-destination-certificate', label: 'Import Destination Certificate', mutation: importCertificate },
-    ];
+    const configs: MutationConfig[] = [];
     const resolvers: VariablesResolvers = {
       'import-destination-certificate': () => ({ certificate: props.certificate }),
     };
@@ -171,6 +177,12 @@ export const ApplyActionsStep = (props: Props) => {
 
     configs.push({ id: CONFIGURATOR_CHAIN_LINK_ID, label: 'Configure Destination', mutation: setup });
     resolvers[CONFIGURATOR_CHAIN_LINK_ID] = () => body;
+
+    configs.push({
+      id: 'import-destination-certificate',
+      label: 'Import Certificate into Truststore',
+      mutation: importCertificate,
+    });
 
     configs.push({ id: 'create-location', label: 'Create Location', mutation: createLocation });
     resolvers['create-location'] = (prev) => {
@@ -253,6 +265,7 @@ export const ApplyActionsStep = (props: Props) => {
           sourceBucketName: sourceBucketName ?? '',
           targetBucketName: props.targetBucketName ?? '',
           destinationAccountName: destinationAccountName ?? '',
+          isManagementNetwork: props.connectionMode === 'management-network',
         },
         { configuratorEvents: setup.events, chainStatusById, configuratorError },
       ),
@@ -263,6 +276,7 @@ export const ApplyActionsStep = (props: Props) => {
       sourceBucketName,
       props.targetBucketName,
       destinationAccountName,
+      props.connectionMode,
       setup.events,
       chainStatusById,
       configuratorError,

--- a/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/steps.test.ts
+++ b/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/steps.test.ts
@@ -16,6 +16,7 @@ const baseInput: StepListInput = {
   sourceBucketName: 'src-bucket',
   targetBucketName: 'target-bucket',
   destinationAccountName: 'dest-account',
+  isManagementNetwork: true,
 };
 
 const noProgress: StepStateSources = { configuratorEvents: [], chainStatusById: {} };
@@ -34,7 +35,6 @@ describe('buildStepViews', () => {
   it('lists the full provisioning sequence in order when the user creates a new source account and a replication rule', () => {
     const views = buildStepViews(baseInput, noProgress);
     expect(views.map((v) => v.id)).toEqual([
-      'import-destination-certificate',
       'create-source-account',
       'create-source-bucket',
       'create-account',
@@ -44,17 +44,24 @@ describe('buildStepViews', () => {
       'create-role',
       'attach-role-policy',
       'create-bucket',
+      'register-endpoint',
+      'configure-source-dns',
+      'import-destination-certificate',
       'create-location',
       'create-replication-rule',
     ]);
   });
 
   it('numbers the steps and shows the chosen source and destination account names', () => {
-    const [first, sourceAcc, sourceBkt, destAcc] = buildStepViews(baseInput, noProgress);
-    expect(first).toMatchObject({ step: 1, label: 'Import Destination Certificate' });
-    expect(sourceAcc).toMatchObject({ step: 2, label: 'Create Account on Source: src-account' });
-    expect(sourceBkt).toMatchObject({ step: 3, label: 'Create Bucket on Source: src-bucket' });
-    expect(destAcc).toMatchObject({ step: 4, label: 'Create Account on Destination: dest-account' });
+    const views = buildStepViews(baseInput, noProgress);
+    const [sourceAcc, sourceBkt, destAcc] = views;
+    expect(sourceAcc).toMatchObject({ step: 1, label: 'Create Account on Source: src-account' });
+    expect(sourceBkt).toMatchObject({ step: 2, label: 'Create Bucket on Source: src-bucket' });
+    expect(destAcc).toMatchObject({ step: 3, label: 'Create Account on Destination: dest-account' });
+    expect(views.find((v) => v.id === 'import-destination-certificate')).toMatchObject({
+      step: 12,
+      label: 'Import Certificate into Truststore',
+    });
   });
 
   it('labels the destination IAM chain and the target bucket per the ARTESCA CRR procedure', () => {
@@ -65,6 +72,8 @@ describe('buildStepViews', () => {
     expect(labels).toContain('Create IAM Role');
     expect(labels).toContain('Attach Policy to Role');
     expect(labels).toContain('Create Target Bucket: target-bucket');
+    expect(labels).toContain('Register Destination S3 Endpoint');
+    expect(labels).toContain('Configure Source DNS Resolution');
     expect(labels).toContain('Create Location');
     expect(labels).toContain('Create Replication Rule');
   });
@@ -79,6 +88,12 @@ describe('buildStepViews', () => {
     expect(views.find((v) => v.id === 'create-source-bucket')).toBeUndefined();
     expect(views.find((v) => v.id === 'create-bucket')).toBeUndefined();
     expect(views.find((v) => v.id === 'create-replication-rule')).toBeUndefined();
+  });
+
+  it('drops the endpoint and DNS steps in data-network mode', () => {
+    const views = buildStepViews({ ...baseInput, isManagementNetwork: false }, noProgress);
+    expect(views.find((v) => v.id === 'register-endpoint')).toBeUndefined();
+    expect(views.find((v) => v.id === 'configure-source-dns')).toBeUndefined();
   });
 
   it('shows every step as pending before anything runs', () => {
@@ -149,6 +164,35 @@ describe('buildStepViews — wizard-run rows', () => {
   });
 });
 
+describe('buildStepViews — active flag', () => {
+  it('marks a wizard row active only while its link is running', () => {
+    const running = buildStepViews(baseInput, withChain({ 'create-location': { status: 'pending' } }));
+    expect(running.find((v) => v.id === 'create-location')).toMatchObject({ state: 'pending', active: true });
+  });
+
+  it('does not mark a wizard row active before it starts or after it succeeds', () => {
+    const idle = buildStepViews(baseInput, noProgress);
+    expect(idle.find((v) => v.id === 'create-location')).toMatchObject({ state: 'pending', active: false });
+
+    const done = buildStepViews(baseInput, withChain({ 'create-location': { status: 'success' } }));
+    expect(done.find((v) => v.id === 'create-location')?.active).toBe(false);
+  });
+
+  it('marks a configurator row active between its started and completed events', () => {
+    const started = buildStepViews(baseInput, withEvents([{ event: 'step.started', step: 'create-user', at: 't' }]));
+    expect(started.find((v) => v.id === 'create-user')).toMatchObject({ state: 'pending', active: true });
+
+    const completed = buildStepViews(
+      baseInput,
+      withEvents([
+        { event: 'step.started', step: 'create-user', at: 't' },
+        { event: 'step.completed', step: 'create-user', at: 't' },
+      ]),
+    );
+    expect(completed.find((v) => v.id === 'create-user')).toMatchObject({ state: 'succeeded', active: false });
+  });
+});
+
 describe('buildStepViews — crr-configurator rows', () => {
   it('marks a configurator step done once it completes and shows the reason when one fails', () => {
     const events: SetupEvent[] = [
@@ -165,6 +209,29 @@ describe('buildStepViews — crr-configurator rows', () => {
     const failed = views.find((v) => v.id === 'create-user');
     expect(failed?.state).toBe('failed');
     expect(failed?.errorMessage).toBe('IAM refused CreateUser: entity already exists');
+  });
+
+  it('drives the management-network endpoint and DNS rows from their stream events', () => {
+    const succeeded = buildStepViews(
+      baseInput,
+      withEvents([{ event: 'step.completed', step: 'register-endpoint', at: 't' }]),
+    );
+    expect(succeeded.find((v) => v.id === 'register-endpoint')?.state).toBe('succeeded');
+
+    const failed = buildStepViews(
+      baseInput,
+      withEvents([
+        {
+          event: 'step.failed',
+          step: 'configure-source-dns',
+          at: 't',
+          error: { code: 'InternalError', message: 'source could not resolve the endpoint' },
+        },
+      ]),
+    );
+    const dns = failed.find((v) => v.id === 'configure-source-dns');
+    expect(dns?.state).toBe('failed');
+    expect(dns?.errorMessage).toBe('source could not resolve the endpoint');
   });
 
   it('blames the first pending configurator row when the stream fails without pinning a step', () => {
@@ -234,6 +301,8 @@ describe('allSucceeded / hasFailure', () => {
         'create-role',
         'attach-role-policy',
         'create-bucket',
+        'register-endpoint',
+        'configure-source-dns',
       ].map((step) => ({ event: 'step.completed', step, at: 't' }) as SetupEvent),
       chainStatusById: {
         'import-destination-certificate': { status: 'success' },

--- a/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/steps.ts
+++ b/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/steps.ts
@@ -11,6 +11,8 @@ export type StepId =
   | 'create-role'
   | 'attach-role-policy'
   | 'create-bucket'
+  | 'register-endpoint'
+  | 'configure-source-dns'
   | 'create-location'
   | 'create-replication-rule';
 
@@ -21,6 +23,7 @@ export type StepView = {
   step: number;
   label: string;
   state: StepState;
+  active: boolean;
   errorMessage?: string;
 };
 
@@ -31,6 +34,7 @@ export type StepListInput = {
   sourceBucketName: string;
   targetBucketName: string;
   destinationAccountName: string;
+  isManagementNetwork: boolean;
 };
 
 export type ChainStepState = 'idle' | 'pending' | 'success' | 'error';
@@ -50,11 +54,6 @@ type StepDef = {
 };
 
 const STEPS: StepDef[] = [
-  {
-    id: 'import-destination-certificate',
-    when: () => true,
-    label: () => 'Import Destination Certificate',
-  },
   {
     id: 'create-source-account',
     when: (i) => i.isNewSourceAccount,
@@ -80,6 +79,21 @@ const STEPS: StepDef[] = [
     when: (i) => i.createReplicationRule,
     label: (i) => `Create Target Bucket: ${i.targetBucketName}`,
   },
+  {
+    id: 'register-endpoint',
+    when: (i) => i.isManagementNetwork,
+    label: () => 'Register Destination S3 Endpoint',
+  },
+  {
+    id: 'configure-source-dns',
+    when: (i) => i.isManagementNetwork,
+    label: () => 'Configure Source DNS Resolution',
+  },
+  {
+    id: 'import-destination-certificate',
+    when: () => true,
+    label: () => 'Import Certificate into Truststore',
+  },
   { id: 'create-location', when: () => true, label: () => 'Create Location' },
   {
     id: 'create-replication-rule',
@@ -97,6 +111,8 @@ const CONFIGURATOR_STEP_IDS = new Set<StepId>([
   'create-role',
   'attach-role-policy',
   'create-bucket',
+  'register-endpoint',
+  'configure-source-dns',
 ]);
 
 /** The single crr-configurator chain link; every configurator row retries by re-running it. */
@@ -117,29 +133,37 @@ const WIZARD_ROW_LINKS: Partial<Record<StepId, string[]>> = {
   'create-replication-rule': ['create-replication-rule'],
 };
 
-const configuratorRowState = (events: SetupEvent[], id: StepId): { state: StepState; errorMessage?: string } => {
+const configuratorRowState = (
+  events: SetupEvent[],
+  id: StepId,
+): { state: StepState; active: boolean; errorMessage?: string } => {
   let state: StepState = 'pending';
+  let active = false;
   let errorMessage: string | undefined;
   for (const event of events) {
     if (!('step' in event) || event.step !== id) continue;
-    if (event.event === 'step.completed') state = 'succeeded';
-    else if (event.event === 'step.failed') {
+    if (event.event === 'step.started') active = true;
+    else if (event.event === 'step.completed') {
+      state = 'succeeded';
+      active = false;
+    } else if (event.event === 'step.failed') {
       state = 'failed';
+      active = false;
       errorMessage = event.error.message;
     }
   }
-  return { state, errorMessage };
+  return { state, active, errorMessage };
 };
 
 const wizardRowState = (
   linkIds: string[],
   chainStatusById: Record<string, ChainStatus | undefined>,
-): { state: StepState; errorMessage?: string } => {
+): { state: StepState; active: boolean; errorMessage?: string } => {
   const statuses = linkIds.map((id) => chainStatusById[id]);
   const errored = statuses.find((s) => s?.status === 'error');
-  if (errored) return { state: 'failed', errorMessage: errored.errorMessage };
-  if (statuses.every((s) => s?.status === 'success')) return { state: 'succeeded' };
-  return { state: 'pending' };
+  if (errored) return { state: 'failed', active: false, errorMessage: errored.errorMessage };
+  if (statuses.every((s) => s?.status === 'success')) return { state: 'succeeded', active: false };
+  return { state: 'pending', active: statuses.some((s) => s?.status === 'pending') };
 };
 
 /**
@@ -151,16 +175,21 @@ export const buildStepViews = (input: StepListInput, sources: StepStateSources):
   const active = STEPS.filter((def) => def.when(input));
   const views: StepView[] = active.map((def, index) => {
     const base = { id: def.id, step: index + 1, label: def.label(input) };
-    const { state, errorMessage } = CONFIGURATOR_STEP_IDS.has(def.id)
+    const {
+      state,
+      active: isActive,
+      errorMessage,
+    } = CONFIGURATOR_STEP_IDS.has(def.id)
       ? configuratorRowState(sources.configuratorEvents, def.id)
       : wizardRowState(WIZARD_ROW_LINKS[def.id] ?? [def.id], sources.chainStatusById);
-    return { ...base, state, errorMessage };
+    return { ...base, state, active: isActive, errorMessage };
   });
 
   if (sources.configuratorError && !views.some((v) => v.state === 'failed')) {
     const firstPendingConfiguratorRow = views.find((v) => CONFIGURATOR_STEP_IDS.has(v.id) && v.state === 'pending');
     if (firstPendingConfiguratorRow) {
       firstPendingConfiguratorRow.state = 'failed';
+      firstPendingConfiguratorRow.active = false;
       firstPendingConfiguratorRow.errorMessage = sources.configuratorError;
     }
   }


### PR DESCRIPTION
### TL;DR

Rounds out the CRR wizard's **Apply Actions** step: adds the management-network setup rows, moves the certificate import ahead of the location creation, and makes that import idempotent on retry.

### Context

The Apply Actions table must mirror the full crr-configurator setup chain. In **management-network** mode the destination S3 endpoint is registered on the destination and the source DNS is pointed at it — those two steps had no rows. The certificate also has to be in the source truststore **before** the CRR location is created, and re-running the step (a retry) must not append duplicate CA entries.

### Screenshot

<!-- Apply Actions step (/data/create-crr-configuration, step 2) in MANAGEMENT-NETWORK mode — showing the new "Register Destination S3 Endpoint" + "Configure Source DNS Resolution" rows, and "Import Certificate into Truststore" listed before "Create Location", with the active row spinning. -->

### Review focus

- 🟡 `steps/ApplyActionsStep/steps.ts` › `STEPS` / `CONFIGURATOR_STEP_IDS` — adds the `register-endpoint` + `configure-source-dns` rows (management-network only, gated on `isManagementNetwork`) and moves `import-destination-certificate` ahead of `create-location`.
- 🟡 `hooks/useImportDestinationCertificateMutation.ts` › `normalizeCertificate` — idempotent import: the PEM is normalized (CRLF/whitespace) so a paste-vs-file re-run doesn't duplicate the truststore entry.
- ⚪ `steps/ApplyActionsStep/steps.ts` › `StepView.active` — flags the currently-executing row so the UI spins only it.
- ⚪ `CRRSetupWizard.test.tsx` › `fillValidForm` — fills the form with `fireEvent.change` (one event per field) instead of char-by-char `userEvent.type`; drops the Configure tests from ~5s (a flaky 5000ms timeout under CI) to ~0.4s.

### How to test

1. **Data Management → create a CRR configuration**, choose **Management Network**, complete *Configure*.
2. On **Apply Actions**, the table shows **Register Destination S3 Endpoint** + **Configure Source DNS Resolution**, and **Import Certificate into Truststore** appears **before** *Create Location*; the running row spins.
3. Switch the config to **Data Network** → the two endpoint/DNS rows are absent.
4. Retry the certificate step (or re-run with the same cert pasted vs. uploaded) → no duplicate CA entry is added to the source truststore.

### References

- **ARTESCA-16787** — CRR provisioning wizard.