### PR TITLE
ZKUI-508: bump @scality/core-ui to 0.227.0 (styled-components v6, CUI-12 modals, react-router 7.18.2)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hookform/resolvers": "^5.2.2",
         "@scality/certchain": "1.4.0",
-        "@scality/core-ui": "0.219.0",
+        "@scality/core-ui": "0.227.0",
         "@scality/data-browser-library": "1.4.4",
         "@scality/module-federation": "1.6.1",
         "@scality/react-chained-query": "^2.1.0",
@@ -37,13 +37,13 @@
         "react-error-boundary": "^3.1.1",
         "react-hook-form": "^7.28.1",
         "react-query": "3.34.0",
-        "react-router": "7.13.0",
-        "react-router-dom": "7.13.0",
+        "react-router": "7.18.2",
+        "react-router-dom": "7.18.2",
         "react-table": "^7.3.0",
         "react-virtualized": "9.21.0",
         "react-window": "^1.8.5",
         "react-window-infinite-loader": "^1.0.5",
-        "styled-components": "^5.3.11",
+        "styled-components": "6.5.1",
         "zenkoclient": "github:scality/zenkoclient#1.3.0"
       },
       "devDependencies": {
@@ -71,7 +71,6 @@
         "@types/react-router-dom": "^5.3.3",
         "@types/react-select": "^4.0.18",
         "@types/react-window-infinite-loader": "^1.0.6",
-        "@types/styled-components": "^5.1.34",
         "@welldone-software/why-did-you-render": "^4.0.5",
         "babel-loader": "^8.0.6",
         "cheerio": "^1.0.0-rc.3",
@@ -1152,6 +1151,7 @@
       "version": "7.27.3",
       "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.27.3.tgz",
       "integrity": "sha512-fXSwMQqitTGeHLBC08Eq5yXz2m37E4pJX1qAU1+2cNedz/ifv/bVXft90VeSav5nFO61EcNgwr0aJxbyPaWBPg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/types": "^7.27.3"
@@ -1326,6 +1326,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
       "integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -1685,6 +1686,7 @@
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.28.6.tgz",
       "integrity": "sha512-wgEmr06G6sIpqr8YDwA2dSRTE3bJ+V0IfpzfSY3Lfgd7YWOaAdlykvJi13ZKBt8cZHfgH1IXN+CL656W3uUa4w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.28.6"
@@ -3402,13 +3404,19 @@
       "license": "MIT"
     },
     "node_modules/@emotion/is-prop-valid": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
-      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
       "license": "MIT",
       "dependencies": {
-        "@emotion/memoize": "^0.9.0"
+        "@emotion/memoize": "0.7.4"
       }
+    },
+    "node_modules/@emotion/is-prop-valid/node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "license": "MIT"
     },
     "node_modules/@emotion/memoize": {
       "version": "0.9.0",
@@ -3457,12 +3465,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.4.0.tgz",
       "integrity": "sha512-fTBW9/8r2w3dXWYM4HCB1Rdp8NLibOw2+XELH5m5+AkWiL/KqYX6dc0kKYlaYyKjrQ6ds33MCdMPEwgs2z1rqg==",
-      "license": "MIT"
-    },
-    "node_modules/@emotion/stylis": {
-      "version": "0.8.5",
-      "resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-      "integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
       "license": "MIT"
     },
     "node_modules/@emotion/unitless": {
@@ -5623,9 +5625,9 @@
       "license": "MIT"
     },
     "node_modules/@scality/core-ui": {
-      "version": "0.219.0",
-      "resolved": "https://registry.npmjs.org/@scality/core-ui/-/core-ui-0.219.0.tgz",
-      "integrity": "sha512-R9SzHl11grKAeoq1GNPlld5ry6HNDfcNqCcJE3wimvqWdokaWiO0PUcmKAgvvwAK7kYG4KWb+FAQLp+EpVsP7A==",
+      "version": "0.227.0",
+      "resolved": "https://registry.npmjs.org/@scality/core-ui/-/core-ui-0.227.0.tgz",
+      "integrity": "sha512-c07t7P3u1ATxuHyRpTijvFG5r2uL8NvsA/CQi+cjSg9NXU3zu4MbnPwVLwzrIe3pawM9+ucrqunLRPZEAN1C3w==",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
         "@codemirror/lang-json": "^6.0.2",
@@ -5640,7 +5642,7 @@
         "@fortawesome/react-fontawesome": "^3.1.1",
         "@js-temporal/polyfill": "^0.4.4",
         "@lezer/highlight": "^1.2.3",
-        "@typescript-eslint/parser": "^8.56.1",
+        "@styled-system/should-forward-prop": "^5.1.5",
         "@uiw/react-codemirror": "^4.25.5",
         "codemirror-json-schema": "^0.8.1",
         "downshift": "^7.0.5",
@@ -5649,8 +5651,8 @@
         "react-dropzone": "^14.2.3",
         "react-hook-form": "^7.62.0",
         "react-query": "^3.34.0",
-        "react-router": "7.13.0",
-        "react-router-dom": "7.13.0",
+        "react-router": "7.18.2",
+        "react-router-dom": "7.18.2",
         "react-select": "4.3.1",
         "react-table": "^7.7.0",
         "react-test-renderer": "^18.3.1",
@@ -5658,9 +5660,9 @@
         "react-window": "^1.8.6",
         "recharts": "^3.0.2",
         "remark-gfm": "^4.0.1",
-        "styled-components": "^5.2.1",
+        "styled-components": "^6.4.3",
         "styled-system": "^5.1.5",
-        "uuid": "^13.0.0"
+        "uuid": "^14.0.0"
       },
       "peerDependencies": {
         "react": "^18.0.0 || ^19.0.0",
@@ -6774,6 +6776,23 @@
         "@styled-system/core": "^5.1.2"
       }
     },
+    "node_modules/@styled-system/should-forward-prop": {
+      "version": "5.1.5",
+      "resolved": "https://registry.npmjs.org/@styled-system/should-forward-prop/-/should-forward-prop-5.1.5.tgz",
+      "integrity": "sha512-+rPRomgCGYnUIaFabDoOgpSDc4UUJ1KsmlnzcEp0tu5lFrBQKgZclSo18Z1URhaZm7a6agGtS5Xif7tuC2s52Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@emotion/is-prop-valid": "^0.8.1",
+        "@emotion/memoize": "^0.7.1",
+        "styled-system": "^5.1.5"
+      }
+    },
+    "node_modules/@styled-system/should-forward-prop/node_modules/@emotion/memoize": {
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
+      "integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ==",
+      "license": "MIT"
+    },
     "node_modules/@styled-system/space": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@styled-system/space/-/space-5.1.2.tgz",
@@ -7562,19 +7581,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/hoist-non-react-statics": {
-      "version": "3.3.7",
-      "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.7.tgz",
-      "integrity": "sha512-PQTyIulDkIDro8P+IHbKCsw7U2xxBYflVzW/FgWdCAePD9xGSidgA76/GeJ6lBKoblyhf9pBY763gbrN+1dI8g==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "hoist-non-react-statics": "^3.3.0"
-      },
-      "peerDependencies": {
-        "@types/react": "*"
-      }
-    },
     "node_modules/@types/http-errors": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.5.tgz",
@@ -7959,18 +7965,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@types/styled-components": {
-      "version": "5.1.36",
-      "resolved": "https://registry.npmjs.org/@types/styled-components/-/styled-components-5.1.36.tgz",
-      "integrity": "sha512-pGMRNY5G2rNDKEv2DOiFYa7Ft1r0jrhmgBwHhOMzPTgCjO76bCot0/4uEfqj7K0Jf1KdQmDtAuaDk9EAs9foSw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@types/hoist-non-react-statics": "*",
-        "@types/react": "*",
-        "csstype": "^3.2.2"
-      }
-    },
     "node_modules/@types/tapable": {
       "version": "2.2.7",
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-2.2.7.tgz",
@@ -8039,189 +8033,6 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@typescript-eslint/parser": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
-      "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/scope-manager": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/typescript-estree": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
-        "debug": "^4.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/project-service": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
-      "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.59.1",
-        "@typescript-eslint/types": "^8.59.1",
-        "debug": "^4.4.3"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
-      "integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
-      "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/types": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
-      "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
-      "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/project-service": "8.59.1",
-        "@typescript-eslint/tsconfig-utils": "8.59.1",
-        "@typescript-eslint/types": "8.59.1",
-        "@typescript-eslint/visitor-keys": "8.59.1",
-        "debug": "^4.4.3",
-        "minimatch": "^10.2.2",
-        "semver": "^7.7.3",
-        "tinyglobby": "^0.2.15",
-        "ts-api-utils": "^2.5.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4 <6.1.0"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/balanced-match": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
-      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
-      "license": "MIT",
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
-      "license": "MIT",
-      "dependencies": {
-        "balanced-match": "^4.0.2"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
-      "version": "10.2.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
-      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
-      "license": "BlueOak-1.0.0",
-      "dependencies": {
-        "brace-expansion": "^5.0.5"
-      },
-      "engines": {
-        "node": "18 || 20 || >=22"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
-    "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.59.1",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
-      "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
-      "license": "MIT",
-      "dependencies": {
-        "@typescript-eslint/types": "8.59.1",
-        "eslint-visitor-keys": "^5.0.0"
-      },
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/typescript-eslint"
-      }
     },
     "node_modules/@uiw/codemirror-extensions-basic-setup": {
       "version": "4.25.5",
@@ -8930,22 +8741,6 @@
       },
       "peerDependencies": {
         "@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-      }
-    },
-    "node_modules/babel-plugin-styled-components": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/babel-plugin-styled-components/-/babel-plugin-styled-components-2.1.4.tgz",
-      "integrity": "sha512-Xgp9g+A/cG47sUyRwwYxGM4bR/jDRg5N6it/8+HxCnbT5XNKSKDT9xm4oag/osgqjC2It/vH0yXsomOG6k558g==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/helper-annotate-as-pure": "^7.22.5",
-        "@babel/helper-module-imports": "^7.22.5",
-        "@babel/plugin-syntax-jsx": "^7.22.5",
-        "lodash": "^4.17.21",
-        "picomatch": "^2.3.1"
-      },
-      "peerDependencies": {
-        "styled-components": ">= 2"
       }
     },
     "node_modules/babel-preset-current-node-syntax": {
@@ -11545,18 +11340,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/eslint-visitor-keys": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-      "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
-      },
-      "funding": {
-        "url": "https://opencollective.com/eslint"
-      }
-    },
     "node_modules/esprima": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
@@ -11930,23 +11713,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
-      }
-    },
-    "node_modules/fdir": {
-      "version": "6.5.0",
-      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
-      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "peerDependencies": {
-        "picomatch": "^3 || ^4"
-      },
-      "peerDependenciesMeta": {
-        "picomatch": {
-          "optional": true
-        }
       }
     },
     "node_modules/figures": {
@@ -15266,6 +15032,7 @@
       "version": "4.17.23",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
       "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/lodash.clonedeepwith": {
@@ -17303,6 +17070,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
       "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8.6"
@@ -17939,9 +17707,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.13.0.tgz",
-      "integrity": "sha512-PZgus8ETambRT17BUm/LL8lX3Of+oiLaPuVTRH3l1eLvSPpKO3AvhAEb5N7ihAFZQrYDqkvvWfFh9p0z9VsjLw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.18.2.tgz",
+      "integrity": "sha512-aUVMjFm3GAPTTZL7oYr5E7ETiqfQCHRLH+B+5afnICvf0r7kkK4eR6SMuwbSTJw/7t+12khT/Kahij49fqOCIg==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -17961,12 +17729,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.13.0.tgz",
-      "integrity": "sha512-5CO/l5Yahi2SKC6rGZ+HDEjpjkGaG/ncEP7eWFTvFxbHP8yeeI0PxTDjimtpXYlR3b3i9/WIL4VJttPrESIf2g==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.18.2.tgz",
+      "integrity": "sha512-AIKJ/jgGlFb3EbfCXk5Gzshiwt+l3mqbCrNjmEWMMjqQxNJ3svBa6bgzFyCC2Sw3RA0VWF1kg3uQf2OFhxb8hw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.13.0"
+        "react-router": "7.18.2"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -18934,12 +18702,6 @@
       "dev": true,
       "license": "ISC"
     },
-    "node_modules/shallowequal": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
-      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
-      "license": "MIT"
-    },
     "node_modules/shebang-command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
@@ -19579,61 +19341,55 @@
       "license": "MIT"
     },
     "node_modules/styled-components": {
-      "version": "5.3.11",
-      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-5.3.11.tgz",
-      "integrity": "sha512-uuzIIfnVkagcVHv9nE0VPlHPSCmXIUGKfJ42LNjxCCTDTL5sgnJ8Z7GZBq0EnLYGln77tPpEpExt2+qa+cZqSw==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/styled-components/-/styled-components-6.5.1.tgz",
+      "integrity": "sha512-6AsQEXcG7QhtdzjwJ4s5Amx5R9veYH9AP3+U6nF2BAMU0i1iM3cAXKJXuAKZCdv3Y2ntVMcL44cPx4cIDxgYFg==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.0.0",
-        "@babel/traverse": "^7.4.5",
-        "@emotion/is-prop-valid": "^1.1.0",
-        "@emotion/stylis": "^0.8.4",
-        "@emotion/unitless": "^0.7.4",
-        "babel-plugin-styled-components": ">= 1.12.0",
-        "css-to-react-native": "^3.0.0",
-        "hoist-non-react-statics": "^3.0.0",
-        "shallowequal": "^1.1.0",
-        "supports-color": "^5.5.0"
+        "@emotion/is-prop-valid": "1.4.0",
+        "css-to-react-native": "3.2.0",
+        "csstype": "3.2.3",
+        "stylis": "4.3.6"
       },
       "engines": {
-        "node": ">=10"
+        "node": ">= 16"
       },
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/styled-components"
       },
       "peerDependencies": {
+        "css-to-react-native": ">= 3.2.0",
         "react": ">= 16.8.0",
         "react-dom": ">= 16.8.0",
-        "react-is": ">= 16.8.0"
+        "react-native": ">= 0.68.0"
+      },
+      "peerDependenciesMeta": {
+        "css-to-react-native": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "react-native": {
+          "optional": true
+        }
       }
     },
-    "node_modules/styled-components/node_modules/@emotion/unitless": {
-      "version": "0.7.5",
-      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
-      "integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==",
-      "license": "MIT"
-    },
-    "node_modules/styled-components/node_modules/has-flag": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/styled-components/node_modules/supports-color": {
-      "version": "5.5.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+    "node_modules/styled-components/node_modules/@emotion/is-prop-valid": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.4.0.tgz",
+      "integrity": "sha512-QgD4fyscGcbbKwJmqNvUMSE02OsHUa+lAWKdEUIJKgqe5IwRSKd7+KhibEWdaKwgjLj0DRSHA9biAIqGBk05lw==",
       "license": "MIT",
       "dependencies": {
-        "has-flag": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
+        "@emotion/memoize": "^0.9.0"
       }
+    },
+    "node_modules/styled-components/node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "license": "MIT"
     },
     "node_modules/styled-system": {
       "version": "5.1.5",
@@ -19810,34 +19566,6 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
-    "node_modules/tinyglobby": {
-      "version": "0.2.16",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
-      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
-      "license": "MIT",
-      "dependencies": {
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.4"
-      },
-      "engines": {
-        "node": ">=12.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/SuperchupuDev"
-      }
-    },
-    "node_modules/tinyglobby/node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
-      }
-    },
     "node_modules/tmpl": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -19952,18 +19680,6 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
-      }
-    },
-    "node_modules/ts-api-utils": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.5.0.tgz",
-      "integrity": "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18.12"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.8.4"
       }
     },
     "node_modules/ts-node": {
@@ -20480,9 +20196,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@types/react-router-dom": "^5.3.3",
     "@types/react-select": "^4.0.18",
     "@types/react-window-infinite-loader": "^1.0.6",
-    "@types/styled-components": "^5.1.34",
     "@welldone-software/why-did-you-render": "^4.0.5",
     "babel-loader": "^8.0.6",
     "cheerio": "^1.0.0-rc.3",
@@ -59,7 +58,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
     "@scality/certchain": "1.4.0",
-    "@scality/core-ui": "0.219.0",
+    "@scality/core-ui": "0.227.0",
     "@scality/data-browser-library": "1.4.4",
     "@scality/module-federation": "1.6.1",
     "@scality/react-chained-query": "^2.1.0",
@@ -85,13 +84,13 @@
     "react-error-boundary": "^3.1.1",
     "react-hook-form": "^7.28.1",
     "react-query": "3.34.0",
-    "react-router": "7.13.0",
-    "react-router-dom": "7.13.0",
+    "react-router": "7.18.2",
+    "react-router-dom": "7.18.2",
     "react-table": "^7.3.0",
     "react-virtualized": "9.21.0",
     "react-window": "^1.8.5",
     "react-window-infinite-loader": "^1.0.5",
-    "styled-components": "^5.3.11",
+    "styled-components": "6.5.1",
     "zenkoclient": "github:scality/zenkoclient#1.3.0"
   },
   "msw": {

--- a/src/react/ISV/components/Modal/CardISV.tsx
+++ b/src/react/ISV/components/Modal/CardISV.tsx
@@ -30,9 +30,9 @@ const CardContent = (props: { logo: React.JSX.Element; application: string }) =>
   );
 };
 
-const CustomLabel = styled.label<{ selected?: boolean; disabled?: boolean }>`
-  opacity: ${(props) => (props.disabled ? 0.5 : 1)};
-  cursor: ${(props) => (props.disabled ? 'not-allowed' : 'pointer')};
+const CustomLabel = styled.label<{ $selected?: boolean; $disabled?: boolean }>`
+  opacity: ${(props) => (props.$disabled ? 0.5 : 1)};
+  cursor: ${(props) => (props.$disabled ? 'not-allowed' : 'pointer')};
   position: relative;
   display: flex;
   justify-content: space-between;
@@ -40,11 +40,11 @@ const CustomLabel = styled.label<{ selected?: boolean; disabled?: boolean }>`
   padding: ${spacing.r20};
   align-items: flex-start;
   border-radius: ${spacing.f8};
-  background-color: ${(props) => (props.selected ? props.theme.highlight : props.theme.backgroundLevel4)};
+  background-color: ${(props) => (props.$selected ? props.theme.highlight : props.theme.backgroundLevel4)};
   border: 1px solid
-    ${(props) => (props.selected ? props.theme.highlight : props.theme.backgroundLevel4)};
+    ${(props) => (props.$selected ? props.theme.highlight : props.theme.backgroundLevel4)};
   &:hover {
-    border-color: ${(props) => !props.disabled && props.theme.textPrimary};
+    border-color: ${(props) => !props.$disabled && props.theme.textPrimary};
   }
   width: 100%;
   height: 100%;
@@ -76,7 +76,7 @@ export const CardISV = (props: CardProps) => {
   const isDisabled = disabled ?? false;
 
   const labelContent = (
-    <CustomLabel disabled={isDisabled} htmlFor={`isv-${name}`} selected={selected} aria-disabled={isDisabled}>
+    <CustomLabel $disabled={isDisabled} htmlFor={`isv-${name}`} $selected={selected} aria-disabled={isDisabled}>
       <CardContent logo={logo} application={application} />
 
       <Input

--- a/src/react/ISV/components/Modal/WelcomeModal.test.tsx
+++ b/src/react/ISV/components/Modal/WelcomeModal.test.tsx
@@ -28,11 +28,10 @@ jest.mock('./ISVModal', () => {
   const originalModule = jest.requireActual('./ISVModal');
   return {
     ...originalModule,
-    ISVModalContent: ({ children, ...props }) => (
-      <div data-testid="isv-modal-content" {...props}>
-        {children}
-      </div>
-    ),
+    // Do not spread the remaining props onto the div: selectedISV/setSelectedISV are not
+    // DOM attributes and styled-components v6 no longer filters them out, so spreading
+    // them logs "React does not recognize the ... prop on a DOM element".
+    ISVModalContent: ({ children }) => <div data-testid="isv-modal-content">{children}</div>,
   };
 });
 

--- a/src/react/ISV/components/RadioGroup.tsx
+++ b/src/react/ISV/components/RadioGroup.tsx
@@ -21,9 +21,9 @@ type RadioGroupProps = {
   disabled?: boolean;
 };
 
-const RadioContainer = styled.div<{ direction: 'horizontal' | 'vertical' }>`
+const RadioContainer = styled.div<{ $direction: 'horizontal' | 'vertical' }>`
   display: flex;
-  flex-direction: ${(props) => (props.direction === 'horizontal' ? 'row' : 'column')};
+  flex-direction: ${(props) => (props.$direction === 'horizontal' ? 'row' : 'column')};
   gap: ${spacing.r8};
 `;
 
@@ -128,7 +128,7 @@ export const RadioGroup = ({
   const groupName = name || groupId;
 
   return (
-    <RadioContainer direction={direction}>
+    <RadioContainer $direction={direction}>
       {options.map((option) => {
         const optionId = `${groupName}-${option.value}`;
 

--- a/src/react/ISV/components/__tests__/ISVConfiguration.test.tsx
+++ b/src/react/ISV/components/__tests__/ISVConfiguration.test.tsx
@@ -17,14 +17,6 @@ jest.mock('@scality/module-federation', () => ({
   useBasenameRelativeNavigate: jest.fn().mockImplementation(() => mockNavigate),
 }));
 
-// Mock useRef to reset iamRequestSentRef
-jest.mock('react', () => ({
-  ...jest.requireActual('react'),
-  useRef: jest.fn().mockImplementation((initialValue) => ({
-    current: initialValue,
-  })),
-}));
-
 // Mock domain hooks
 jest.mock('../../../next-architecture/domain/business/accounts', () => ({
   useListAccounts: jest.fn(),

--- a/src/react/ISV/components/shared/StyledComponents.tsx
+++ b/src/react/ISV/components/shared/StyledComponents.tsx
@@ -5,7 +5,7 @@ export const ListItem = styled.li`
   padding: 0.5rem;
 `;
 
-export const ISVWideModal = styled(Modal)`
+export const ISVWideModal = styled(Modal).attrs({ wide: true })`
   background-color: ${(props) => props.theme.backgroundLevel1};
   > div {
     max-width: 60vw;

--- a/src/react/ISV/components/veeam/VeeamCapacityFormSection.tsx
+++ b/src/react/ISV/components/veeam/VeeamCapacityFormSection.tsx
@@ -53,10 +53,10 @@ export const VeeamCapacityFormSection = ({ autoFocusEnabled }: { autoFocusEnable
   } = useFormContext();
 
   return (
-    <FormSection forceLabelWidth={300}>
+    <FormSection>
       <FormGroup
         id="capacity"
-        label="Max Veeam Repository Capacity"
+        label="Max Capacity"
         error={errors.capacity?.message?.toString() ?? ''}
         helpErrorPosition="bottom"
         labelHelpTooltip={<VeeamCapacityTooltip />}

--- a/src/react/ISV/components/veeam/VeeamCapacityModal.test.tsx
+++ b/src/react/ISV/components/veeam/VeeamCapacityModal.test.tsx
@@ -14,7 +14,7 @@ describe('VeeamCapacityModal', () => {
     editBtn: () => screen.getByLabelText('Edit max capacity'),
     cancelBtn: () => screen.getByText('Cancel'),
     editModalBtn: () => screen.getByLabelText('Update max capacity'),
-    capacityInput: () => screen.getByRole('spinbutton', { name: /Max Veeam Repository Capacity/ }),
+    capacityInput: () => screen.getByRole('spinbutton', { name: /Max Capacity/ }),
   };
 
   beforeEach(() => {

--- a/src/react/ISV/components/veeam/VeeamCapacityModal.tsx
+++ b/src/react/ISV/components/veeam/VeeamCapacityModal.tsx
@@ -133,7 +133,6 @@ export const VeeamCapacityModalInternal = ({
             style={{
               paddingTop: '0.5rem',
               paddingBottom: '0.5rem',
-              width: '40rem',
             }}
           >
             <VeeamCapacityFormSection autoFocusEnabled={isCapacityModalOpen} />

--- a/src/react/account/AccountRoleSelectButtonAndModal.tsx
+++ b/src/react/account/AccountRoleSelectButtonAndModal.tsx
@@ -154,7 +154,7 @@ export function AccountRoleSelectButtonAndModal({
   return (
     <>
       <AccountSelectorButton
-        bigButton={bigButton}
+        $bigButton={bigButton}
         variant="primary"
         onClick={() => {
           setIsModalOpen(true);
@@ -174,6 +174,7 @@ export function AccountRoleSelectButtonAndModal({
         icon={<Icon name="Account" />}
       />
       <Modal
+        wide
         close={handleClose}
         footer={
           <ModalFooter

--- a/src/react/account/details/Properties.tsx
+++ b/src/react/account/details/Properties.tsx
@@ -11,13 +11,13 @@ type Props = {
   account: Account;
 };
 const Container = styled.div<{
-  height: CSSProperties['height'];
-  width: CSSProperties['width'];
+  $height: CSSProperties['height'];
+  $width: CSSProperties['width'];
 }>`
   display: flex;
   flex-direction: column;
-  height: ${(props) => props.height}px;
-  width: ${(props) => props.width}px;
+  height: ${(props) => props.$height}px;
+  width: ${(props) => props.$width}px;
 `;
 
 function Properties({ account }: Props) {
@@ -34,7 +34,7 @@ function Properties({ account }: Props) {
   return (
     <AutoSizer>
       {({ height, width }) => (
-        <Container height={height} width={width}>
+        <Container $height={height} $width={width}>
           <AccountInfo account={account} />
           {isStorageManager && <AccountKeys account={account} onOpenKeyModal={handleOpenModal} />}
           <SecretKeyModal

--- a/src/react/account/iamAttachment/AttachmentConfirmationModal.tsx
+++ b/src/react/account/iamAttachment/AttachmentConfirmationModal.tsx
@@ -263,7 +263,7 @@ function AttachmentConfirmationModal({
     ];
 
     return (
-      <div style={{ height: '25rem', width: '50rem' }}>
+      <div style={{ height: '20rem', width: '50rem', display: 'flex', flexDirection: 'column' }}>
         <div>The following entities will be attached or detached: </div>
         <Box display="flex" gap={24} alignItems="center">
           <SecondaryText>
@@ -271,17 +271,22 @@ function AttachmentConfirmationModal({
           </SecondaryText>
           <p>{resourceName}</p>
         </Box>
-        <Table
-          //@ts-expect-error fix this when you are working on it
-          columns={columns}
-          data={attachmentOperationsFlat}
-          defaultSortingKey={'entityName'}
-        >
-          <Table.SingleSelectableContent
-            rowHeight="h32"
-            separationLineVariant="backgroundLevel3"
-          ></Table.SingleSelectableContent>
-        </Table>
+        {/* Table is height: 100% and measures its parent, so it must be handed the space left
+            below the text as a definite height. Sizing it against the wrapper instead overflows
+            by the text's height and moves the scrollbar onto the modal body. */}
+        <div style={{ flex: 1, minHeight: 0 }}>
+          <Table
+            //@ts-expect-error fix this when you are working on it
+            columns={columns}
+            data={attachmentOperationsFlat}
+            defaultSortingKey={'entityName'}
+          >
+            <Table.SingleSelectableContent
+              rowHeight="h32"
+              separationLineVariant="backgroundLevel3"
+            ></Table.SingleSelectableContent>
+          </Table>
+        </div>
       </div>
     );
   }
@@ -299,6 +304,7 @@ function AttachmentConfirmationModal({
         />
       </Box>
       <Modal
+        wide
         close={handleClose}
         footer={modalFooter()}
         isOpen={isModalOpen}

--- a/src/react/account/iamAttachment/AttachmentTable.tsx
+++ b/src/react/account/iamAttachment/AttachmentTable.tsx
@@ -32,23 +32,23 @@ export type AttachmentTableProps<
 
 const rowHeight = 'h48';
 const MenuContainer = styled.ul<{
-  width: string;
-  isOpen: boolean;
-  searchInputIsFocused: boolean;
+  $width: string;
+  $isOpen: boolean;
+  $searchInputIsFocused: boolean;
 }>`
   background-color: ${(props) => props.theme.backgroundLevel1};
   background-clip: content-box;
   padding: 0;
   list-style: none;
   position: absolute;
-  width: ${(props) => props.width};
+  width: ${(props) => props.$width};
   z-index: 1;
   margin-top: -1.7rem;
   margin-left: 0;
   margin-bottom: 0;
   margin-right: 0;
   ${(props) =>
-    props.isOpen
+    props.$isOpen
       ? `
       border-top-left-radius: 0;
       border-top-right-radius: 0;
@@ -56,7 +56,7 @@ const MenuContainer = styled.ul<{
       border-bottom-left-radius: 4px;
       border: 1px solid ${props.theme.selectedActive};
   `
-      : props.searchInputIsFocused
+      : props.$searchInputIsFocused
         ? `border-bottom: 1px solid ${props.theme.selectedActive};`
         : ''}
   border-top: 0;
@@ -339,7 +339,6 @@ export const AttachmentTable = <
                 onBlur={() => {
                   setSearchInputIsFocused(false);
                 }}
-                disableToggle
                 disabled={firstPageStatus === 'error' || firstPageStatus === 'loading'}
               />
               <Loader />
@@ -360,15 +359,14 @@ export const AttachmentTable = <
             onBlur={() => {
               setSearchInputIsFocused(false);
             }}
-            disableToggle
           />
         )}
       </SearchBoxContainer>
       <MenuContainer
         {...getMenuProps()}
-        width={searchWidth}
-        isOpen={isOpen}
-        searchInputIsFocused={searchInputIsFocused}
+        $width={searchWidth}
+        $isOpen={isOpen}
+        $searchInputIsFocused={searchInputIsFocused}
       >
         {isOpen &&
           filteredEntities.map((item, index) => (
@@ -379,7 +377,7 @@ export const AttachmentTable = <
         {isOpen && filteredEntities.length === 0 && status === 'loading' && <li>Searching...</li>}
         {isOpen && numberOfFilteredEntities > filteredEntities.length && (
           <li>
-            <GentleEmphaseSecondaryText alignRight>
+            <GentleEmphaseSecondaryText $alignRight>
               There {numberOfFilteredEntities - filteredEntities.length === 1 ? 'is' : 'are'}{' '}
               {numberOfFilteredEntities - filteredEntities.length} more{' '}
               {numberOfFilteredEntities - filteredEntities.length === 1 ? 'entity' : 'entities'} matching your search.

--- a/src/react/truststore/CertificateDetails.tsx
+++ b/src/react/truststore/CertificateDetails.tsx
@@ -8,7 +8,7 @@ import { ModalBody } from '../ui-elements/Modal';
 import { downloadCertificate, formatExpiryDate } from './utils';
 
 const CertificateViewFieldWrapper = styled.div`
-  width: 12rem;
+  flex: 0 0 12rem;
 `;
 const MAX_CONTENT_WIDTH = '24rem';
 
@@ -80,7 +80,7 @@ const CertificateDetailRow = ({ label, value, copyable = false }: CertificateDet
     }
 
     return (
-      <Stack direction="horizontal" gap="r8" style={{ maxWidth: MAX_CONTENT_WIDTH, flex: 1 }}>
+      <Stack direction="horizontal" gap="r8" style={{ maxWidth: MAX_CONTENT_WIDTH, flex: 1, minWidth: 0 }}>
         <div style={{ flex: 1, minWidth: 0 }}>{content}</div>
         {copyable && <CopyButton textToCopy={displayValue} />}
       </Stack>

--- a/src/react/ui-elements/EditableKeyValue.tsx
+++ b/src/react/ui-elements/EditableKeyValue.tsx
@@ -13,18 +13,18 @@ export const Items = styled.div`
   display: flex;
   flex-direction: column;
 `;
-export const Item = styled.div<{ isShrink?: boolean }>`
+export const Item = styled.div<{ $isShrink?: boolean }>`
   display: flex;
   flex-direction: row;
   align-items: center;
 
   margin-bottom: ${spacing.r4};
-  // For Select we adjust width of the sc-scrollbar div because in CoreUI.SelectV2
-  // the first parent is .sc-scrollbar
+  /* For Select we adjust width of the sc-scrollbar div because in CoreUI.SelectV2
+     the first parent is .sc-scrollbar */
   .sc-scrollbar {
-    flex: 0 ${(props) => (props.isShrink ? '36%' : '53%')};
-    width: ${(props) => (props.isShrink ? '36%' : '53%')};
-    min-width: ${(props) => (props.isShrink ? '36%' : '53%')};
+    flex: 0 ${(props) => (props.$isShrink ? '36%' : '53%')};
+    width: ${(props) => (props.$isShrink ? '36%' : '53%')};
+    min-width: ${(props) => (props.$isShrink ? '36%' : '53%')};
   }
 `;
 export const Header = styled.div`
@@ -76,10 +76,10 @@ export const InputExtraKey = styled(Input)`
   width: 28%;
   min-width: 28%;
 `;
-export const InputValue = styled(Input)<{ isShrink?: boolean }>`
-  flex: 0 ${(props) => (props.isShrink ? '22%' : '39%')};
-  width: ${(props) => (props.isShrink ? '22%' : '39%')};
-  min-width: ${(props) => (props.isShrink ? '22%' : '39%')};
+export const InputValue = styled(Input)<{ $isShrink?: boolean }>`
+  flex: 0 ${(props) => (props.$isShrink ? '22%' : '39%')};
+  width: ${(props) => (props.$isShrink ? '22%' : '39%')};
+  min-width: ${(props) => (props.$isShrink ? '22%' : '39%')};
   background-color: ${(props) => props.theme.backgroundLevel1};
 `;
 export const InputTag = styled(Input)`
@@ -96,9 +96,9 @@ export const Char = styled.div`
   min-width: 2%;
   text-align: center;
 `;
-const CustomButton = styled(Button)<{ isVisible?: boolean }>`
+const CustomButton = styled(Button)<{ $isVisible?: boolean }>`
   ${(props) =>
-    !props.isVisible
+    !props.$isVisible
       ? `
         display: none;
     `
@@ -140,7 +140,7 @@ export const AddButton = ({ index, items, insertEntry, disabled, iconStyle }: Ad
     <>
       {!isVisible && <Box ml={16} />}
       <CustomButton
-        isVisible={isVisible}
+        $isVisible={isVisible}
         type="button"
         variant="outline"
         disabled={isDisabled}

--- a/src/react/ui-elements/FormContainer.ts
+++ b/src/react/ui-elements/FormContainer.ts
@@ -11,7 +11,7 @@ const FormContainer = styled.form`
   padding: ${spacing.sp20};
   background-color: ${(props) => props.theme.backgroundLevel4};
 
-  // TODO: fix inside core-ui
+  /* TODO: fix inside core-ui */
   .sc-select__single-value {
     width: 100%;
   }
@@ -42,7 +42,6 @@ const FormContainer = styled.form`
 
     input {
       margin-bottom: ${spacing.sp4};
-      // width:90%;
     }
     input.form-check-input {
       width: auto;

--- a/src/react/ui-elements/FormLayout.tsx
+++ b/src/react/ui-elements/FormLayout.tsx
@@ -41,18 +41,18 @@ export const SubTitle = styled.div`
   color: ${(props) => props.theme.textPrimary};
   font-weight: bold;
 `;
-export const SectionTitle = styled.div<{ fontSize?: string }>`
+export const SectionTitle = styled.div<{ $fontSize?: string }>`
   display: flex;
   color: ${(props) => props.theme.textPrimary};
-  font-size: ${(props) => props.fontSize || 'inherit'};
+  font-size: ${(props) => props.$fontSize || 'inherit'};
 `;
 export const Fieldset = styled.fieldset<{
-  direction?: string;
-  alignItems?: string;
+  $direction?: string;
+  $alignItems?: string;
 }>`
   display: flex;
-  flex-direction: ${(props) => props.direction || 'column'};
-  ${(props) => (props.alignItems ? `align-items: ${props.alignItems};` : '')}
+  flex-direction: ${(props) => props.$direction || 'column'};
+  ${(props) => (props.$alignItems ? `align-items: ${props.$alignItems};` : '')}
   border: 0;
   padding: 0;
   margin-top: ${spacing.r12};
@@ -143,7 +143,7 @@ export const WarningInput = ({ error, id }: ErrorInputProps) => {
   );
 };
 // * Label
-const LabelContainer = styled.label<{ required?: boolean }>`
+const LabelContainer = styled.label<{ $required?: boolean }>`
   display: flex;
   align-items: center;
   width: 60%;

--- a/src/react/ui-elements/Hide.tsx
+++ b/src/react/ui-elements/Hide.tsx
@@ -6,11 +6,19 @@ const HideContainer = styled.div`
   display: flex;
   align-items: center;
 `;
-const HideValue = styled.div<{ shown?: boolean }>`
-  ${(props) => props.shown && 'width: 15rem;'}
+const HideValue = styled.div<{ $shown?: boolean }>`
+  /* A definite width of 0 (not a flex-basis) so the shown value contributes nothing to the
+     cell's max-content width, then grows into whatever room the cell already had — the
+     value can no longer widen its own container, at any root font size. */
+  ${(props) => props.$shown && 'width: 0; flex-grow: 1;'}
   overflow: hidden;
 `;
 const HideAction = styled.div`
+  /* Callers put this inside cells that set word-break: break-word, which makes the
+     label's min-content one character wide — the flex row then shrinks it and breaks
+     "Hide" into "Hid e". */
+  flex-shrink: 0;
+  white-space: nowrap;
   margin-left: ${spacing.r8};
   color: ${(props) => props.theme.textLink};
   text-decoration: none;
@@ -23,7 +31,7 @@ export function HideCredential({ credentials }: { credentials: string }) {
   const [shown, setShown] = useState(false);
   return (
     <HideContainer>
-      <HideValue shown={shown}>{shown ? <ConstrainedText text={credentials} /> : '*********'}</HideValue>
+      <HideValue $shown={shown}>{shown ? <ConstrainedText text={credentials} /> : '*********'}</HideValue>
       <HideAction onClick={() => setShown(!shown)}>{shown ? 'Hide' : 'Show'}</HideAction>
     </HideContainer>
   );

--- a/src/react/ui-elements/Input.ts
+++ b/src/react/ui-elements/Input.ts
@@ -21,14 +21,14 @@ export const Hint = styled.div`
   }
 `;
 // make my own import due to some imput event target undefined issue
-const Input = styled.input<{ hasError?: boolean }>`
+const Input = styled.input<{ $hasError?: boolean }>`
   display: flex;
 
   background-color: ${(props) => props.theme?.backgroundLevel1};
   color: ${(props) => props.theme?.textPrimary};
   border-width: ${spacing.sp1};
   border-style: solid;
-  border-color: ${(props) => (props.hasError ? props.theme.statusCritical : props.theme?.border)};
+  border-color: ${(props) => (props.$hasError ? props.theme.statusCritical : props.theme?.border)};
   padding: 0px ${spacing.sp8};
   font-size: ${fontSize.base};
   border-radius: ${spacing.sp4};
@@ -51,7 +51,7 @@ const Input = styled.input<{ hasError?: boolean }>`
 cursor: not-allowed;
 opacity: 0.5;
 `}
-  // Removing input background color for Chrome autocomplete
+  /* Removing input background color for Chrome autocomplete */
   &:-webkit-autofill,
   &:-webkit-autofill:hover,
   &:-webkit-autofill:focus,

--- a/src/react/ui-elements/MiddleEllipsis.tsx
+++ b/src/react/ui-elements/MiddleEllipsis.tsx
@@ -11,8 +11,8 @@ const MiddleEllipsisContainer = styled.div`
     display: block;
   }
 `;
-const MiddleEllipsisText = styled.span<{ calculationDone?: boolean }>`
-  opacity: ${(props) => (props.calculationDone ? '1' : '0')};
+const MiddleEllipsisText = styled.span<{ $calculationDone?: boolean }>`
+  opacity: ${(props) => (props.$calculationDone ? '1' : '0')};
 `;
 export const ellipseNode = (
   parentNode: HTMLElement,
@@ -110,7 +110,7 @@ const MiddleEllipsis = ({
       }}
     >
       <StyledMiddleEllipsis ref={ref}>
-        <MiddleEllipsisText calculationDone={calculationDone} className="middle-ellipsis-text">
+        <MiddleEllipsisText $calculationDone={calculationDone} className="middle-ellipsis-text">
           {text}
         </MiddleEllipsisText>
       </StyledMiddleEllipsis>

--- a/src/react/ui-elements/Table.tsx
+++ b/src/react/ui-elements/Table.tsx
@@ -56,7 +56,7 @@ export const HeadRow = styled.tr`
   width: 100%;
   cursor: pointer;
 
-  // following is needed to display scroll bar onto the table
+  /* following is needed to display scroll bar onto the table */
   display: table;
   table-layout: fixed;
 `;
@@ -67,16 +67,16 @@ export const HeadCell = styled.th`
 
 // * table body
 export const Body = styled.tbody`
-  // following is needed to display scroll bar onto the table
+  /* following is needed to display scroll bar onto the table */
   display: block;
   overflow: auto;
 `;
 export const BodyWindowing = styled.tbody`
   flex: 1;
 `;
-export const Row = styled(HeadRow)`
-  // it's better to use 1px instead of spacing.r1, otherwise the border of some rows
-  // can look different cause of subpixel positioning
+export const Row = styled(HeadRow)<{ $isSelected?: boolean }>`
+  /* it's better to use 1px instead of spacing.r1, otherwise the border of some rows
+     can look different cause of subpixel positioning */
   border-bottom: 1px solid ${(props) => props.theme.backgroundLevel1};
   &:hover,
   &:focus {
@@ -88,19 +88,16 @@ export const Row = styled(HeadRow)`
   box-sizing: border-box;
   border-right: ${spacing.r4} solid transparent;
 
-  ${(
-    //@ts-expect-error fix this when you are working on it
-    { isSelected, theme },
-  ) =>
-    isSelected &&
+  ${({ $isSelected, theme }) =>
+    $isSelected &&
     `
         background-color: ${theme.highlight};
         border-right: ${spacing.r4} solid ${theme.selectedActive};
     `}
 `;
-export const Cell = styled.td<{ shade?: boolean }>`
+export const Cell = styled.td<{ $shade?: boolean }>`
   vertical-align: middle;
-  color: ${(props) => (props.shade ? props.theme.infoPrimary : props.theme.textPrimary)};
+  color: ${(props) => (props.$shade ? props.theme.infoPrimary : props.theme.textPrimary)};
   padding: ${spacing.r4} ${spacing.r16} ${spacing.r4} ${spacing.r16};
   text-overflow: ellipsis;
   overflow: hidden;
@@ -142,12 +139,12 @@ export const Search = styled.div`
   display: flex;
   flex: 0 0 auto;
 `;
-export const SearchMetadataContainer = styled.form<{ isHidden?: boolean }>`
+export const SearchMetadataContainer = styled.form<{ $isHidden?: boolean }>`
   flex: 1 0 auto;
   display: flex;
   max-width: 600px;
   margin-right: ${spacing.r20};
-  visibility: ${(props) => (props.isHidden ? 'hidden' : 'visible')};
+  visibility: ${(props) => (props.$isHidden ? 'hidden' : 'visible')};
 `;
 export const SearchMetadataInputAndIcon = styled.div`
   position: relative;
@@ -172,8 +169,8 @@ export const ActionButton = styled(Button)`
 export const InlineButton = styled(Button)`
   height: ${spacing.r24};
 `;
-export const AccountSelectorButton = styled(Button)<{ bigButton?: boolean }>`
-  height: ${(props) => (props.bigButton ? spacing.r32 : spacing.r24)};
+export const AccountSelectorButton = styled(Button)<{ $bigButton?: boolean }>`
+  height: ${(props) => (props.$bigButton ? spacing.r32 : spacing.r24)};
 `;
 export const Title = styled.div`
   font-size: ${fontSize.larger};
@@ -230,8 +227,8 @@ export const ButtonContainer = styled.div`
     margin-left: ${spacing.r4};
   }
 `;
-export const SubHeaderContainer = styled.div<{ isHidden?: boolean }>`
-  visibility: ${(props) => (props.isHidden ? 'hidden' : 'visible')};
+export const SubHeaderContainer = styled.div<{ $isHidden?: boolean }>`
+  visibility: ${(props) => (props.$isHidden ? 'hidden' : 'visible')};
   margin-left: ${spacing.r4};
 `;
 export const TableContainer = styled.div`
@@ -240,11 +237,11 @@ export const TableContainer = styled.div`
   height: 100%;
 `;
 export const GentleEmphaseSecondaryText = styled(SecondaryText)<{
-  alignRight?: boolean;
+  $alignRight?: boolean;
 }>`
   font-style: italic;
   ${(props) =>
-    props.alignRight
+    props.$alignRight
       ? `
     text-align: right;
     display: block;

--- a/src/react/ui-elements/TableKeyValue2.tsx
+++ b/src/react/ui-elements/TableKeyValue2.tsx
@@ -80,11 +80,11 @@ export const Row = styled.div`
   margin-bottom: ${spacing.sp4};
   min-height: ${spacing.sp24};
 `;
-const RawKey = styled.div<{ principal?: boolean; required?: boolean }>`
-  color: ${(props) => (props.principal ? props.theme.textPrimary : props.theme?.textSecondary)};
-  font-weight: ${(props) => (props.principal ? 'bold' : 'normal')};
+const RawKey = styled.div<{ $principal?: boolean; $required?: boolean }>`
+  color: ${(props) => (props.$principal ? props.theme.textPrimary : props.theme?.textSecondary)};
+  font-weight: ${(props) => (props.$principal ? 'bold' : 'normal')};
   ${(props) =>
-    props.required
+    props.$required
       ? `
         &:after {
             content: '*';
@@ -92,15 +92,15 @@ const RawKey = styled.div<{ principal?: boolean; required?: boolean }>`
     `
       : ''}
 `;
-export const Key = styled(RawKey)<{ size?: string }>`
+export const Key = styled(RawKey)<{ $size?: string }>`
   && {
-    flex: ${(props) => props.size || '0.35'};
+    flex: ${(props) => props.$size || '0.35'};
     min-width: 0;
   }
 `;
-const KeyContainer = styled.div<{ size?: number }>`
+const KeyContainer = styled.div<{ $size?: number }>`
   display: flex;
-  flex: 1 1 ${(props) => props.size || 35}%;
+  flex: 1 1 ${(props) => props.$size || 35}%;
 `;
 type KeyTooltipProps = {
   children: ReactNode;
@@ -110,24 +110,27 @@ type KeyTooltipProps = {
   principal?: boolean;
   size?: number;
 };
-export const KeyTooltip = ({ children, tooltipMessage, tooltipWidth, size, ...props }: KeyTooltipProps) => (
-  <KeyContainer size={size}>
-    <RawKey {...props}> {children} </RawKey>
+export const KeyTooltip = ({ children, tooltipMessage, tooltipWidth, size, required, principal }: KeyTooltipProps) => (
+  <KeyContainer $size={size}>
+    <RawKey $principal={principal} $required={required}>
+      {' '}
+      {children}{' '}
+    </RawKey>
     {tooltipMessage && <IconHelp tooltipMessage={tooltipMessage} overlayStyle={{ width: tooltipWidth }} />}
   </KeyContainer>
 );
-export const Value = styled.div<{ size?: string; width?: string }>`
-  flex: ${(props) => props.size || '0.65'};
+export const Value = styled.div<{ $size?: string; $width?: string }>`
+  flex: ${(props) => props.$size || '0.65'};
   flex-direction: column;
   i {
     margin-right: ${spacing.sp8};
   }
   min-width: 0;
-  width: ${(props) => props.width};
+  width: ${(props) => props.$width};
 `;
-export const GroupValues = styled.div<{ size?: string }>`
+export const GroupValues = styled.div<{ $size?: string }>`
   display: flex;
-  flex: ${(props) => props.size || '0.65'};
+  flex: ${(props) => props.$size || '0.65'};
   justify-content: space-between;
   align-items: center;
   min-width: 0;
@@ -140,22 +143,22 @@ const Table = styled.div`
   overflow: auto;
   width: 100%;
 `;
-export const Header = styled.div<{ isRemoved?: boolean }>`
-  display: ${(props) => (props.isRemoved ? 'none' : 'flex')};
+export const Header = styled.div<{ $isRemoved?: boolean }>`
+  display: ${(props) => (props.$isRemoved ? 'none' : 'flex')};
   flex-direction: row;
   justify-content: space-between;
 `;
-export const BannerContainer = styled.div<{ isHidden?: boolean }>`
+export const BannerContainer = styled.div<{ $isHidden?: boolean }>`
   margin-right: ${spacing.sp8};
   width: 60%;
-  visibility: ${(props) => (props.isHidden ? 'hidden' : 'visible')};
+  visibility: ${(props) => (props.$isHidden ? 'hidden' : 'visible')};
 `;
 export const Footer = styled.div`
   display: flex;
   justify-content: flex-end;
   margin-bottom: ${spacing.sp8};
 `;
-export const ExtraCell = styled.div<{ marginLeft?: string }>`
-  margin-left: ${(props) => props.marginLeft || spacing.sp20};
+export const ExtraCell = styled.div<{ $marginLeft?: string }>`
+  margin-left: ${(props) => props.$marginLeft || spacing.sp20};
 `;
 export default Table;

--- a/src/react/ui-elements/Utility.ts
+++ b/src/react/ui-elements/Utility.ts
@@ -1,11 +1,11 @@
 import type { Property } from 'csstype';
 import styled from 'styled-components';
 export const TextTransformer = styled.span<{
-  transform: Property.TextTransform;
+  $transform: Property.TextTransform;
 }>`
-  text-transform: ${(props) => props.transform};
+  text-transform: ${(props) => props.$transform};
 `;
 
-export const TextAligner = styled.div<{ alignment?: string }>`
-  text-align: ${(props) => props.alignment};
+export const TextAligner = styled.div<{ $alignment?: string }>`
+  text-align: ${(props) => props.$alignment};
 `;

--- a/src/react/ui-elements/Warning.tsx
+++ b/src/react/ui-elements/Warning.tsx
@@ -3,7 +3,7 @@ import { Button } from '@scality/core-ui/dist/next';
 import type { ReactNode } from 'react';
 import styled, { css } from 'styled-components';
 
-const Container = styled.div<{ centered?: boolean }>`
+const Container = styled.div<{ $centered?: boolean }>`
   ${(props) => {
     return css`
       color: ${props.theme.textSecondary};
@@ -12,7 +12,7 @@ const Container = styled.div<{ centered?: boolean }>`
   display: flex;
   flex-direction: column;
   width: 100%;
-  text-align: ${(props) => (props.centered ? 'center' : 'left')};
+  text-align: ${(props) => (props.$centered ? 'center' : 'left')};
 `;
 const Container2 = styled.div`
   text-align: center;
@@ -36,7 +36,7 @@ type WarningProps = {
   centered?: boolean;
 };
 export const Warning = ({ icon, title, btnTitle, btnAction, centered }: WarningProps) => (
-  <Container centered={centered}>
+  <Container $centered={centered}>
     <div>{icon}</div>
     <Title> {title} </Title>
     {!!btnTitle && !!btnAction && (

--- a/src/styled.d.ts
+++ b/src/styled.d.ts
@@ -1,0 +1,6 @@
+import type { CoreUITheme } from '@scality/core-ui/dist/style/theme';
+import 'styled-components';
+
+declare module 'styled-components' {
+  export interface DefaultTheme extends CoreUITheme {}
+}


### PR DESCRIPTION
**TL;DR** — Moves zenko-ui onto `@scality/core-ui` 0.227.0, which brings styled-components v6, the CUI-12 modal layout, and react-router 7.18.2 in one bump. 27 style-only props become transient, five modals are refitted, and one field label changes. No responsive behaviour is adopted yet.

### Context / Why

[ZKUI-508](https://scality.atlassian.net/browse/ZKUI-508) — Step 1 of the fleet-wide core-ui uplift ([ARTESCA-17790](https://scality.atlassian.net/browse/ARTESCA-17790), *Responsive UI for Guardian embedding*). This unblocks [ARTESCA-17874](https://scality.atlassian.net/browse/ARTESCA-17874) (bump `ZENKO_UI_IMAGE_VERSION` in the appliance).

zenko-ui is the largest styled surface in the fleet, so it is the real stress test of the transient-prop sweep.

### 🧩 Approach

**Exact pins, not carets — this is the part worth arguing about.** core-ui 0.227.0 itself declares `styled-components: ^6.4.3`, and the Module Federation `shared` config derives `requiredVersion` from `deps['styled-components']`. Under a caret, shell-ui and this remote can each resolve a different patch and load **two** styled-components runtimes — which breaks theming *silently* rather than crashing, because each runtime carries its own `ThemeProvider` context.

| | before | after | why |
|---|---|---|---|
| `@scality/core-ui` | `0.219.0` | **`0.227.0`** | registry pin |
| `styled-components` | `^5.3.11` | **`6.5.1`** | MF singleton — a caret admits two runtimes |
| `react-router` / `-dom` | `7.13.0` | **`7.18.2`** | matches what core-ui 0.227.0 resolves |
| `@types/styled-components` | `^5.1.34` | *removed* | v6 ships its own types, via the new `src/styled.d.ts` |

`@types/styled-components` is replaced by a three-line module augmentation (`src/styled.d.ts`) declaring `DefaultTheme extends CoreUITheme` — that is what keeps `props.theme.backgroundLevel1` typed across ~90 styled definitions.

**`@scality/data-browser-library` is not pinned by this PR** — `development/4` already ships **1.4.4** ([ZKUI-514](https://scality.atlassian.net/browse/ZKUI-514)), which is downstream of the [DBR-72](https://scality.atlassian.net/browse/DBR-72) v6 release (scality/data-browser#411, 1.4.3). Worth stating because the library's old `^5.0.0` styled-components peer was a real conflict against this branch's v6 pin — it installed only because every workflow here passes `--legacy-peer-deps`. 1.4.4 widens that peer to `>=5 <7`, so it is now genuinely satisfied, and this branch inherits it untouched.

**Transient props — 27 of them, and TypeScript cannot catch a miss.** The v6 prop pipeline forwards everything and only *warns*; it no longer drops invalid DOM props. Straight from the shipped 6.5.1 bundle:

```js
for (const key in props) {
  if (props[key] === undefined || key[0] === '$' || key === 'as' || …) continue;   // ← dropped
  else if (shouldForwardProp && !shouldForwardProp(key, target)) { /* dropped */ }
  else {
    computedProps[key] = props[key];                              // ← forwarded ALWAYS
    if (!shouldForwardProp && isDev && !isPropValid(key) && isTag(target)) {
      console.warn('styled-components: it looks like an unknown prop …');   // ← warn only
    }
  }
}
```

So `$` is the *only* thing that stops a style-only prop reaching the DOM. Renamed at each definition **and every call site**, across the `ui-elements`, `ISV`, `account` and `truststore` trees: `$size`, `$width`, `$isShrink`, `$isHidden`, `$disabled`, `$direction`, `$selected`, `$required`, `$principal`, `$shown`, `$searchInputIsFocused`, `$isVisible`, `$isSelected`, `$isOpen`, `$height`, `$centered`, `$calculationDone`, `$bigButton`, `$alignRight`, `$alignItems`, `$transform`, `$shade`, `$marginLeft`, `$isRemoved`, `$hasError`, `$fontSize`, `$alignment`.

The compiler is not a safety net: a single loosely-typed JSX spread on an element disables excess-property checking for the explicitly-written sibling props on that same element, so a missed rename type-checks cleanly and only surfaces as a runtime warning. **The console sweep is the actual backstop** — see Verification.

**That failure mode was already live in this file, and this PR is what found it.** `AttachmentTable` passed `disableToggle` to a `styled(SearchInput)`:

Before:
```tsx
<StyledSearchInput
  placeholder="Search by entity name"
  {...getInputProps({ ref: (element) => { … } })}   // ← untyped spread parks excess-property checking
  disableToggle                                      // ← removed from core-ui in 0.136.0 (June 2024)
  disabled={firstPageStatus === 'error' || …}
/>
```
After:
```tsx
<StyledSearchInput
  placeholder="Search by entity name"
  {...getInputProps({ ref: (element) => { … } })}
  disabled={firstPageStatus === 'error' || …}        // ← dead prop dropped
/>
```

core-ui's `SearchInput` deleted `disableToggle` from its `Props` more than a year ago and spreads its `...rest` onto a `styled.div`. Under v5 that div filtered the prop out; under v6 it forwards it to the DOM. The prop had been dead the whole time and `tsc` never said a word, because downshift's `getInputProps()` spread sits on the same element. Two call sites, both dropped — **no behaviour change**, the toggle it once controlled no longer exists.

**stylis v4** no longer accepts `//` comments inside a styled template literal; nine of them become `/* */` (`Table.tsx`, `Input.ts`, `EditableKeyValue.tsx`, `FormContainer.ts`, `Utility.ts`).

**CUI-12 modal layout.** A non-`wide` body is now `width: min(480px, 90vw)` + `padding: 2rem` + `border-box`. That padding is **rem-based**, so under the shell's 92% root font-size (**1rem = 14.72px**) the usable content box is **421px** — the familiar "416px" figure only holds at a 16px root. Anything wider gets a horizontal scrollbar inside the body and is clipped by `ModalContent`'s `overflow: hidden`. **Five** modals needed refitting: three opt into `wide` because their content genuinely needs the room, one drops a hardcoded width, and one turns a width into a flex basis.

| Modal | fix | offending child |
|---|---|---|
| `ISVWideModal` (Welcome / ISV / ISVConnector) | `styled(Modal).attrs({ wide: true })` | none — the shell was already wide, the **body** wasn't |
| Attachment confirmation | `wide` + `height` `25rem`→`20rem` + a `flex: 1; min-height: 0` table wrapper | `width: 50rem` (**kept** — it now drives the wide modal's width) |
| Account & role selector | `wide` | none — the role table's natural width |
| Veeam max capacity | `width: 40rem` and `forceLabelWidth={300}` deleted | `40rem` = 589px |
| Certificate details | `width: 12rem` → `flex: 0 0 12rem` + `min-width: 0` | a `width` on a flex child collapses instead of reserving |

⚠️ **One user-visible copy change rides along**: the Veeam capacity field label goes from **"Max Veeam Repository Capacity"** to **"Max Capacity"**. It is what lets the row fit 421px without `wide`, but it is a wording decision, not a layout one — see the screenshot pair and flag it if the shorter label is not wanted.

### 📷 Screenshots

All five captured at 1440×900 on the same core-ui 0.227.0 install. **"Before" is this branch with only the modal-pass hunks reverted** (`git checkout HEAD~2 -- <the 6 files>`), so each pair differs by exactly this PR's modal changes and nothing else — same dependencies, same data, same cluster. **The images are to scale**, so every width change is visible directly.

**1. ISV connector** — *Accounts › **Start ISV Connector***. The worst of the five: `ISVWideModal`'s own `> div { max-width: 60vw }` sized the *shell* to 907px, but CUI-12 pinned the *body* to 480px, so the card grid was crammed into a 480px column inside a 907px dialog — third column gone, card titles colliding with their "Learn more" links, ~427px of dead space on the right.

| Before — 907px shell, 480px body | After — `.attrs({ wide: true })` |
|---|---|
| <img width="916" height="720" alt="ISV connector modal: a 907px-wide dialog whose content is squeezed into a 480px column, the third card column cut off and card titles overlapping their Learn more links" src="https://github.com/user-attachments/assets/c2bdd349-63ca-4742-b212-32d1ff918d99" /> | <img width="916" height="693" alt="The same modal with wide: three full card columns, titles and Learn more links on separate lines, no dead space" src="https://github.com/user-attachments/assets/96a69693-16dd-42c9-b7ba-6d9fcd18757f" /> |

The selected **Veeam Backup & Replication** card carries the `theme.highlight` background on both sides — that is the `$selected` rename holding, next to the greyed-out cards proving `$disabled` still applies.

**2. Attachment confirmation** — *Accounts › an account › Policies › **Attach** › mark entities › **Save***. Measured `.sc-modal-body`: `clientWidth 469` / `scrollWidth 795` — **326px over**, plus `clientHeight 444` / `scrollHeight 477` vertically. Both scrollbars, and the **Attachment status** column entirely off-screen.

| Before — 480px, both scrollbars | After — `wide`, 795px |
|---|---|
| <img width="488" height="588" alt="Attachment confirmation modal at 480px: the Attachment status column is cut off the right edge and a horizontal scrollbar sits under the table" src="https://github.com/user-attachments/assets/0143ff93-9da7-48df-9618-bee6229e2b1f" /> | <img width="804" height="482" alt="The same modal with wide at 795px: all four columns visible, no scrollbars" src="https://github.com/user-attachments/assets/b55c1b86-bdcf-4089-8316-922ecbd7ffa6" /> |

The height change is the other half: `25rem` was taller than the room left under the intro text, so the table pushed a *vertical* scrollbar onto the body. `20rem` plus a `flex: 1; min-height: 0` wrapper hands the table the space that is actually left instead.

**3. Account & role selector** — the breadcrumb account button on any account page. Not previously flagged as an offender, but the role table needs 597px and only got 408px, so **Role Path** was silently truncated:

| Before — 480px, Role Path truncated | After — `wide`, 639px |
|---|---|
| <img width="488" height="577" alt="Select Account and Role modal at 480px: only Account Name and Role Name columns are visible, Role Path is cut off" src="https://github.com/user-attachments/assets/c0591764-d618-42ab-b59e-ef05f19ab478" /> | <img width="648" height="556" alt="The same modal with wide at 639px: Account Name, Role Name and Role Path all visible" src="https://github.com/user-attachments/assets/4904b91f-df5a-4905-aba8-f043ff147aa0" /> |

**4. Veeam max capacity** — the only one fixed *without* `wide`, and the one carrying the label change. `clientWidth 480` / `scrollWidth 673` before — **193px over**, with the unit dropdown clipped mid-control:

| Before — `40rem` form, long label | After — no fixed width, `Max Capacity` |
|---|---|
| <img width="488" height="268" alt="Edit max repository capacity modal before: the label reads Max Veeam Repository Capacity, the TiB unit dropdown is clipped at the right edge, and a horizontal scrollbar runs under the form" src="https://github.com/user-attachments/assets/0db90bdf-ba2c-49ca-a9de-2c86a9ef0d6a" /> | <img width="488" height="257" alt="The same modal after: label reads Max Capacity, value and TiB dropdown both fully visible, no scrollbar" src="https://github.com/user-attachments/assets/0bc6d8e7-28fe-4176-aa84-8af04c439ff8" /> |

**5. Certificate details** — *Truststore › a certificate › **View Details***. No scrollbar on either side; this one is pure alignment. `width: 12rem` on a flex child does not reserve space, so on the two long rows the label column **collapsed** — labels slid left, "Public Key" wrapped onto two lines, and the value column lost its common left edge:

| Before — `width: 12rem`, labels collapse | After — `flex: 0 0 12rem` |
|---|---|
| <img width="488" height="534" alt="Certificate Details modal before: the Certificate and Public Key labels sit further left than the rows above them, Public Key wraps onto two lines, and the values no longer share a left edge" src="https://github.com/user-attachments/assets/d97e9326-131d-4272-86f6-a9e7dbdac114" /> | <img width="488" height="515" alt="The same modal after: every label in one column, every value aligned on a common left edge, Public Key on one line" src="https://github.com/user-attachments/assets/9ae12d9f-d217-4887-9c3b-48b54a56631e" /> |

**Not screenshotted:** `Hide.tsx` gets the same class of fix — `HideValue`'s `width: 15rem` becomes `width: 0; flex-grow: 1` so a revealed secret can no longer widen its own cell, and `HideAction` gains `flex-shrink: 0; white-space: nowrap` because the surrounding `word-break: break-word` was letting "Hide" render as "Hid e". Its only host is the Root-user-access-key modal, which cannot be reached without creating a real access key, so it is unverified visually — please exercise it during review.

### 🔍 Review focus

- 🟡 **Moderate** — `src/react/ISV/components/veeam/VeeamCapacityFormSection.tsx` › `VeeamCapacityFormSection` — the **label copy change** ("Max Veeam Repository Capacity" → "Max Capacity") and the dropped `forceLabelWidth={300}`. The only wording change in the PR; a layout bump is a poor place to hide one, so it is called out rather than buried.
- 🟡 **Moderate** — `src/react/ui-elements/TableKeyValue2.tsx` and `Table.tsx` › styled definitions + call sites — the densest rename sites (21 and 13) and shared by many screens, so a missed call site here has the widest blast radius. `KeyTooltip` in particular stops forwarding `{...props}` and now passes `$principal` / `$required` explicitly.
- ⚪ **Minor** — `src/react/account/iamAttachment/AttachmentConfirmationModal.tsx` › `AttachmentConfirmationModal` — `width: 50rem` **stays** and now sets the wide modal's width. Worth deciding whether that is the intent or whether it should size to content like the Veeam modal does.
- ⚪ **Minor** — `src/react/ISV/components/shared/StyledComponents.tsx` › `ISVWideModal` — `.attrs({ wide: true })` is a new indirection; worth confirming it reads clearly versus `wide` at each of the three call sites.

### 🧪 How to test

zenko-ui is a federated micro-frontend and does not render standalone — use [artesca-ui-launcher](https://github.com/scality/artesca-ui-launcher) (`npm run v2 -- zenko metalk8s`; the Truststore nav only appears when a metalk8s instance is discovered), not a bare `npm run dev`.

1. Accounts › **Start ISV Connector** — the card grid should fill the dialog. Select and deselect a card: the highlight background and the greyed-out disabled cards are the `$selected` / `$disabled` renames.
2. Accounts › an account › **Policies** › **Attach** › mark an entity › **Save** — all four columns visible, no scrollbar in either axis.
3. The breadcrumb **account button** on any account page — Account Name, Role Name *and* Role Path all visible.
4. A bucket whose `application` tag is Veeam Backup & Replication › **Max repository Capacity** › **Edit** — the field, its unit dropdown and the footer all fit at the default width.
5. Truststore › a certificate › **View Details** — every label in one column, every value on a common left edge.
6. Accounts › an account › **Create Access key** — reveal the secret with **Show**: the value must not widen the row, and the link must read "Hide", not "Hid e".
7. Accounts › an account › **Overview** — the key/value grids should keep their column proportions (the `$size` / `$width` renames).
8. Data Browser views (buckets, objects, object details) — these come from `@scality/data-browser-library` 1.4.4, itself on core-ui 0.227.0 and v6; confirm they render, are themed, and that its **Create folder**, **Upload**, **Delete object**, **Restore object** and **Empty bucket** modals fit their content box.
9. Watch the console throughout: no `React does not recognize …`, no `received $x`, no `unknown prop` warnings, no `useTheme` errors. Two styled-components runtimes show up as unthemed content, not an error.

### 🚧 Follow-up

- **Merge gate** — must land with the rest of the train, not ahead of it (see below).
- **Appliance integration** — [ARTESCA-17874](https://scality.atlassian.net/browse/ARTESCA-17874) bumps `ZENKO_UI_IMAGE_VERSION` once this releases.
- **Responsive adoption** (`ResponsiveContainer` / `useContainerWidth` / shrink-to-fit) is deliberately out of scope — this wave only gets the UI *onto* the responsive-ready core-ui.

### ⚠️ Lockstep warning for the integrator

`styled-components` is a `singleton: true` MF share — one instance serves the whole page at runtime, and a v5 remote next to a v6 remote breaks theming **silently** rather than crashing. shell-ui (host), metalk8s ui, zenko-ui, identity-ui, xcore ui and `@artesca/ui` must ship in **one** ARTESCA release train, all six on core-ui `0.227.0` / styled-components `6.5.1` / react-router `7.18.2`. `ZENKO_UI_IMAGE_VERSION` must not be bumped in the appliance alone.

### 🔗 References

- [ZKUI-508](https://scality.atlassian.net/browse/ZKUI-508) — Bump @scality/core-ui to latest version (styled-components v6, modal, react-router, responsive)
- [ARTESCA-17790](https://scality.atlassian.net/browse/ARTESCA-17790) — Epic: Responsive UI (core-ui) for Guardian embedding
- [ARTESCA-17874](https://scality.atlassian.net/browse/ARTESCA-17874) — Integrate zenko-ui core-ui-v6 release into ARTESCA (blocked by this)
- [DBR-72](https://scality.atlassian.net/browse/DBR-72) — data-browser-library uplift; released as 1.4.3 (scality/data-browser#411), and reached this branch via 1.4.4 on the base
- [ZKUI-514](https://scality.atlassian.net/browse/ZKUI-514) — bumped the library to 1.4.4 on `development/4`; this branch rebased onto it
- scality/metalk8s#5080 — sibling Step-1 PR (MK8S-364)
- scality/identity-ui#241 — sibling Step-1 PR (IUI-19)
- scality/hyperdrive-operator#2834 — sibling Step-1 PR (HD-4674)
- scality/artesca#5411 — sibling Step-1 PR (ARTESCA-17873)

<details><summary>What changed</summary>

**Verification**

- **898 passed / 10 skipped across 109 of 110 suites** (1 suite skipped) — all green, re-run after rebasing onto `development/4` at `083a69c0`, which brought in the CRR setup-wizard work and its new suites.
- **Zero** v6 prop-leak warnings (`React does not recognize`, `received $x`, unknown/non-boolean attribute) across the full jsdom run, and zero render-loop errors.
- **Zero** in a real browser too: the five screenshot flows above plus the accounts, buckets, policies, truststore and ISV screens were driven at 1440×900 with the console captured throughout — no prop-leak warning of any kind. Everything logged was pre-existing federation version chatter and react-router splat-path advisories.
- Exactly **one physical `styled-components` (6.5.1)** hoisted, with core-ui `deduped` onto it.
- Lockfile shrinks by ~284 net lines: v6 drops v5's babel-plugin/emotion subtree.

**Test adjustments (second commit)**

- `WelcomeModal`'s `ISVModalContent` mock stopped spreading its remaining props onto a `div`: `selectedISV`/`setSelectedISV` are not DOM attributes, and v6 no longer filters them, so the spread logged `React does not recognize the … prop`.
- `ISVConfiguration` mocked the whole of `react` to stub `useRef`. Under the new core-ui that stub returned a fresh object each render, so an effect keyed on the ref looped. The stub is gone — the test never needed it.

**How the Veeam capacity modal was reached (no cluster writes)**

No bucket on the dev cluster carries the `application: Veeam Backup & Replication` tag that gates `VeeamCapacityOverviewRow`, and tagging one would have been a real S3 write. Instead the gate was forced locally behind a `?veeamshot` query param — two temporary edits (`detectBucketApplication` returning the Veeam case, `isSOSAPIEnabled` short-circuited with a seeded 9.09 TiB capacity), both reverted; the worktree is clean. Nothing was written to the cluster, and **Confirm** was never clicked on any of the five modals.

**On the 421px content box**

Worth carrying to the sibling PRs: because core-ui's modal padding is `2rem` rather than a px literal, the content box tracks the root font size. Under the shell (root 92% → 14.72px) it is **421px**; the "416px" number in the CUI-12 guideline assumes a 16px root. Every rem-declared child width scales the same way — `28rem` is 412px here, not 448px — so rem arithmetic done at 16px overstates overflow. px literals do *not* scale. All five overflows above were measured live as `clientWidth` vs `scrollWidth` rather than computed.

**Known dead dependency (untouched)**

`@welldone-software/why-did-you-render` is declared but imported nowhere in `src/`. Left alone here to keep this PR to the uplift; worth removing separately.

</details>


[ZKUI-508]: https://scality.atlassian.net/browse/ZKUI-508?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ARTESCA-17790]: https://scality.atlassian.net/browse/ARTESCA-17790?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ARTESCA-17874]: https://scality.atlassian.net/browse/ARTESCA-17874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ZKUI-514]: https://scality.atlassian.net/browse/ZKUI-514?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ