### PR TITLE
ZKUI-517: Bump data-browser-library to 1.4.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@hookform/resolvers": "^5.2.2",
         "@scality/certchain": "1.4.0",
         "@scality/core-ui": "0.227.0",
-        "@scality/data-browser-library": "1.4.4",
+        "@scality/data-browser-library": "1.4.5",
         "@scality/module-federation": "1.6.1",
         "@scality/react-chained-query": "^2.1.0",
         "@types/react-table": "^7.7.10",
@@ -5733,9 +5733,9 @@
       }
     },
     "node_modules/@scality/data-browser-library": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.4.4.tgz",
-      "integrity": "sha512-jlV4xY0F+TiSkoTmjo8v5O8MBYsHz6y9ZGXmy9P8cdvR4Kl99gen8kxmqJwKtwVajW/vpzf0VWPHH2SOJLLIIA==",
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/@scality/data-browser-library/-/data-browser-library-1.4.5.tgz",
+      "integrity": "sha512-2FnRgV2K+fmfouCrxFVPDrjqzUfIm182fcdX+jhIHC+Mcjunt9KBRys0GU6QijvzpbtnBV9pZDCpp102feHnTQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "@aws-sdk/client-s3": "^3.983.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@hookform/resolvers": "^5.2.2",
     "@scality/certchain": "1.4.0",
     "@scality/core-ui": "0.227.0",
-    "@scality/data-browser-library": "1.4.4",
+    "@scality/data-browser-library": "1.4.5",
     "@scality/module-federation": "1.6.1",
     "@scality/react-chained-query": "^2.1.0",
     "@types/react-table": "^7.7.10",


### PR DESCRIPTION
## Summary
Automated bump of `@scality/data-browser-library`.

## Links
- Release: https://github.com/scality/data-browser/releases/tag/1.4.5
- Jira: https://scality.atlassian.net/browse/ZKUI-517

🤖 Generated by data-browser auto-bump