### PR TITLE
ZKUI-514: Configure the lifecycle documentation URLs and bump data-browser-library to 1.4.4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@scality/certchain": "1.4.0",
         "@scality/core-ui": "0.219.0",
-        "@scality/data-browser-library": "1.4.2",
+        "@scality/data-browser-library": "1.4.4",
         "@scality/module-federation": "1.6.1",
         "@scality/react-chained-query": "^2.1.0",
         "@types/react-table": "^7.7.10",
@@ -5731,9 +5731,9 @@
       }
     },
     "node_modules/@scality/data-browser-library": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.4.2.tgz",
-      "integrity": "sha512-h2aQTAbiTcyKQT5QG5Y5uvTXPACxaASAJHcB5lo539Jp6v7zgp3c2PkpfLjZ3apZFjAJii+yN74l6t/gB4ccng==",
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.4.4.tgz",
+      "integrity": "sha512-jlV4xY0F+TiSkoTmjo8v5O8MBYsHz6y9ZGXmy9P8cdvR4Kl99gen8kxmqJwKtwVajW/vpzf0VWPHH2SOJLLIIA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.983.0",
@@ -5752,11 +5752,11 @@
       },
       "peerDependencies": {
         "@scality/core-ui": ">=0.202.0",
-        "react": ">=18.0.0",
-        "react-dom": ">=18.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0",
         "react-router": ">=7.1.3",
         "react-router-dom": ">=7.1.3",
-        "styled-components": "^5.0.0"
+        "styled-components": ">=5 <7"
       }
     },
     "node_modules/@scality/data-browser-library/node_modules/file-selector": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@scality/certchain": "1.4.0",
     "@scality/core-ui": "0.219.0",
-    "@scality/data-browser-library": "1.4.2",
+    "@scality/data-browser-library": "1.4.4",
     "@scality/module-federation": "1.6.1",
     "@scality/react-chained-query": "^2.1.0",
     "@types/react-table": "^7.7.10",

--- a/src/react/databrowser/DataBrowser.tsx
+++ b/src/react/databrowser/DataBrowser.tsx
@@ -26,6 +26,12 @@ import { useBucketCreateConfig } from './buckets/useBucketCreateConfig';
 import ListLayoutButtons from './HeaderButtons';
 import { BucketMetricsPrefetch } from './hooks/useBucketMetrics';
 
+// Served by the bundled documentation, so these resolve in offline deployments too.
+// Expiration is a chapter with its own index; transition is a single page.
+const BUCKET_OPERATIONS_DOCS = '/artesca/docs/data_management/bucket_operations';
+const LIFECYCLE_EXPIRATION_DOCS_URL = `${BUCKET_OPERATIONS_DOCS}/lifecycle_expiration/index.html`;
+const LIFECYCLE_TRANSITION_DOCS_URL = `${BUCKET_OPERATIONS_DOCS}/transition_workflow.html`;
+
 const EXTRA_BUCKET_OVERVIEW_SECTIONS = [
   {
     id: 'useCase',
@@ -167,6 +173,8 @@ export default function DataBrowser({ hideHeader = false }: { hideHeader?: boole
         replicationDestinationFields={ReplicationCRRDestinationFields}
         isLocationCold={isLocationCold}
         isVersioningDisabled={isVersioningDisabled}
+        lifecycleExpirationDocsUrl={LIFECYCLE_EXPIRATION_DOCS_URL}
+        lifecycleTransitionDocsUrl={LIFECYCLE_TRANSITION_DOCS_URL}
       />
     </>
   );


### PR DESCRIPTION
## Why this is more than a version bump

`@scality/data-browser-library` 1.4.4 no longer supplies default URLs for the two lifecycle "Learn more" links — each renders only when the host application passes its URL. zenko-ui passed neither and relied on that default, so bumping alone would silently drop both links from the bucket lifecycle rule form.

## Changes

- `@scality/data-browser-library` 1.4.2 → 1.4.4
- Pass `lifecycleExpirationDocsUrl` and `lifecycleTransitionDocsUrl` to `<DataBrowserUI>`, pointing at the bundled documentation

Expiration is a chapter with its own index; transition is a single page, hence the different endings. Behaviour is unchanged, offline deployments included — only the ownership of the paths moved, from a library default to the host application.

## Verification

```
tsc --noemit    0 errors
biome           unchanged from the development/4 baseline
```

The type-check is the meaningful one: it confirms both prop names exist on `DataBrowserUIProps` in 1.4.4, so the links are wired rather than silently ignored.