### PR TITLE
bugfix(crr): address Configure & Apply Actions UI review findings

### DIFF
--- a/src/react/locations/CRRSetupWizard/CRRSetupWizard.test.tsx
+++ b/src/react/locations/CRRSetupWizard/CRRSetupWizard.test.tsx
@@ -143,4 +143,37 @@ describe('CRRSetupWizard — Configure step', () => {
       { hostname: 'iam.dest.local', ip: '10.0.0.9' },
     ]);
   });
+
+  it('reopens the DNS modal when the mapped IP leaves the destination unreachable', async () => {
+    let verifyCalls = 0;
+    server.use(
+      rest.post(VERIFY_URL, (_req, res, ctx) => {
+        verifyCalls += 1;
+        const code = verifyCalls === 1 ? 'DestinationDnsResolutionFailed' : 'DestinationUnreachable';
+        return res(
+          ctx.status(502),
+          ctx.set('Content-Type', 'application/problem+json'),
+          ctx.body(
+            JSON.stringify({
+              type: 'about:blank',
+              title: 'error',
+              status: 502,
+              code,
+              ...(verifyCalls === 1 ? { unresolvedHosts: ['s3.dest.local'] } : {}),
+            }),
+          ),
+        );
+      }),
+    );
+    render(<CRRSetupWizard />, { wrapper: Wrapper });
+
+    fillValidForm();
+    await clickWhenEnabled(/Check Connection/i);
+    expect(await screen.findByText('• s3.dest.local')).toBeInTheDocument();
+
+    await userEvent.type(screen.getByRole('textbox', { name: /Destination cluster IP/i }), '10.0.0.9');
+    await clickWhenEnabled(/Retry Connection/i);
+
+    expect(await screen.findByText('• s3.dest.local')).toBeInTheDocument();
+  });
 });

--- a/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/ApplyActionsStep.tsx
+++ b/src/react/locations/CRRSetupWizard/steps/ApplyActionsStep/ApplyActionsStep.tsx
@@ -1,4 +1,4 @@
-import { Form, Icon, Loader, Stack, Text } from '@scality/core-ui';
+import { Banner, Form, Icon, Loader, Stack, Text } from '@scality/core-ui';
 import { useStepper } from '@scality/core-ui/dist/components/steppers/Stepper.component';
 import { Button } from '@scality/core-ui/dist/next';
 import { useCreateBucket, useSetBucketReplication, useSetBucketVersioning } from '@scality/data-browser-library';
@@ -57,7 +57,6 @@ const StatusCell = ({ view, onRetry }: { view: StepView; onRetry: () => void }) 
         <Icon name="Exclamation-circle" color={theme.statusCritical} />
         <span>Failed</span>
         <Button icon={<Icon name="Redo" />} variant="secondary" type="button" label="Retry" onClick={onRetry} />
-        {view.errorMessage && <ErrorText>{view.errorMessage}</ErrorText>}
       </StatusBox>
     );
   }
@@ -347,23 +346,31 @@ export const ApplyActionsStep = (props: Props) => {
       style={{ width: '50rem' }}
     >
       {Slots}
+      {stepViews.some((view) => view.id === 'create-location' && view.active) && (
+        <Banner variant="warning" icon={<Icon color="statusWarning" name="Exclamation-circle" />}>
+          Expect some delay (about 1 minute)—creating the location takes time.
+        </Banner>
+      )}
       <div style={{ height: '32rem', overflow: 'auto' }}>
         <Table>
           <T.Head>
             <T.HeadRow style={{ display: 'flex' }}>
               <T.HeadCell style={{ width: '150px' }}>Step</T.HeadCell>
-              <T.HeadCell style={{ width: '50%' }}>Action</T.HeadCell>
-              <T.HeadCell style={{ width: '12.5%' }}>Status</T.HeadCell>
+              <T.HeadCell style={{ flex: 1, minWidth: 0 }}>Action</T.HeadCell>
+              <T.HeadCell style={{ width: '200px' }}>Status</T.HeadCell>
             </T.HeadRow>
           </T.Head>
           <T.Body>
             {stepViews.map((view) => (
               <T.Row key={view.id} style={{ display: 'flex' }}>
                 <T.Cell style={{ width: '150px' }}>{view.step}</T.Cell>
-                <T.Cell style={{ width: '50%' }}>
-                  <Text>{view.label}</Text>
+                <T.Cell style={{ flex: 1, minWidth: 0 }}>
+                  <Stack direction="vertical" gap="r4">
+                    <Text>{view.label}</Text>
+                    {view.state === 'failed' && view.errorMessage && <ErrorText>{view.errorMessage}</ErrorText>}
+                  </Stack>
                 </T.Cell>
-                <T.Cell style={{ width: '12.5%' }}>
+                <T.Cell style={{ width: '200px' }}>
                   <StatusCell view={view} onRetry={() => onRetry(view)} />
                 </T.Cell>
               </T.Row>

--- a/src/react/locations/CRRSetupWizard/steps/ConfigureStep/ConfigureStep.tsx
+++ b/src/react/locations/CRRSetupWizard/steps/ConfigureStep/ConfigureStep.tsx
@@ -43,6 +43,9 @@ const unresolvedHostsFrom = (error: unknown): string[] | null => {
   return null;
 };
 
+const isDestinationUnreachable = (error: unknown): boolean =>
+  error instanceof ServiceError && error.code === 'DestinationUnreachable';
+
 const mergeAliases = (existing: HostAlias[], added: HostAlias[]): HostAlias[] => {
   const byHost = new Map(existing.map((alias) => [alias.hostname, alias]));
   for (const alias of added) byHost.set(alias.hostname, alias);
@@ -74,6 +77,11 @@ export const ConfigureStep = () => {
     const hosts = unresolvedHostsFrom(error);
     if (hosts) {
       setDnsFallbackHosts(hosts);
+      return;
+    }
+    const aliases = getValues('hostAliases');
+    if (aliases.length > 0 && isDestinationUnreachable(error)) {
+      setDnsFallbackHosts(aliases.map((alias) => alias.hostname));
       return;
     }
     showToast({ open: true, status: 'error', message: errorMessage(error) });

--- a/src/react/locations/CRRSetupWizard/steps/ConfigureStep/DestinationConnectionSection.tsx
+++ b/src/react/locations/CRRSetupWizard/steps/ConfigureStep/DestinationConnectionSection.tsx
@@ -1,6 +1,7 @@
-import { FormGroup, FormSection, Icon, Radio, Stack, Text, Wrap } from '@scality/core-ui';
+import { FormGroup, FormSection, Icon, Stack, Text, Wrap } from '@scality/core-ui';
 import { Button, Input } from '@scality/core-ui/dist/next';
 import { Controller, useFormContext } from 'react-hook-form';
+import { RadioGroup } from '../../../../ISV/components/RadioGroup';
 import { CertificateSection } from '../../../../ui-elements/CertificateSection';
 import type { ConfigureFormValues } from './schema';
 
@@ -47,22 +48,16 @@ export const DestinationConnectionSection = ({
             name="connectionMode"
             control={control}
             render={({ field }) => (
-              <Stack direction="horizontal" gap="r16">
-                <Radio
-                  name="connectionMode"
-                  value="management-network"
-                  checked={field.value === 'management-network'}
-                  onChange={() => field.onChange('management-network')}
-                  label="Management Network"
-                />
-                <Radio
-                  name="connectionMode"
-                  value="data-network"
-                  checked={field.value === 'data-network'}
-                  onChange={() => field.onChange('data-network')}
-                  label="Data Network"
-                />
-              </Stack>
+              <RadioGroup
+                name="connectionMode"
+                options={[
+                  { value: 'management-network', label: 'Management Network' },
+                  { value: 'data-network', label: 'Data Network' },
+                ]}
+                value={field.value}
+                onChange={(next) => field.onChange(next)}
+                direction="horizontal"
+              />
             )}
           />
         }
@@ -86,7 +81,9 @@ export const DestinationConnectionSection = ({
           required
           helpErrorPosition="bottom"
           error={errorIfTouched('baseDomain')}
-          content={<Input id="baseDomain" {...register('baseDomain')} />}
+          content={
+            <Input id="baseDomain" noPlaceholderPrefix placeholder="ui.<base-domain>" {...register('baseDomain')} />
+          }
         />
       )}
       {connectionMode === 'data-network' && (

--- a/src/react/ui-elements/CertificateSection.tsx
+++ b/src/react/ui-elements/CertificateSection.tsx
@@ -1,4 +1,4 @@
-import { Dropzone, Stack, Text, TextArea } from '@scality/core-ui';
+import { Dropzone, Stack, spacing, Text, TextArea } from '@scality/core-ui';
 import type { ChangeEvent } from 'react';
 import { useFormContext } from 'react-hook-form';
 import styled from 'styled-components';
@@ -13,6 +13,10 @@ const CertificateContainer = styled.div`
   gap: 0.5rem;
   color: ${(props) => props.theme.textPrimary};
   max-width: 45rem;
+
+  & textarea {
+    border: ${spacing.r1} solid transparent;
+  }
 `;
 
 const PLACEHOLDER = `Example:


### PR DESCRIPTION
### TL;DR

Fixes a batch of UI issues raised in the review of the CRR wizard's **Configure** and **Apply Actions** steps — retry visibility on a failed step, radio consistency, a certificate-field layout shift, DNS-override re-editing, a Base Domain example, and a create-location progress hint.

### Context

The "bug lot" from the PO's review — the changes that need no product decision. The form redesign, the location-naming question, and making the certificate optional are tracked separately.

### Review focus

- 🟡 `steps/ConfigureStep/ConfigureStep.tsx` › `handleVerifyError` — the DNS fallback modal now **reopens** (pre-seeded) when a mapped IP leaves the destination unreachable, so a wrong IP can be corrected instead of dead-ending on a toast.
- 🟡 `steps/ApplyActionsStep/ApplyActionsStep.tsx` › `StatusCell` / table columns — the error message moves to the **Action** column and the **Status** column widens, so the **Retry** button is no longer clipped on a failed step.
- ⚪ `steps/ConfigureStep/DestinationConnectionSection.tsx` — the **Mode** radios now use the shared `RadioGroup` (same component as the Source account radios); **Base Domain** shows a `ui.<base-domain>` placeholder.
- ⚪ `ui-elements/CertificateSection.tsx` — a constant-width border on the textarea removes the hover/focus **layout shift**.
- ⚪ `steps/ApplyActionsStep/ApplyActionsStep.tsx` — a "this can take up to a minute" hint while **create-location** applies.

### How to test

1. **Apply Actions**, on a **failed** step → the **Retry** button is fully visible in Status; the error text reads in the Action column.
2. **Configure → Data Network** → **Base Domain** shows the `ui.<base-domain>` example.
3. The **Mode** radios match the **Source** account radios visually.
4. **Certificate** textarea: hovering / focusing no longer nudges the layout.
5. **DNS fallback**: enter a wrong IP → on the unreachable retry the modal **reopens** pre-filled to correct it.
6. **create-location**: the long step shows the reassuring hint while it applies.

### References

- CRR Configure / Apply Actions UI review (PO).