### PR TITLE
ZKUI-516: align the Accounts screens with the Buckets screens

### DIFF
--- a/src/react/account/AccountHead.tsx
+++ b/src/react/account/AccountHead.tsx
@@ -4,7 +4,7 @@ import ArrowNavigation from '../ui-elements/ArrowNavigation';
 export function AccountHead({ accountName }: { accountName: string }) {
   return (
     <Stack gap="r16">
-      <ArrowNavigation path="/accounts" ariaLabel="Back to all accounts" />
+      <ArrowNavigation path="/accounts" label="Return to all accounts" />
       <Icon name="Account" color="infoPrimary" size="2x" withWrapper />
       <Text variant="Larger">{accountName}</Text>
     </Stack>

--- a/src/react/account/AccountHead.tsx
+++ b/src/react/account/AccountHead.tsx
@@ -1,8 +1,10 @@
 import { Icon, Stack, Text } from '@scality/core-ui';
+import ArrowNavigation from '../ui-elements/ArrowNavigation';
 
 export function AccountHead({ accountName }: { accountName: string }) {
   return (
     <Stack gap="r16">
+      <ArrowNavigation path="/accounts" ariaLabel="Back to all accounts" />
       <Icon name="Account" color="infoPrimary" size="2x" withWrapper />
       <Text variant="Larger">{accountName}</Text>
     </Stack>

--- a/src/react/account/Accounts.tsx
+++ b/src/react/account/Accounts.tsx
@@ -44,7 +44,7 @@ const Accounts = () => {
         <>
           <AppContainer.OverallSummary>
             <Header
-              icon={<MultiAccountsIcon />}
+              icon={<MultiAccountsIcon size="2x" />}
               headTitle={'All Accounts'}
               numInstance={accounts.value.length}
             ></Header>

--- a/src/react/account/MultiAccountsIcon.tsx
+++ b/src/react/account/MultiAccountsIcon.tsx
@@ -1,6 +1,23 @@
-export const MultiAccountsIcon = () => {
+// Follows the shape of core-ui's own custom icons (Bucket, Buckets): the fa
+// classes drive the size and the color is inherited from the wrapper.
+//
+// Two deviations, both because the drawing is not square like a FontAwesome
+// glyph: the viewBox is cropped to the artwork (it used to carry ~14 units of
+// empty space on the sides), and the height is set to 1.4em instead of the 1em
+// `svg-inline--fa` imposes, so the pair of wallets fills the circle the way the
+// bucket icons do rather than floating in the middle of it.
+export const MultiAccountsIcon = ({ size, ariaLabel }: { size?: string; ariaLabel?: string }) => {
   return (
-    <svg width="44" height="28" viewBox="0 0 44 28" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <svg
+      viewBox="7 0 30 28"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      className={`svg-inline--fa ${size ? `fa-${size}` : ''}`}
+      style={{ height: '1.4em' }}
+      role="img"
+      aria-hidden={!ariaLabel}
+      aria-label={ariaLabel}
+    >
       <path
         fillRule="evenodd"
         clipRule="evenodd"

--- a/src/react/account/MultiAccountsIcon.tsx
+++ b/src/react/account/MultiAccountsIcon.tsx
@@ -1,11 +1,3 @@
-// Follows the shape of core-ui's own custom icons (Bucket, Buckets): the fa
-// classes drive the size and the color is inherited from the wrapper.
-//
-// Two deviations, both because the drawing is not square like a FontAwesome
-// glyph: the viewBox is cropped to the artwork (it used to carry ~14 units of
-// empty space on the sides), and the height is set to 1.4em instead of the 1em
-// `svg-inline--fa` imposes, so the pair of wallets fills the circle the way the
-// bucket icons do rather than floating in the middle of it.
 export const MultiAccountsIcon = ({ size, ariaLabel }: { size?: string; ariaLabel?: string }) => {
   return (
     <svg

--- a/src/react/ui-elements/ArrowNavigation.tsx
+++ b/src/react/ui-elements/ArrowNavigation.tsx
@@ -1,0 +1,38 @@
+import { Icon } from '@scality/core-ui';
+import { spacing } from '@scality/core-ui/dist/spacing';
+import { useBasenameRelativeNavigate } from '@scality/module-federation';
+import styled from 'styled-components';
+
+// The box is reserved up front. `Icon` resolves its FontAwesome glyph through a
+// dynamic import, and until it lands core-ui's fallback only reserves 1em of
+// width where the arrow needs 1.25em, so the title next to it shifted right by
+// about 8px on first paint. r40 x r32 is the measured size of the rendered
+// 2x arrow.
+const IconWrapper = styled.div`
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: ${spacing.r40};
+  height: ${spacing.r32};
+  flex: none;
+  cursor: pointer;
+
+  svg {
+    color: ${(props) => props.theme.textPrimary};
+    transition: color 0.2s ease;
+  }
+
+  &:hover svg {
+    color: ${(props) => props.theme.textSecondary};
+  }
+`;
+
+export default function ArrowNavigation({ path, ariaLabel }: { path: string; ariaLabel: string }) {
+  const navigate = useBasenameRelativeNavigate();
+
+  return (
+    <IconWrapper onClick={() => navigate(path)}>
+      <Icon name="Arrow-left" size={'2x'} ariaLabel={ariaLabel} />
+    </IconWrapper>
+  );
+}

--- a/src/react/ui-elements/ArrowNavigation.tsx
+++ b/src/react/ui-elements/ArrowNavigation.tsx
@@ -1,38 +1,34 @@
 import { Icon } from '@scality/core-ui';
+import { Button } from '@scality/core-ui/dist/next';
 import { spacing } from '@scality/core-ui/dist/spacing';
 import { useBasenameRelativeNavigate } from '@scality/module-federation';
 import styled from 'styled-components';
 
-// The box is reserved up front. `Icon` resolves its FontAwesome glyph through a
-// dynamic import, and until it lands core-ui's fallback only reserves 1em of
-// width where the arrow needs 1.25em, so the title next to it shifted right by
-// about 8px on first paint. r40 x r32 is the measured size of the rendered
-// 2x arrow.
-const IconWrapper = styled.div`
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+// core-ui's Button with an icon and neither label nor variant is already the
+// bare icon button we need: transparent, no border, and it handles hover and
+// focus-visible. Being a real button, it is also reachable by keyboard, which a
+// styled div with an onClick is not. core-ui requires a string tooltip on an
+// icon-only button and uses it as the accessible name.
+//
+// The box is sized explicitly because `Icon` resolves its FontAwesome glyph
+// through a dynamic import, and until it lands core-ui's fallback only reserves
+// 1em of width where the arrow needs 1.25em, so the title next to it shifted
+// right on first paint. r40 x r32 is the measured size of the rendered 2x arrow.
+const ArrowButton = styled(Button)`
   width: ${spacing.r40};
   height: ${spacing.r32};
+  padding: 0;
   flex: none;
-  cursor: pointer;
-
-  svg {
-    color: ${(props) => props.theme.textPrimary};
-    transition: color 0.2s ease;
-  }
-
-  &:hover svg {
-    color: ${(props) => props.theme.textSecondary};
-  }
 `;
 
-export default function ArrowNavigation({ path, ariaLabel }: { path: string; ariaLabel: string }) {
+export default function ArrowNavigation({ path, label }: { path: string; label: string }) {
   const navigate = useBasenameRelativeNavigate();
 
   return (
-    <IconWrapper onClick={() => navigate(path)}>
-      <Icon name="Arrow-left" size={'2x'} ariaLabel={ariaLabel} />
-    </IconWrapper>
+    <ArrowButton
+      icon={<Icon name="Arrow-left" size={'2x'} />}
+      onClick={() => navigate(path)}
+      tooltip={{ overlay: label }}
+    />
   );
 }

--- a/src/react/ui-elements/ArrowNavigation.tsx
+++ b/src/react/ui-elements/ArrowNavigation.tsx
@@ -14,10 +14,15 @@ import styled from 'styled-components';
 // through a dynamic import, and until it lands core-ui's fallback only reserves
 // 1em of width where the arrow needs 1.25em, so the title next to it shifted
 // right on first paint. r40 x r32 is the measured size of the rendered 2x arrow.
+// The left margin is not decoration: AppContainer.OverallSummary wraps its
+// children in an overflow:hidden box, and this button is its first child, flush
+// against the edge. Without the margin, the focus-visible outline, which is
+// painted outside the border box, gets its left edge clipped away.
 const ArrowButton = styled(Button)`
   width: ${spacing.r40};
   height: ${spacing.r32};
   padding: 0;
+  margin-left: ${spacing.r4};
   flex: none;
 `;
 

--- a/src/react/ui-elements/ArrowNavigation.tsx
+++ b/src/react/ui-elements/ArrowNavigation.tsx
@@ -4,20 +4,9 @@ import { spacing } from '@scality/core-ui/dist/spacing';
 import { useBasenameRelativeNavigate } from '@scality/module-federation';
 import styled from 'styled-components';
 
-// core-ui's Button with an icon and neither label nor variant is already the
-// bare icon button we need: transparent, no border, and it handles hover and
-// focus-visible. Being a real button, it is also reachable by keyboard, which a
-// styled div with an onClick is not. core-ui requires a string tooltip on an
-// icon-only button and uses it as the accessible name.
-//
-// The box is sized explicitly because `Icon` resolves its FontAwesome glyph
-// through a dynamic import, and until it lands core-ui's fallback only reserves
-// 1em of width where the arrow needs 1.25em, so the title next to it shifted
-// right on first paint. r40 x r32 is the measured size of the rendered 2x arrow.
-// The left margin is not decoration: AppContainer.OverallSummary wraps its
-// children in an overflow:hidden box, and this button is its first child, flush
-// against the edge. Without the margin, the focus-visible outline, which is
-// painted outside the border box, gets its left edge clipped away.
+// Fixed size: `Icon` resolves its glyph through a dynamic import and the
+// fallback reserves too little width, shifting the title on first paint.
+// The left margin keeps the focus outline out of OverallSummary's overflow.
 const ArrowButton = styled(Button)`
   width: ${spacing.r40};
   height: ${spacing.r32};

--- a/src/react/ui-elements/EntityHeader.tsx
+++ b/src/react/ui-elements/EntityHeader.tsx
@@ -1,4 +1,5 @@
-import { Icon, Stack } from '@scality/core-ui';
+import { Stack } from '@scality/core-ui';
+import { IconWrapper } from '@scality/core-ui/dist/components/icon/Icon.component';
 import { fontSize } from '@scality/core-ui/dist/style/theme';
 import type { JSX } from 'react';
 import styled from 'styled-components';
@@ -12,14 +13,14 @@ type Props = {
 
 export const HeadTitle = styled.div`
   display: flex;
-  color: ${(props) => props.theme.textSecondary};
+  color: ${(props) => props.theme.textPrimary};
   font-size: ${fontSize.large};
   align-items: center;
 `;
-export default function Header({ headTitle, numInstance }: Props) {
+export default function Header({ icon, headTitle, numInstance }: Props) {
   return (
     <Stack>
-      <Icon name="Account" size="2x" withWrapper />
+      <IconWrapper $size="2x">{icon}</IconWrapper>
       <HeadTitle>
         {headTitle}
         <TextBadge text={numInstance.toString()} variant="infoPrimary" />


### PR DESCRIPTION
Aligns the Data Management Accounts screens with the Buckets ones, as reported in ARTESCA-18059.

**Title color.** `All Accounts` moves from `textSecondary` to `textPrimary`, which is what `All Buckets` already uses in data-browser's `BrowserPageLayout`.

**Account list icon.** `EntityHeader` had stopped rendering the `icon` prop it receives and hardcoded the single wallet, so `MultiAccountsIcon` was built and thrown away on every render, and both levels showed the same glyph. The icon now goes through core-ui's `IconWrapper`, the same way `BrowserPageLayout` renders `Buckets`. Its viewBox is cropped to the artwork, which carried about 14 units of empty space on the sides, and its height set to `1.4em` rather than the `1em` `svg-inline--fa` imposes, since the drawing is not square like a FontAwesome glyph.

This should be brought to CoreUI, but it will be done via another PR. 


**Back navigation.** An account page gets a back arrow to the account list, mirroring the one the object page of a bucket already offers. Its box is reserved at `r40` by `r32`, the measured size of the rendered `2x` arrow, so the title next to it does not shift while the FontAwesome glyph resolves through its dynamic import.

<img width="1915" height="891" alt="2026-08-28_15h22_49" src="https://github.com/user-attachments/assets/35060341-4e74-4b4d-ac7f-dc601bc11f00" />


<img width="1917" height="875" alt="image" src="https://github.com/user-attachments/assets/6a4a6f03-4b66-412b-b55e-4b61b938e9d2" />




