### PR TITLE
improvement(crr): redesign the Configure Location form per UX review

### DIFF
--- a/src/react/locations/CRRSetupWizard/steps/ConfigureStep/ConfigureStep.tsx
+++ b/src/react/locations/CRRSetupWizard/steps/ConfigureStep/ConfigureStep.tsx
@@ -1,4 +1,4 @@
-import { Form, Icon, Stack, useToast } from '@scality/core-ui';
+import { Form, Icon, InfoMessage, Stack, useToast } from '@scality/core-ui';
 import { useStepper } from '@scality/core-ui/dist/components/steppers/Stepper.component';
 import { Button } from '@scality/core-ui/dist/next';
 import { useBasenameRelativeNavigate } from '@scality/module-federation';
@@ -155,13 +155,19 @@ export const ConfigureStep = () => {
           </Stack>
         }
       >
-        <SourceSection />
+        <InfoMessage
+          title="Cross-Region location"
+          content="A location is created here, on the source site, pointing to a destination site. The destination automatically receives the resources required for replication."
+          link="/artesca/docs/data_management/location_management/add_a_crr_location.html"
+          linkText="Learn more"
+        />
         <DestinationConnectionSection
           isCheckingConnection={verify.isLoading}
           onCheckConnection={onCheckConnection}
           isConnected={isConnected}
           connectedInstanceName={connectedInstanceName}
         />
+        <SourceSection />
         <DestinationAccountSection />
         <ReplicationSection />
       </Form>

--- a/src/react/locations/CRRSetupWizard/steps/ConfigureStep/DestinationAccountSection.tsx
+++ b/src/react/locations/CRRSetupWizard/steps/ConfigureStep/DestinationAccountSection.tsx
@@ -1,25 +1,45 @@
-import { FormGroup, FormSection } from '@scality/core-ui';
-import { Input } from '@scality/core-ui/dist/next';
+import { FormGroup, FormSection, Icon, Stack, Text } from '@scality/core-ui';
+import { Button, Input } from '@scality/core-ui/dist/next';
 import { useFormContext } from 'react-hook-form';
 import type { ConfigureFormValues } from './schema';
 
 export const DestinationAccountSection = () => {
   const {
     register,
+    setValue,
+    getValues,
     formState: { errors, touchedFields },
   } = useFormContext<ConfigureFormValues>();
   const nameError = touchedFields.destinationAccountName ? errors.destinationAccountName?.message : undefined;
 
   return (
-    <FormSection forceLabelWidth={280} title={{ name: 'Destination Account' }}>
+    <FormSection forceLabelWidth={280} title={{ name: 'Destination site' }}>
+      <Text color="textSecondary">An account will be created on the destination site with this name.</Text>
       <FormGroup
         id="destinationAccountName"
         direction="horizontal"
-        label="Account Name"
+        label="Account name"
         required
         helpErrorPosition="bottom"
         error={nameError}
-        content={<Input id="destinationAccountName" autoComplete="off" {...register('destinationAccountName')} />}
+        content={
+          <Stack direction="vertical" gap="r8">
+            <Input id="destinationAccountName" autoComplete="off" {...register('destinationAccountName')} />
+            <Button
+              type="button"
+              variant="outline"
+              label="Copy from Source site Account name"
+              icon={<Icon name="Copy" />}
+              onClick={() =>
+                setValue('destinationAccountName', getValues('accountName'), {
+                  shouldValidate: true,
+                  shouldDirty: true,
+                  shouldTouch: true,
+                })
+              }
+            />
+          </Stack>
+        }
       />
     </FormSection>
   );

--- a/src/react/locations/CRRSetupWizard/steps/ConfigureStep/DestinationConnectionSection.tsx
+++ b/src/react/locations/CRRSetupWizard/steps/ConfigureStep/DestinationConnectionSection.tsx
@@ -1,9 +1,21 @@
-import { FormGroup, FormSection, Icon, Stack, Text, Wrap } from '@scality/core-ui';
+import { FormGroup, FormSection, Icon, Stack, spacing, Text, Wrap } from '@scality/core-ui';
 import { Button, Input } from '@scality/core-ui/dist/next';
 import { Controller, useFormContext } from 'react-hook-form';
+import styled from 'styled-components';
 import { RadioGroup } from '../../../../ISV/components/RadioGroup';
 import { CertificateSection } from '../../../../ui-elements/CertificateSection';
 import type { ConfigureFormValues } from './schema';
+
+const ConnectionBox = styled.div`
+  background: ${(props) => props.theme.backgroundLevel2};
+  border: 1px solid ${(props) => props.theme.border};
+  border-radius: 6px;
+  padding: ${spacing.r16};
+`;
+
+const ConstrainedInput = styled(Input)`
+  max-width: 22rem;
+`;
 
 type Props = {
   isCheckingConnection: boolean;
@@ -37,73 +49,94 @@ export const DestinationConnectionSection = ({
 
   return (
     <FormSection forceLabelWidth={280} title={{ name: 'Destination Connection' }}>
-      <FormGroup
-        id="connectionMode"
-        direction="horizontal"
-        label="Mode"
-        required
-        helpErrorPosition="bottom"
-        content={
-          <Controller
-            name="connectionMode"
-            control={control}
-            render={({ field }) => (
-              <RadioGroup
-                name="connectionMode"
-                options={[
-                  { value: 'management-network', label: 'Management Network' },
-                  { value: 'data-network', label: 'Data Network' },
-                ]}
-                value={field.value}
-                onChange={(next) => field.onChange(next)}
-                direction="horizontal"
-              />
-            )}
-          />
-        }
-      />
-      {connectionMode === 'management-network' && (
+      <ConnectionBox>
         <FormGroup
-          id="url"
+          id="connectionMode"
           direction="horizontal"
-          label="URL"
+          label="Mode"
           required
           helpErrorPosition="bottom"
-          error={errorIfTouched('url')}
-          content={<Input id="url" noPlaceholderPrefix placeholder="https://<IP>:8443" {...register('url')} />}
-        />
-      )}
-      {connectionMode === 'data-network' && (
-        <FormGroup
-          id="baseDomain"
-          direction="horizontal"
-          label="Base Domain"
-          required
-          helpErrorPosition="bottom"
-          error={errorIfTouched('baseDomain')}
           content={
-            <Input id="baseDomain" noPlaceholderPrefix placeholder="ui.<base-domain>" {...register('baseDomain')} />
-          }
-        />
-      )}
-      {connectionMode === 'data-network' && (
-        <FormGroup
-          id="s3Endpoint"
-          direction="horizontal"
-          label="S3 Endpoint"
-          required
-          helpErrorPosition="bottom"
-          error={errorIfTouched('s3Endpoint')}
-          content={
-            <Input
-              id="s3Endpoint"
-              noPlaceholderPrefix
-              placeholder="https://s3.example.com"
-              {...register('s3Endpoint')}
+            <Controller
+              name="connectionMode"
+              control={control}
+              render={({ field }) => (
+                <RadioGroup
+                  name="connectionMode"
+                  options={[
+                    {
+                      value: 'management-network',
+                      label: 'Management Network',
+                      description: 'Connects directly to the management IP.',
+                    },
+                    {
+                      value: 'data-network',
+                      label: 'Data Network',
+                      description: 'Goes through the public S3 endpoint instead.',
+                    },
+                  ]}
+                  value={field.value}
+                  onChange={(next) => field.onChange(next)}
+                  direction="vertical"
+                />
+              )}
             />
           }
         />
-      )}
+        {connectionMode === 'management-network' && (
+          <FormGroup
+            id="url"
+            direction="horizontal"
+            label="URL"
+            required
+            helpErrorPosition="bottom"
+            error={errorIfTouched('url')}
+            content={
+              <ConstrainedInput id="url" noPlaceholderPrefix placeholder="https://<IP>:8443" {...register('url')} />
+            }
+          />
+        )}
+        {connectionMode === 'data-network' && (
+          <FormGroup
+            id="baseDomain"
+            direction="horizontal"
+            label="Base Domain"
+            required
+            helpErrorPosition="bottom"
+            error={errorIfTouched('baseDomain')}
+            content={
+              <ConstrainedInput
+                id="baseDomain"
+                noPlaceholderPrefix
+                placeholder="ui.<base-domain>"
+                {...register('baseDomain')}
+              />
+            }
+          />
+        )}
+        {connectionMode === 'data-network' && (
+          <FormGroup
+            id="s3Endpoint"
+            direction="horizontal"
+            label="S3 Endpoint"
+            required
+            helpErrorPosition="bottom"
+            error={errorIfTouched('s3Endpoint')}
+            content={
+              <ConstrainedInput
+                id="s3Endpoint"
+                noPlaceholderPrefix
+                placeholder="https://s3.example.com"
+                {...register('s3Endpoint')}
+              />
+            }
+          />
+        )}
+      </ConnectionBox>
+      <Text color="textSecondary">
+        Credentials: these must belong to a user with at least the Storage Manager role on the destination site
+        deployment.
+      </Text>
       <FormGroup
         id="username"
         direction="horizontal"

--- a/src/react/locations/CRRSetupWizard/steps/ConfigureStep/ReplicationSection.tsx
+++ b/src/react/locations/CRRSetupWizard/steps/ConfigureStep/ReplicationSection.tsx
@@ -1,5 +1,6 @@
 import { Checkbox, FormGroup, FormSection } from '@scality/core-ui';
 import { Input } from '@scality/core-ui/dist/next';
+import { useEffect, useRef } from 'react';
 import { useFormContext } from 'react-hook-form';
 import type { ConfigureFormValues } from './schema';
 
@@ -12,6 +13,13 @@ export const ReplicationSection = () => {
   const enabled = watch('createReplicationRule');
   const errorIfTouched = (field: keyof ConfigureFormValues) =>
     touchedFields[field] ? errors[field]?.message : undefined;
+  const ruleFieldsRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (enabled) {
+      ruleFieldsRef.current?.scrollIntoView({ behavior: 'smooth', block: 'nearest' });
+    }
+  }, [enabled]);
 
   return (
     <FormSection forceLabelWidth={280} title={{ name: 'Replication' }}>
@@ -19,40 +27,39 @@ export const ReplicationSection = () => {
         id="createReplicationRule"
         direction="horizontal"
         label="Create Replication Rule"
+        help="Optional — creating a rule now is not required, it can also be set up later from the bucket."
         helpErrorPosition="bottom"
         content={<Checkbox id="createReplicationRule" {...register('createReplicationRule')} />}
       />
       {enabled && (
-        <FormGroup
-          id="sourceBucketName"
-          direction="horizontal"
-          label="Source Bucket Name"
-          required
-          helpErrorPosition="bottom"
-          error={errorIfTouched('sourceBucketName')}
-          content={<Input id="sourceBucketName" autoComplete="off" {...register('sourceBucketName')} />}
-        />
-      )}
-      {enabled && (
-        <FormGroup
-          id="targetBucketName"
-          direction="horizontal"
-          label="Target Bucket Name"
-          required
-          helpErrorPosition="bottom"
-          error={errorIfTouched('targetBucketName')}
-          content={<Input id="targetBucketName" autoComplete="off" {...register('targetBucketName')} />}
-        />
-      )}
-      {enabled && (
-        <FormGroup
-          id="prefix"
-          direction="horizontal"
-          label="Prefix (optional)"
-          helpErrorPosition="bottom"
-          error={errorIfTouched('prefix')}
-          content={<Input id="prefix" autoComplete="off" {...register('prefix')} />}
-        />
+        <div ref={ruleFieldsRef}>
+          <FormGroup
+            id="sourceBucketName"
+            direction="horizontal"
+            label="Source Bucket name"
+            required
+            helpErrorPosition="bottom"
+            error={errorIfTouched('sourceBucketName')}
+            content={<Input id="sourceBucketName" autoComplete="off" {...register('sourceBucketName')} />}
+          />
+          <FormGroup
+            id="targetBucketName"
+            direction="horizontal"
+            label="Target Bucket name"
+            required
+            helpErrorPosition="bottom"
+            error={errorIfTouched('targetBucketName')}
+            content={<Input id="targetBucketName" autoComplete="off" {...register('targetBucketName')} />}
+          />
+          <FormGroup
+            id="prefix"
+            direction="horizontal"
+            label="Prefix (optional)"
+            helpErrorPosition="bottom"
+            error={errorIfTouched('prefix')}
+            content={<Input id="prefix" autoComplete="off" {...register('prefix')} />}
+          />
+        </div>
       )}
     </FormSection>
   );

--- a/src/react/locations/CRRSetupWizard/steps/ConfigureStep/SourceSection.tsx
+++ b/src/react/locations/CRRSetupWizard/steps/ConfigureStep/SourceSection.tsx
@@ -1,4 +1,4 @@
-import { FormGroup, FormSection } from '@scality/core-ui';
+import { FormGroup, FormSection, Text } from '@scality/core-ui';
 import { Input, Select } from '@scality/core-ui/dist/next';
 import { useMemo } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
@@ -42,7 +42,11 @@ export const SourceSection = () => {
   );
 
   return (
-    <FormSection forceLabelWidth={280} title={{ name: 'Source' }}>
+    <FormSection forceLabelWidth={280} title={{ name: 'Source site' }}>
+      <Text color="textSecondary">
+        Use an existing account or create a new one. If you choose an existing account, data already present in its
+        buckets won't be recovered by the replication.
+      </Text>
       <FormGroup
         id="accountNameType"
         direction="horizontal"
@@ -70,7 +74,7 @@ export const SourceSection = () => {
       <FormGroup
         id="accountName"
         direction="horizontal"
-        label="Account Name"
+        label="Account name"
         required
         helpErrorPosition="bottom"
         error={accountNameError}


### PR DESCRIPTION
### TL;DR

Reworks the **Configure Cross-Region Location** form to match the UX review: connection-first section order, a grouped connection box, vertical Mode radios with descriptions, an info message header, section guidance copy, and label casing. Form layout/copy only — no change to the wizard's behaviour or the underlying requests.

### Context

Design lot of the PO's review of the CRR wizard (the bug lot shipped in #1273). Scope was intentionally limited to the Configure form. Location naming is unchanged (already auto-generated) and the certificate stays required — both were considered and deferred.

https://potential-adventure-qjkz9qj.pages.github.io/branches/feature-crr-configure-review/crr-configure-review/

### Review focus

- 🟡 `DestinationConnectionSection.tsx` — Mode + endpoint fields are now wrapped in a gray `ConnectionBox` `<div>` inside the `FormSection`; label/content alignment relies on core-ui's context-based label width, so it survives the wrapper (verified) — worth an eyeball against the target.
- ⚪ `ConfigureStep.tsx` — section order is now **Destination Connection → Source site → Destination site → Replication**; the header uses core-ui `InfoMessage` (title + content + `Learn more` link to the embedded CRR doc).
- ⚪ `ReplicationSection.tsx` — the "optional" note moved to the FormGroup `help` (aligned under the checkbox); revealed rule fields smooth-scroll into view when the rule is enabled.

### How to test

Locations → **Create CRR configuration**. Check against the UX target (below):
1. Header is an info message ("Cross-Region location" + Learn more).
2. Section order: Destination Connection first; Mode radios are vertical with a one-line description each, grouped with the URL/Base Domain/S3 Endpoint in a gray box.
3. Credentials line reads "… at least the Storage Manager role …".
4. "Destination site" has a **Copy from Source site Account name** button that copies the Source account name.
5. Section title reads "Replication (optional)" (single "(optional)"); enabling **Create Replication Rule** smooth-scrolls the bucket fields into view.
6. Labels use sentence case: "Account name", "Source/Target Bucket name".

### References

- CRR Configure UX review (PO) — target prototype: https://potential-adventure-qjkz9qj.pages.github.io/branches/feature-crr-configure-review/crr-configure-review/
- Bug lot (sibling PR): #1273