### PR TITLE
Decouple CRR location creation from reconciliation in the setup wizard

### DIFF
--- a/src/react/locations/CRRSetupWizard/hooks/useCreateCRRLocationMutation.ts
+++ b/src/react/locations/CRRSetupWizard/hooks/useCreateCRRLocationMutation.ts
@@ -7,8 +7,11 @@ import { useManagementClient } from '../../../ManagementProvider';
 import { useInstanceId } from '../../../next-architecture/ui/AuthProvider';
 import { useCreateLocationMutation } from '../../hooks/useCreateLocationMutation';
 
-const POLL_INTERVAL_MS = 500;
-const MAX_POLLS = 120; // ~60s
+// Bounded best-effort window for the running configuration to catch up before
+// the following replication-rule step runs. Bounded by wall-clock time, not a
+// poll count, because each status poll is itself a round-trip to the instance.
+const RECONCILE_WAIT_MS = 60_000;
+const POLL_INTERVAL_MS = 2_000;
 
 const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -18,12 +21,18 @@ const isAlreadyExists = (error: unknown): boolean => {
 };
 
 /**
- * Creates the CRR location and resolves only once it has been applied to the
- * running configuration. The subsequent replication rule references the
- * location by name (`StorageClass`), which cloudserver only accepts after the
- * overlay has reconciled — so the wizard must wait here before that step runs.
+ * Creates the CRR location. Success is decoupled from reconciliation: the step
+ * succeeds as soon as the location is written to the overlay (the same source
+ * the Locations list reads from), so it no longer lags behind — nor reports a
+ * false failure while — the location already exists.
+ *
+ * `waitForReconciliation` adds a bounded best-effort wait for
+ * `runningConfigurationVersion` to advance, used only when a replication rule
+ * follows: that step references the location by name through cloudserver, which
+ * accepts it only once the overlay has reconciled. The wait never fails the
+ * step — on timeout it resolves, leaving the replication-rule step to retry.
  */
-export const useCreateCRRLocationMutation = () => {
+export const useCreateCRRLocationMutation = ({ waitForReconciliation }: { waitForReconciliation: boolean }) => {
   const createLocation = useCreateLocationMutation();
   const managementClient = useManagementClient();
   const { useAuth } = useShellHooks();
@@ -47,21 +56,22 @@ export const useCreateCRRLocationMutation = () => {
 
   return useMutation({
     mutationFn: async (location: LocationV1) => {
-      const referenceVersion = await runningConfigurationVersion();
+      const referenceVersion = waitForReconciliation ? await runningConfigurationVersion() : 0;
       try {
         await createLocation.mutateAsync(location);
       } catch (error) {
-        // On a retry after a reconcile timeout the location already exists — keep waiting, don't re-fail.
+        // On a retry the location already exists — treat as created, keep going.
         if (!isAlreadyExists(error)) throw error;
       }
-      for (let attempt = 0; attempt < MAX_POLLS; attempt += 1) {
+      // The location is now in the overlay, so the create is done. Only wait when
+      // a replication rule follows, and only best-effort within a bounded window.
+      if (!waitForReconciliation) return;
+      const deadline = Date.now() + RECONCILE_WAIT_MS;
+      while (Date.now() < deadline) {
         if (cancelledRef.current) return;
-        if ((await runningConfigurationVersion()) > referenceVersion) {
-          return;
-        }
+        if ((await runningConfigurationVersion()) > referenceVersion) return;
         await delay(POLL_INTERVAL_MS);
       }
-      throw new Error('Timed out waiting for the location to be applied to the running configuration');
     },
   });
 };

--- a/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/ApplyActionsStep.tsx
+++ b/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/ApplyActionsStep.tsx
@@ -94,7 +94,7 @@ export const ApplyActionsStep = (props: Props) => {
   const createSourceBucket = useCreateBucket();
   const enableSourceVersioning = useSetBucketVersioning();
   const setup = useCRRConfigurationSetupMutation();
-  const createLocation = useCreateCRRLocationMutation();
+  const createLocation = useCreateCRRLocationMutation({ waitForReconciliation: withReplicationRule });
   const createReplicationRuleMutation = useSetBucketReplication();
 
   const accountsAdapter = useAccessibleAccountsAdapter();


### PR DESCRIPTION
In the CRR setup wizard, the **Create Location** step could sit on *Pending* for minutes — or report a false failure — even though the location was already created and visible in the Locations list. The step's success was gated on the instance's `runningConfigurationVersion` advancing, a runtime reconciliation heartbeat that can lag or stall independently of the create actually succeeding.

**How**
- Success is now keyed on the location being written to the overlay (the same source the Locations list reads from), so the step succeeds as soon as the location exists.
- The wait for the running configuration to reconcile is now **conditional** — it runs only when a replication rule follows, since that step references the location by name through cloudserver, which accepts it only once the overlay has reconciled.
- That wait is **time-bounded** (wall-clock, not a poll count that each round-trips to the instance) and **best-effort**: on timeout it resolves rather than failing the step.

**What's next**
- The with-replication-rule path keeps the bounded best-effort reconcile wait before the replication-rule step runs; that step retains its own inline Retry.