### PR TITLE
ZKUI-514: Bump data-browser-library to 1.4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@scality/certchain": "1.4.0",
         "@scality/core-ui": "0.218.0",
-        "@scality/data-browser-library": "1.4.2",
+        "@scality/data-browser-library": "1.4.4",
         "@scality/module-federation": "1.6.1",
         "@scality/react-chained-query": "^2.1.0",
         "@types/react-table": "^7.7.10",
@@ -5731,9 +5731,9 @@
       }
     },
     "node_modules/@scality/data-browser-library": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.4.2.tgz",
-      "integrity": "sha512-h2aQTAbiTcyKQT5QG5Y5uvTXPACxaASAJHcB5lo539Jp6v7zgp3c2PkpfLjZ3apZFjAJii+yN74l6t/gB4ccng==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.4.4.tgz",
+      "integrity": "sha512-jlV4xY0F+TiSkoTmjo8v5O8MBYsHz6y9ZGXmy9P8cdvR4Kl99gen8kxmqJwKtwVajW/vpzf0VWPHH2SOJLLIIA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.983.0",
@@ -5752,11 +5752,11 @@
       },
       "peerDependencies": {
         "@scality/core-ui": ">=0.202.0",
-        "react": ">=18.0.0",
-        "react-dom": ">=18.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
         "react-router": ">=7.1.3",
         "react-router-dom": ">=7.1.3",
-        "styled-components": "^5.0.0"
+        "styled-components": ">=5 <7"
       }
     },
     "node_modules/@scality/data-browser-library/node_modules/file-selector": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@scality/certchain": "1.4.0",
     "@scality/core-ui": "0.218.0",
-    "@scality/data-browser-library": "1.4.2",
+    "@scality/data-browser-library": "1.4.4",
     "@scality/module-federation": "1.6.1",
     "@scality/react-chained-query": "^2.1.0",
     "@types/react-table": "^7.7.10",


### PR DESCRIPTION
## Summary
Automated bump of `@scality/data-browser-library`.

## Links
- Release: https://github.com/scality/data-browser/releases/tag/1.4.4
- Jira: https://scality.atlassian.net/browse/ZKUI-514

🤖 Generated by data-browser auto-bump